### PR TITLE
Potential fix for code scanning alert no. 111: Useless type test

### DIFF
--- a/src/test/java/com/falkordb/impl/api/GraphPipelineTransactionExplainUnitTest.java
+++ b/src/test/java/com/falkordb/impl/api/GraphPipelineTransactionExplainUnitTest.java
@@ -101,7 +101,6 @@ public class GraphPipelineTransactionExplainUnitTest {
         );
         
         // Validate structure - should be a list of strings
-        Assertions.assertTrue(mockExplainResponse instanceof List);
         Assertions.assertEquals(4, mockExplainResponse.size());
         
         // Convert to expected format


### PR DESCRIPTION
Potential fix for [https://github.com/FalkorDB/JFalkorDB/security/code-scanning/111](https://github.com/FalkorDB/JFalkorDB/security/code-scanning/111)

The best way to fix this problem is to remove the unnecessary `instanceof` type test. Specifically, in `testExplainResponseStructureValidation`, on line 104, the following line:

```java
Assertions.assertTrue(mockExplainResponse instanceof List);
```

should be deleted. The rest of the logic—checking the list's size and converting its contents—is sufficient for the test. No further changes or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
