### PR TITLE
fix #40 - don't content on external PRs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,6 +14,10 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: write
+
+
 jobs:
   build:
 
@@ -47,5 +51,6 @@ jobs:
 
     # Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Maven Dependency Tree Dependency Submission
+      if: github.token.permissions.contents == 'write'
       uses: advanced-security/maven-dependency-submission-action@v4.0.2
             


### PR DESCRIPTION
Avoid running maven-dependency-submission-action  on external PRs with no write rights

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced GitHub workflow permissions to support new operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->