### PR TITLE
Potential fix for code scanning alert no. 100: Spurious Javadoc @param tags

### DIFF
--- a/src/main/java/com/falkordb/GraphTransaction.java
+++ b/src/main/java/com/falkordb/GraphTransaction.java
@@ -123,7 +123,6 @@ public interface GraphTransaction extends
     // Disabled due to bug in FalkorDB caused by using transactions in conjunction with graph copy
     /**
      * Copies the graph
-     * @param destinationGraphId duplicated graph name
      * @return a response which builds the copy running time statistics
      */
     // Response<String> copyGraph(String destinationGraphId);


### PR DESCRIPTION
Potential fix for [https://github.com/FalkorDB/JFalkorDB/security/code-scanning/100](https://github.com/FalkorDB/JFalkorDB/security/code-scanning/100)

To fix the problem, we need to remove the spurious `@param` tag from the Javadoc comment above the `deleteGraph()` method. Specifically, in the file `src/main/java/com/falkordb/GraphTransaction.java` between lines 125 and 128, we should delete the line containing `@param destinationGraphId duplicated graph name`. The remainder of the documentation should remain unchanged. No changes to logic, imports, or other functionality are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
