### PR TITLE
Fix: remove default 2000ms client socket timeout that kills long-running queries

### DIFF
--- a/src/main/java/com/falkordb/impl/api/DriverImpl.java
+++ b/src/main/java/com/falkordb/impl/api/DriverImpl.java
@@ -4,8 +4,13 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.Protocol;
 import redis.clients.jedis.util.Pool;
 import redis.clients.jedis.util.SafeEncoder;
 
@@ -16,6 +21,18 @@ import com.falkordb.Driver;
  */
 public class DriverImpl implements Driver {
 
+    /**
+     * Socket (read) timeout applied to connections created by this driver: 0 means no
+     * client-side deadline. Graph queries routinely exceed Jedis' default 2000ms socket
+     * timeout (e.g. LOAD CSV, deep traversals), which would otherwise cut the connection
+     * with a read timeout while the server keeps executing the query - so retrying could
+     * duplicate writes. Query duration is governed by the server's TIMEOUT /
+     * TIMEOUT_DEFAULT configuration (or a per-query timeout) instead, matching the other
+     * FalkorDB clients. To use a different socket timeout, build your own pool and pass
+     * it to {@link #DriverImpl(Pool)}.
+     */
+    private static final int DEFAULT_SOCKET_TIMEOUT_MILLIS = 0;
+
     private final Pool<Jedis> pool;
 
     /**
@@ -25,7 +42,7 @@ public class DriverImpl implements Driver {
      * @param port Server port
      */
     public DriverImpl(String host, int port) {
-        this(new JedisPool(host, port));
+        this(new JedisPool(new HostAndPort(host, port), clientConfig(null, null)));
     }
 
     /**
@@ -37,7 +54,7 @@ public class DriverImpl implements Driver {
      * @param password password
      */
     public DriverImpl(String host, int port, String user, final String password) {
-        this(new JedisPool(host, port, user, password));
+        this(new JedisPool(new HostAndPort(host, port), clientConfig(user, password)));
     }
 
     /**
@@ -47,6 +64,24 @@ public class DriverImpl implements Driver {
      */
     public DriverImpl(URI uri) {
         this(new JedisPool(uri));
+    }
+
+    /**
+     * Builds the client configuration used by this driver: Jedis' default connection
+     * timeout, no socket (read) timeout (see {@link #DEFAULT_SOCKET_TIMEOUT_MILLIS}),
+     * and the given credentials when provided.
+     */
+    private static DefaultJedisClientConfig clientConfig(String user, final String password) {
+        DefaultJedisClientConfig.Builder builder = DefaultJedisClientConfig.builder()
+                .connectionTimeoutMillis(Protocol.DEFAULT_TIMEOUT)
+                .socketTimeoutMillis(DEFAULT_SOCKET_TIMEOUT_MILLIS);
+        if (user != null) {
+            builder.user(user);
+        }
+        if (password != null) {
+            builder.password(password);
+        }
+        return builder.build();
     }
 
     /**

--- a/src/main/java/com/falkordb/impl/api/DriverImpl.java
+++ b/src/main/java/com/falkordb/impl/api/DriverImpl.java
@@ -63,7 +63,8 @@ public class DriverImpl implements Driver {
      * @param uri server uri
      */
     public DriverImpl(URI uri) {
-        this(new JedisPool(uri));
+        this(new JedisPool(new GenericObjectPoolConfig<Jedis>(), uri,
+                Protocol.DEFAULT_TIMEOUT, DEFAULT_SOCKET_TIMEOUT_MILLIS));
     }
 
     /**

--- a/src/test/java/com/falkordb/InstantiationTest.java
+++ b/src/test/java/com/falkordb/InstantiationTest.java
@@ -1,6 +1,7 @@
 package com.falkordb;
 
 import java.net.URI;
+import java.util.UUID;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -32,19 +33,42 @@ public class InstantiationTest {
 
     @Test
     public void createClientWithUserAndPassword() {
+        // Unique username so the test never overwrites or deletes a pre-existing
+        // ACL user when run against a shared/dev server.
+        String username = "jfalkordb_test_" + UUID.randomUUID().toString().replace("-", "");
         try (redis.clients.jedis.Jedis admin = new redis.clients.jedis.Jedis("localhost", 6379)) {
-            admin.aclSetUser("testuser", "on", ">testpass", "~*", "+@all");
+            admin.aclSetUser(username, "on", ">testpass", "~*", "+@all");
             try {
-                client = FalkorDB.driver("localhost", 6379, "testuser", "testpass").graph("g");
+                client = FalkorDB.driver("localhost", 6379, username, "testpass").graph("g");
                 ResultSet resultSet = client.query("CREATE ({name:'bsb'})");
                 Assertions.assertEquals(1, resultSet.getStatistics().nodesCreated());
                 client.deleteGraph();
                 client.close();
                 client = null;
             } finally {
-                admin.aclDelUser("testuser");
+                admin.aclDelUser(username);
             }
         }
+    }
+
+    @Test
+    public void createClientSurvivesServerStallLongerThanDefaultTimeout() {
+        // Regression guard for the socket-timeout fix: Jedis' default 2000ms socket
+        // read timeout would abort a read that takes longer than 2s. With the driver
+        // disabling the client-side socket timeout, a command issued while the server
+        // is paused for >2s must still succeed instead of failing with a read timeout.
+        client = FalkorDB.driver("localhost", 6379).graph("g");
+        client.query("RETURN 1"); // establish a pooled connection before pausing the server
+        try (redis.clients.jedis.Jedis admin = new redis.clients.jedis.Jedis("localhost", 6379)) {
+            admin.clientPause(2500L); // pause command processing for 2.5s (> old 2000ms timeout)
+        }
+        long start = System.currentTimeMillis();
+        ResultSet resultSet = client.query("CREATE ({name:'bsb'})");
+        long elapsedMillis = System.currentTimeMillis() - start;
+        Assertions.assertEquals(1, resultSet.getStatistics().nodesCreated());
+        Assertions.assertTrue(elapsedMillis >= 2000L,
+                "query should have blocked through the >2s server pause instead of timing out, but took "
+                        + elapsedMillis + "ms");
     }
 
     @Test

--- a/src/test/java/com/falkordb/InstantiationTest.java
+++ b/src/test/java/com/falkordb/InstantiationTest.java
@@ -31,6 +31,23 @@ public class InstantiationTest {
     }
 
     @Test
+    public void createClientWithUserAndPassword() {
+        try (redis.clients.jedis.Jedis admin = new redis.clients.jedis.Jedis("localhost", 6379)) {
+            admin.aclSetUser("testuser", "on", ">testpass", "~*", "+@all");
+            try {
+                client = FalkorDB.driver("localhost", 6379, "testuser", "testpass").graph("g");
+                ResultSet resultSet = client.query("CREATE ({name:'bsb'})");
+                Assertions.assertEquals(1, resultSet.getStatistics().nodesCreated());
+                client.deleteGraph();
+                client.close();
+                client = null;
+            } finally {
+                admin.aclDelUser("testuser");
+            }
+        }
+    }
+
+    @Test
     public void createClientWithURL() {
         client = FalkorDB.driver(URI.create("redis://localhost:6379")).graph("g");
         ResultSet resultSet = client.query("CREATE ({name:'bsb'})");


### PR DESCRIPTION
## Problem

`DriverImpl` created its `JedisPool` with `new JedisPool(host, port)`, which silently inherits Jedis' default **2000ms socket (read) timeout**. Any graph query taking longer than 2 seconds (bulk loads, LOAD CSV, deep traversals) fails on the client with:

```
redis.clients.jedis.exceptions.JedisConnectionException: java.net.SocketTimeoutException: Read timed out
```

Meanwhile the server keeps executing the query, so retrying a write can duplicate data.

This is the same class of bug fixed in falkordb-rs (FalkorDB/falkordb-rs#297), where redis-rs 1.0's default 500ms response timeout broke queries. falkordb-py already avoids it (`socket_timeout=None`) and falkordb-ts has no command timeout at all.

## Fix

All three constructors now configure the pool with **no socket timeout** (`socketTimeoutMillis(0)` / `soTimeout=0`), keeping Jedis' default connect timeout. Query duration is governed by the server's `TIMEOUT` / `TIMEOUT_DEFAULT` configuration (or a per-query timeout), consistent with the other FalkorDB clients. Users who want a client-side deadline can still build their own pool and use `DriverImpl(Pool)`.

## Validation

Against FalkorDB v4.20.1, `UNWIND range(1,60000000) AS x RETURN sum(x)` (~3s):

| | fast query | slow query |
|---|---|---|
| before | OK (47ms) | **fails at 2005ms** with SocketTimeoutException |
| after | OK (59ms) | **succeeds in 3.1s**, correct result |

With a server `TIMEOUT` set, the client now correctly receives the server's `Query timed out` error instead of a dead connection.

- `mvn compile` clean
- Full test suite: **134/134 pass**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling for database drivers by disabling client-side read timeouts.
  * Standardized connection and authentication configuration across supported connection methods.
  * Preserved support for username and password authentication while improving connection reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->