### PR TITLE
Potential fix for code scanning alert no. 112: Useless type test

### DIFF
--- a/src/test/java/com/falkordb/impl/api/GraphExplainUnitTest.java
+++ b/src/test/java/com/falkordb/impl/api/GraphExplainUnitTest.java
@@ -245,7 +245,7 @@ public class GraphExplainUnitTest {
             this.lastPreparedQuery = preparedQuery;
             
             // Simulate the parsing logic from GraphImpl.sendExplain
-            if (mockExplainResponse instanceof List) {
+            if (mockExplainResponse != null) {
                 List<String> result = new ArrayList<>(mockExplainResponse.size());
                 for (Object item : mockExplainResponse) {
                     if (item instanceof byte[]) {


### PR DESCRIPTION
Potential fix for [https://github.com/FalkorDB/JFalkorDB/security/code-scanning/112](https://github.com/FalkorDB/JFalkorDB/security/code-scanning/112)

To fix the problem, remove the redundant `instanceof List` type check on `mockExplainResponse`. Since `mockExplainResponse` is always a `List<Object>` when not null, the code inside the `if (mockExplainResponse instanceof List)` block can be unconditionally executed if `mockExplainResponse` is not null, or simply assumed to always be a `List<Object>`. There’s no change of behavior needed since the else branch was only ever accessible if `mockExplainResponse` was null (or mis-used), but safer logic is to protect against null if that's a possible test path. The method should be simplified by removing the unnecessary check and always assuming it is a `List<Object>`. Do not change any imports or structure outside the shown method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
