### PR TITLE
cancel concurrent runs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,6 +14,10 @@ on:
   pull_request:
     branches: [ "master" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This PR adds concurrency control to the GitHub Actions workflow to prevent redundant runs for the same pull request or branch.

#### Key Changes
- Added `concurrency` configuration to the `maven.yml` workflow.
- Configured the concurrency group to use the workflow name and the pull request number or branch reference.
- Enabled `cancel-in-progress: true` to automatically cancel any in-progress runs for the same group when a new one is triggered.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 4 (100.0%)    |
| Total Changes | 4             | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI concurrency control to avoid overlapping workflow runs. New behavior groups runs by workflow and by pull request or branch reference, and cancels earlier in-progress runs when a new run for the same group starts. This reduces redundant executions and provides faster, more reliable feedback on changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->