### PR TITLE
build: Spotless (palantir) config in off-by-default quality profile (Wave 1, PR 3/4)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,6 @@
 # Justfile — dev-cycle automation for JFalkorDB. Run `just` (or `just --list`) to see recipes.
 # Every CI job runs one of these recipes, so they reproduce CI locally. Recipes call ./mvnw
-# (the pinned Maven Wrapper). Formatting/quality recipes arrive in a later PR (Spotless).
+# (the pinned Maven Wrapper). Formatting runs in the off-by-default `quality` profile (Spotless).
 
 set shell := ["bash", "-uc"]
 
@@ -12,6 +12,16 @@ port := "6379"
 # Default: list all recipes.
 default:
     @just --list
+
+# --- Format (no server; runs in the off-by-default `quality` profile) ---
+
+# Apply palantir-java-format + import cleanup across the codebase.
+fmt:
+    ./mvnw -B -Pquality spotless:apply
+
+# Check formatting without modifying files. Not yet a CI gate (see the reformat PR).
+fmt-check:
+    ./mvnw -B -Pquality spotless:check
 
 # Compile + package without tests (no server needed).
 build:

--- a/pom.xml
+++ b/pom.xml
@@ -186,9 +186,9 @@
 
 	<profiles>
 		<!-- Static-quality gates that need a modern JDK (Java 11+). OFF by default so it never runs
-		     on the JDK-8 publish build; `just fmt`/`fmt-check` and the JDK-17 CI activate it with
-		     -Pquality. Spotless has NO <executions> binding, so it runs only when its goal is invoked
-		     explicitly (never during `verify`/`deploy`). Extended with more analyzers in a later wave. -->
+		     on the JDK-8 publish build; activate it with -Pquality (via `just fmt` / `just fmt-check`;
+		     a CI format gate is added in the reformat PR). Spotless has NO <executions> binding, so it
+		     runs only when its goal is invoked explicitly (never during `verify`/`deploy`). -->
 		<profile>
 			<id>quality</id>
 			<build>

--- a/pom.xml
+++ b/pom.xml
@@ -183,4 +183,32 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<!-- Static-quality gates that need a modern JDK (Java 11+). OFF by default so it never runs
+		     on the JDK-8 publish build; `just fmt`/`fmt-check` and the JDK-17 CI activate it with
+		     -Pquality. Spotless has NO <executions> binding, so it runs only when its goal is invoked
+		     explicitly (never during `verify`/`deploy`). Extended with more analyzers in a later wave. -->
+		<profile>
+			<id>quality</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.diffplug.spotless</groupId>
+						<artifactId>spotless-maven-plugin</artifactId>
+						<version>3.8.0</version>
+						<configuration>
+							<java>
+								<palantirJavaFormat>
+									<version>2.80.0</version>
+								</palantirJavaFormat>
+								<removeUnusedImports/>
+								<importOrder/>
+							</java>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
**Wave 1 · PR 3 of 4** — adds the formatter config, isolated from the reformat. Follows the [Wave 1 plan](https://github.com/FalkorDB/JFalkorDB/pull/295). Depends on PR 1 (#296, merged).

## What
- **`pom.xml`** — a new **`quality`** Maven profile with **`spotless-maven-plugin` 3.8.0** configured for **`palantir-java-format` 2.80.0** (pinned) + `removeUnusedImports` + `importOrder`.
- **`Justfile`** — `fmt` (`spotless:apply`) and `fmt-check` (`spotless:check`) recipes.

## Why this is safe (no self-fail, no JDK-8 risk)
- The `quality` profile is **off by default**, and Spotless has **no `<executions>` binding** — so `spotless:check` runs **only** when invoked explicitly via `-Pquality`. It never runs during `verify` or the **JDK-8 `mvn deploy`** (which is why a Java-11+ formatter is safe here).
- Therefore **this PR does not enforce formatting** and **does not reformat** — the code is still unformatted, `just verify`/CI stay green, and the big mechanical reformat + the blocking gate come in **PR 4**.

## Verification (JDK 17)
- `just build` / `just verify` → **BUILD SUCCESS**, Spotless does **not** run (confirms it's off the default lifecycle).
- `just fmt-check` → runs **palantir-java-format 2.80.0** and reports **"57 files need changes"** (expected — proves it's wired; palantir 2.80.0 runs on JDK 17).

## Non-goals
No reformat, no CI gate, no branch-protection change (all in PR 4). No behavior/dependency changes to the published artifact.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
