### PR TITLE
chore: bump development version to 0.10.0-SNAPSHOT after 0.9.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ FalkorDB Java client
     <dependency>
       <groupId>com.falkordb</groupId>
       <artifactId>jfalkordb</artifactId>
-      <version>0.7.0</version>
+      <version>0.9.0</version>
     </dependency>
   </dependencies>
 ```
@@ -44,7 +44,7 @@ and
     <dependency>
       <groupId>com.falkordb</groupId>
       <artifactId>jfalkordb</artifactId>
-      <version>0.8.0-SNAPSHOT</version>
+      <version>0.10.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>com.falkordb</groupId>
 	<artifactId>jfalkordb</artifactId>
-	<version>0.8.0-SNAPSHOT</version>
+	<version>0.10.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>JFalkorDB</name>


### PR DESCRIPTION
Post-release housekeeping following the **v0.9.0** release to Maven Central.

- **pom.xml:** `0.8.0-SNAPSHOT` → `0.10.0-SNAPSHOT`. The pom was never bumped after 0.8.0 shipped, so it was stale; the next development cycle targets the 0.10.0 line.
- **README.md:** update the release usage example `0.7.0` → `0.9.0` (the current latest release) and the snapshot example `0.8.0-SNAPSHOT` → `0.10.0-SNAPSHOT`.

No functional/code changes. This keeps snapshot deploys and the docs aligned with the just-published 0.9.0 release.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Maven dependency examples to reference the latest release and snapshot versions.

* **Chores**
  * Advanced the project’s snapshot version to `0.10.0-SNAPSHOT`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->