### PR TITLE
fix: pin junit-jupiter to Java 8-compatible 5.x (unbreak snapshot publish)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
     directory: "/" 
     schedule:
       interval: "daily"
+    ignore:
+      # This library targets Java 8 (see maven.compiler.source/target in pom.xml)
+      # and is published with a JDK 8 build. JUnit Jupiter 6.x requires Java 17, so
+      # its test sources fail to compile under JDK 8. Stay on the latest 5.x line
+      # until the minimum supported Java version is raised.
+      - dependency-name: "org.junit.jupiter:junit-jupiter"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>6.1.0</version>
+			<version>5.14.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
## Problem

Master's **Publish Snapshot** workflow is failing after #283 merged. The `deploy` step fails at test compilation:

```
[ERROR] .../ConfigTest.java:[5,29] cannot access org.junit.jupiter.api.AfterEach
  bad class file: .../junit-jupiter-api-6.1.0.jar(org/junit/jupiter/api/AfterEach.class)
    class file has wrong version 61.0, should be 52.0
```

**Root cause:** `junit-jupiter` 6.x is compiled for **Java 17** (class file version 61.0). This library targets **Java 8** (`maven.compiler.source/target = 8`) and the `snapshot.yml` / `version-and-release.yml` publish workflows build with **JDK 8**, which cannot read Java 17 test classes. `mvn -DskipTests` still *compiles* test sources, so the deploy fails. (The main "Java CI with Maven" job uses JDK 17, so it didn't catch this.)

The `junit-jupiter` 6.1.0 bump came from Dependabot #269, which was combined into #283.

## Fix

- **Pin `junit-jupiter` to `5.14.4`** — the latest 5.x release, which is compiled for Java 8 (verified: `AfterEach.class` bytecode major version 52).
- **Add a Dependabot ignore rule** for `org.junit.jupiter:junit-jupiter` `version-update:semver-major`, so it won't be bumped past the Java 8-compatible 5.x line again until the project raises its minimum Java version.

## Validation

- `mvn -B package` (JDK 17): **BUILD SUCCESS, 134/134 tests pass**.
- Confirmed `junit-jupiter-api:5.14.4` `AfterEach.class` is bytecode **major version 52 (Java 8)**, so the JDK 8 publish build will compile again.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
