### PR TITLE
build(deps): bump oss-parent 7 -> 9 (Java 8-safe, deploy-verified)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.sonatype.oss</groupId>
 		<artifactId>oss-parent</artifactId>
-		<version>7</version>
+		<version>9</version>
 	</parent>
 
 	<groupId>com.falkordb</groupId>


### PR DESCRIPTION
Brings in the only genuinely-new Dependabot PR, verified deploy-safe against the JDK 8 publish build (not just JDK 17 CI).

### Maven
| Dependency | From | To | Supersedes |
| --- | --- | --- | --- |
| org.sonatype.oss:oss-parent (parent POM) | 7 | 9 | #291 |

The only effective difference between oss-parent 7 and 9 is `maven-enforcer-plugin` 1.0 → 1.2 inside the `release` profile, which this project doesn't use (it publishes via its own `central` portal config and overrides `distributionManagement`). No Java version constraints are introduced.

### Deliberately excluded (stale — already on master)
codecov 7.0.0 (#277), codeql 4.36.2 (#276, master is already on 4.37.0), surefire 3.5.6 (#273), slf4j-simple 2.0.18 (#267). These will auto-close.

### Validation
- **JDK 8** (Zulu 8) `mvn -DskipTests -Dgpg.skip=true package` → **BUILD SUCCESS** (deploy path).
- **JDK 17** `mvn -B package` → **BUILD SUCCESS, 134/134 tests pass**.

Once green, #291 can be closed as superseded.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s build configuration to use the latest parent configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->