### PR TITLE
build: pivot to JDK 21 + --release 8 with Java-8 guardrails (Wave 2, PR 5)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,8 +10,8 @@ commons-pool2.
 ## Golden rule: drive everything through `just`
 
 For any action CI performs (build, test, coverage, format, …), run the **exact same `just` recipe CI
-uses** for the standard PR gates rather than an ad-hoc `mvn …` (the JDK-8 dependency-verification
-build and the publish workflows are documented exceptions). If a check needs changing, update the
+uses** rather than an ad-hoc `mvn …` — this now includes the publish workflows, which call
+`just deploy-snapshot` / `just deploy-release`. If a check needs changing, update the
 `just` recipe **and** the CI workflow together so they stay identical. Run `just --list` to see every
 recipe; recipes call the pinned Maven Wrapper (`./mvnw`).
 
@@ -39,17 +39,23 @@ Tests connect to `localhost:6379`; prefer `just verify-local`, which manages Doc
 6. **Never self-merge to `master`.** Open the PR, get it green, and wait for a maintainer to approve
    and merge.
 
-## Backward compatibility & the JDK-8 publish (important)
+## Backward compatibility & the Java-8 guarantee (important)
 
-- The published artifact must keep running on **Java 8** (`maven.compiler.source/target = 8`). The PR
-  build runs on **JDK 17**; the snapshot/release publish builds on **JDK 8**.
-- Because `mvn deploy` on JDK 8 also **compiles test sources**, every test-scope dependency must be
-  Java-8-compatible. This is why **`junit-jupiter` is pinned to 5.x** and **`equalsverifier` to 3.x**
-  (Dependabot ignores their semver-major bumps). Verify dependency bumps with a JDK-8
-  `mvn -DskipTests -Dgpg.skip=true package`, not just JDK 17.
-- Any tool that needs Java 11+ (e.g. Spotless / palantir-java-format) must live in the
-  **off-by-default `quality` Maven profile**, never on the default lifecycle, so it never runs on the
-  JDK-8 deploy.
+- The published artifact must keep running on **Java 8**, but the build now runs on **JDK 21**
+  (PR, snapshot, and release) compiling with **`maven.compiler.release = 8`** — it emits Java-8
+  bytecode (class-file 52) while compiling against the real Java-8 API.
+- Four automated guardrails keep the Java-8 promise (all reachable via `just`):
+  - **`--release 8`** — our source compiles against the Java-8 API and emits class-file 52.
+  - **Animal Sniffer** (`java18` signature, at `verify`) — our main code calls only the Java-8 API.
+  - **Enforcer `enforceBytecodeVersion`** (`maxJdkVersion=1.8`, test scope excluded, at `validate`) —
+    every **shipped** dependency is Java-8 bytecode.
+  - **`just verify-jdk8`** (the `smoke-jdk8` CI job) — runs the packaged jar + full runtime graph on a
+    real **JDK 8** against FalkorDB via the no-arg `driver()`, proving Java-8 *runtime* compatibility.
+- **`junit-jupiter` stays on 5.x** and **`equalsverifier` on 3.x** (Dependabot ignores their
+  semver-major bumps). The JDK-21 build *could* now compile their 6.x/4.x, but raising them is a
+  deliberate later change, not automatic — so keep the pins for now.
+- Any Java-11+ tool (e.g. Spotless / palantir-java-format) still lives in the **off-by-default
+  `quality` Maven profile**, kept as a separate explicit gate off the aggregate lifecycle.
 
 ## Releasing
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,10 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      # This library targets Java 8 (see maven.compiler.source/target in pom.xml)
-      # and is published with a JDK 8 build. These test dependencies dropped Java 8
-      # in their latest major (JUnit Jupiter 6.x and EqualsVerifier 4.x both require
-      # Java 17), so their test sources fail to compile under JDK 8. Stay on the
-      # latest Java 8-compatible major until the minimum supported Java is raised.
+      # Kept on the last Java-8-runnable majors on purpose. The build now runs on JDK 21 with
+      # maven.compiler.release=8, so it *could* compile JUnit Jupiter 6.x / EqualsVerifier 4.x
+      # (which require Java 17) — but raising them is a deliberate, separately-tracked follow-up,
+      # not an automatic bump. Keep ignoring their semver-major updates for now.
       - dependency-name: "org.junit.jupiter:junit-jupiter"
         update-types: ["version-update:semver-major"]
       - dependency-name: "nl.jqno.equalsverifier:equalsverifier"

--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -16,3 +16,4 @@ CodeRabbit
 JDK
 md
 repo
+PRs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,14 +28,24 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up JDK 21
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Install just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+      - name: Build (via just)
+        run: just build
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -41,10 +41,10 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         persist-credentials: false
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
     - name: Install just
@@ -70,14 +70,43 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         persist-credentials: false
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
     - name: Install just
       uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
     - name: Check formatting (via just)
       run: just fmt-check
+
+  smoke-jdk8:
+
+    runs-on: ubuntu-latest
+
+    # Pinned FalkorDB (v4.20.1) so this required Java-8 runtime check can't be broken by an
+    # upstream image change; edge/version-matrix canaries arrive in a later wave.
+    services:
+      falkordb:
+        image: falkordb/falkordb@sha256:9042fdc4e53f5390ca5a3993aa71506523970efb40ffb9a98e6a4b1a9a4f8862
+        ports:
+          - 6379:6379
+
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
+    - name: Set up JDK 21 (build) and JDK 8 (runtime)
+      uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+      with:
+        java-version: |
+          8
+          21
+        distribution: 'temurin'
+        cache: maven
+    - name: Install just
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+    - name: Build on JDK 21, run the packaged-artifact smoke on JDK 8 (via just)
+      run: just verify-jdk8 "$JAVA_HOME_8_X64"
             

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up publishing to maven central
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
         with:
-          java-version: '8'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
           server-id: central
@@ -34,13 +34,14 @@ jobs:
             /var/cache/apt
           key: jfalkordb-${{hashFiles('**/pom.xml')}}
 
-      - name: mvn offline
-        run: |
-          mvn -q dependency:go-offline
-          
-      - name: deploy
-        run: |
-          mvn -DskipTests -Dgpg.skip=true deploy
+      - name: Install just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+
+      - name: Fetch dependencies (via just)
+        run: just fetch-deps
+
+      - name: Deploy snapshot (via just)
+        run: just deploy-snapshot
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -30,18 +30,21 @@ jobs:
           realversion="${realversion//v/}"
           echo "VERSION=$realversion" >> $GITHUB_OUTPUT
 
-      - name: Set up JDK 8 for publishing to Maven Central
+      - name: Set up JDK 21 for publishing to Maven Central
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
         with:
-          java-version: '8'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
           server-id: central
           server-username: MAVEN_CENTRAL_USERNAME
           server-password: MAVEN_CENTRAL_TOKEN
 
+      - name: Install just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+
       - name: Update version in POM
-        run: mvn versions:set -DnewVersion=${{ steps.get_version.outputs.VERSION }}
+        run: just set-version ${{ steps.get_version.outputs.VERSION }}
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
@@ -50,10 +53,7 @@ jobs:
           passphrase: ${{ secrets.OSSH_GPG_SECRET_KEY_PASSWORD }}
 
       - name: Build and deploy to Maven Central
-        run: |
-          mvn --no-transfer-progress \
-            --batch-mode \
-            clean deploy
+        run: just deploy-release
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -44,7 +44,9 @@ jobs:
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
 
       - name: Update version in POM
-        run: just set-version ${{ steps.get_version.outputs.VERSION }}
+        run: just set-version "$VERSION"
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Compiled class file
 *.class
 /bin/
-/target/
+target/
 /test-output/
 
 

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=17.0.12-graal
+java=21.0.11-tem

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,5 +3,6 @@
 This project's engineering conventions for AI agents (and humans) live in the single source of truth:
 **[`.github/copilot-instructions.md`](.github/copilot-instructions.md)**.
 
-Please read and follow it — it covers the `just` = CI workflow, the definition of done, the Java-8 /
-JDK-8-publish constraints, releasing, and the AI-review-resolution and no-self-merge rules.
+Please read and follow it — it covers the `just` = CI workflow, the definition of done, the Java-8
+guarantee (JDK-21 build with `--release 8`), releasing, and the AI-review-resolution and
+no-self-merge rules.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,9 @@ Thanks for contributing! This guide covers the local workflow and the `just` rec
 
 ## Prerequisites
 
-- **JDK 17** (the PR build JDK). The artifact targets Java 8, but you don't need a JDK 8 for
-  day-to-day work.
+- **JDK 21** (the build JDK for PRs, snapshots, and releases). The artifact still targets Java 8
+  (compiled with `--release 8`); for day-to-day work you don't need a JDK 8 — only the
+  `just verify-jdk8` runtime smoke uses one.
 - **[`just`](https://github.com/casey/just)** — `brew install just`, `cargo install just`, or your
   package manager.
 - **Docker** — for a local FalkorDB (the tests need a running server).
@@ -43,4 +44,5 @@ just db-down        # stop it
 - **Don't merge to `master` yourself** — a maintainer reviews and merges.
 
 See [`.github/copilot-instructions.md`](.github/copilot-instructions.md) for the full engineering
-conventions, including the Java-8 / JDK-8-publish constraints.
+conventions, including the Java-8 guarantee (JDK-21 build with `--release 8` plus the Java-8
+guardrails).

--- a/Justfile
+++ b/Justfile
@@ -40,12 +40,15 @@ verify:
     ./mvnw -B -Dgpg.skip=true verify
 
 # Prove the PUBLISHED artifact runs on a Java-8 runtime: build+install the jar on the build JDK,
-# then compile+run the standalone JDK-8 runtime smoke against it. Pass the JDK-8 home, and run a
-# FalkorDB on {{port}} first. CI provides both; locally e.g.
-# `just db-up && just verify-jdk8 ~/.sdkman/candidates/java/8.0.492-zulu`.
+# then compile+run the standalone JDK-8 runtime smoke against it (pinned to the root project's
+# version). Pass the JDK-8 home, and run a FalkorDB on {{port}} first. CI provides both; locally
+# e.g. `just db-up && just verify-jdk8 ~/.sdkman/candidates/java/8.0.492-zulu`.
 verify-jdk8 jdk8_home:
+    #!/usr/bin/env bash
+    set -euo pipefail
     ./mvnw -B -DskipTests -Dgpg.skip=true install
-    JAVA_HOME={{jdk8_home}} ./mvnw -B -f smoke-test/pom.xml test
+    version="$(./mvnw -q -DforceStdout help:evaluate -Dexpression=project.version)"
+    JAVA_HOME="{{jdk8_home}}" ./mvnw -B -f smoke-test/pom.xml -Djfalkordb.version="$version" test
 
 # --- Publish (run by the snapshot/release CI workflows; not for day-to-day local use) ---
 

--- a/Justfile
+++ b/Justfile
@@ -19,7 +19,7 @@ default:
 fmt:
     ./mvnw -B -Pquality spotless:apply
 
-# Check formatting without modifying files. Not yet a CI gate (see the reformat PR).
+# Check formatting without modifying files. This is the CI `format` gate.
 fmt-check:
     ./mvnw -B -Pquality spotless:check
 
@@ -38,6 +38,32 @@ test:
 # Full build + tests + coverage (JaCoCo) — the aggregate gate CI runs. Requires a server.
 verify:
     ./mvnw -B -Dgpg.skip=true verify
+
+# Prove the PUBLISHED artifact runs on a Java-8 runtime: build+install the jar on the build JDK,
+# then compile+run the standalone JDK-8 runtime smoke against it. Pass the JDK-8 home, and run a
+# FalkorDB on {{port}} first. CI provides both; locally e.g.
+# `just db-up && just verify-jdk8 ~/.sdkman/candidates/java/8.0.492-zulu`.
+verify-jdk8 jdk8_home:
+    ./mvnw -B -DskipTests -Dgpg.skip=true install
+    JAVA_HOME={{jdk8_home}} ./mvnw -B -f smoke-test/pom.xml test
+
+# --- Publish (run by the snapshot/release CI workflows; not for day-to-day local use) ---
+
+# Pre-fetch dependencies (snapshot workflow warm-up).
+fetch-deps:
+    ./mvnw -B -q dependency:go-offline
+
+# Set the project version (release workflow, from the git tag).
+set-version version:
+    ./mvnw -B versions:set -DnewVersion={{version}} -DgenerateBackupPoms=false
+
+# Deploy a -SNAPSHOT to Maven Central (no signing, no tests).
+deploy-snapshot:
+    ./mvnw -B -DskipTests -Dgpg.skip=true deploy
+
+# Build, sign, test, and deploy a release to Maven Central.
+deploy-release:
+    ./mvnw -B --no-transfer-progress clean deploy
 
 # --- Dockerized FalkorDB for local runs (readiness-probed) ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,7 @@
     </distributionManagement>
 
 	<properties>
-		<maven.compiler.source>8</maven.compiler.source>
-		<maven.compiler.target>8</maven.compiler.target>
+		<maven.compiler.release>8</maven.compiler.release>
 	</properties>
 
 	<dependencies>
@@ -105,6 +104,12 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.13.0</version>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.5.6</version>
 			</plugin>
@@ -124,6 +129,66 @@
 						<phase>test</phase>
 						<goals>
 							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- Java-8 guardrail #1: every SHIPPED (compile/runtime) dependency classfile is
+			     <= Java-8 bytecode. Test scope is excluded (test tools may be newer now that the
+			     build runs on JDK 21). strict=false (default) skips module-info / MRJAR versioned
+			     entries, so this checks base classfiles. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.5.0</version>
+				<dependencies>
+					<dependency>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>extra-enforcer-rules</artifactId>
+						<version>1.10.0</version>
+					</dependency>
+				</dependencies>
+				<executions>
+					<execution>
+						<id>enforce-bytecode-8</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<enforceBytecodeVersion>
+									<maxJdkVersion>1.8</maxJdkVersion>
+									<ignoredScopes>
+										<ignoredScope>test</ignoredScope>
+									</ignoredScopes>
+								</enforceBytecodeVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- Java-8 guardrail #2: our main code calls only the Java-8 API (a stronger check than
+			     the compiler alone for API misuse it can't catch). Runs at verify. -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>animal-sniffer-maven-plugin</artifactId>
+				<version>1.24</version>
+				<configuration>
+					<signature>
+						<groupId>org.codehaus.mojo.signature</groupId>
+						<artifactId>java18</artifactId>
+						<version>1.0</version>
+					</signature>
+				</configuration>
+				<executions>
+					<execution>
+						<id>check-java8-api</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>check</goal>
 						</goals>
 					</execution>
 				</executions>
@@ -185,10 +250,10 @@
 	</build>
 
 	<profiles>
-		<!-- Static-quality gates that need a modern JDK (Java 11+). OFF by default so it never runs
-		     on the JDK-8 publish build; activate it with -Pquality (via `just fmt` / `just fmt-check`;
-		     a CI format gate is added in the reformat PR). Spotless has NO <executions> binding, so it
-		     runs only when its goal is invoked explicitly (never during `verify`/`deploy`). -->
+		<!-- Static-quality gates (Spotless / palantir-java-format). OFF by default and kept as a
+		     separate explicit gate: activate with -Pquality (via `just fmt` / `just fmt-check`, and the
+		     `format` CI job). Spotless has NO <executions> binding, so it runs only when its goal is
+		     invoked explicitly (never during `verify`/`deploy`), keeping the aggregate build fast. -->
 		<profile>
 			<id>quality</id>
 			<build>

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <!--
+      Standalone (non-reactor, non-deployable) JDK-8 RUNTIME smoke test.
+
+      It resolves the PUBLISHED jfalkordb jar + its full runtime dependency graph from the local
+      repository and exercises the no-arg FalkorDB.driver() default contract end to end (connect ->
+      query -> read -> close) against a real FalkorDB on localhost:6379, executed on a Java-8 runtime.
+      This is the Java-8 *runtime* guarantee that the compile-time guards (release 8, Animal Sniffer,
+      Enforcer) cannot give. Run via `just verify-jdk8`; it is never part of the main reactor or the
+      published artifact.
+    -->
+    <groupId>com.falkordb.smoke</groupId>
+    <artifactId>jfalkordb-jdk8-smoke</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>8</maven.compiler.release>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.falkordb</groupId>
+            <artifactId>jfalkordb</artifactId>
+            <version>0.10.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.14.4</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.6</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -24,13 +24,17 @@
         <maven.compiler.release>8</maven.compiler.release>
         <maven.deploy.skip>true</maven.deploy.skip>
         <gpg.skip>true</gpg.skip>
+        <!-- Overridden by `just verify-jdk8` with the root project's actual version; the default
+             keeps the smoke build runnable stand-alone against the current -SNAPSHOT. -->
+        <jfalkordb.version>0.10.0-SNAPSHOT</jfalkordb.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.falkordb</groupId>
             <artifactId>jfalkordb</artifactId>
-            <version>0.10.0-SNAPSHOT</version>
+            <version>${jfalkordb.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/smoke-test/src/test/java/com/falkordb/smoke/SmokeTest.java
+++ b/smoke-test/src/test/java/com/falkordb/smoke/SmokeTest.java
@@ -8,6 +8,7 @@ import com.falkordb.FalkorDB;
 import com.falkordb.GraphContextGenerator;
 import com.falkordb.Record;
 import com.falkordb.ResultSet;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -23,8 +24,11 @@ class SmokeTest {
 
     @Test
     void connectQueryClose() throws Exception {
+        // Unique per run so the smoke never touches a pre-existing graph (deterministic MATCH, and
+        // deleteGraph() only ever removes this run's throwaway graph — safe against a shared server).
+        String graphId = "jdk8-smoke-" + UUID.randomUUID();
         try (Driver driver = FalkorDB.driver()) { // no-arg => localhost:6379 default contract
-            GraphContextGenerator graph = driver.graph("jdk8-smoke");
+            GraphContextGenerator graph = driver.graph(graphId);
             try {
                 ResultSet created = graph.query("CREATE (:N {v: 1})");
                 assertEquals(1, created.getStatistics().nodesCreated());

--- a/smoke-test/src/test/java/com/falkordb/smoke/SmokeTest.java
+++ b/smoke-test/src/test/java/com/falkordb/smoke/SmokeTest.java
@@ -1,0 +1,41 @@
+package com.falkordb.smoke;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.falkordb.Driver;
+import com.falkordb.FalkorDB;
+import com.falkordb.GraphContextGenerator;
+import com.falkordb.Record;
+import com.falkordb.ResultSet;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Runs the published {@code jfalkordb} artifact on a Java-8 runtime against a real FalkorDB on
+ * {@code localhost:6379}, exercising the no-arg {@link FalkorDB#driver()} default contract end to
+ * end (connect -&gt; query -&gt; read -&gt; close).
+ *
+ * <p>This is the Java-8 <em>runtime</em> guarantee that the compile-time guards ({@code release 8},
+ * Animal Sniffer, Enforcer) cannot give: it proves the packaged jar plus its full runtime
+ * dependency graph actually loads and works on JDK 8.
+ */
+class SmokeTest {
+
+    @Test
+    void connectQueryClose() throws Exception {
+        try (Driver driver = FalkorDB.driver()) { // no-arg => localhost:6379 default contract
+            GraphContextGenerator graph = driver.graph("jdk8-smoke");
+            try {
+                ResultSet created = graph.query("CREATE (:N {v: 1})");
+                assertEquals(1, created.getStatistics().nodesCreated());
+
+                ResultSet rs = graph.query("MATCH (n:N) RETURN n.v");
+                Record row = rs.iterator().next();
+                assertNotNull(row);
+                assertEquals(1L, ((Number) row.getValue(0)).longValue());
+            } finally {
+                graph.deleteGraph();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Wave 2 — PR 5: pivot the build to JDK 21 + `--release 8` (with Java-8 guardrails)

First PR of Wave 2 (plan approved in #300, using the recommended defaults). Moves the build to **JDK 21** while keeping a **Java-8 artifact**, and installs the automated guardrails that replace the old "build on JDK 8" habit.

### Build pivot
- `pom.xml`: `maven.compiler.source/target=8` → **`maven.compiler.release=8`** (compiles against the real Java-8 API, emits **class-file 52**); pinned `maven-compiler-plugin` 3.13.0.
- All workflows move to **JDK 21**: `maven.yml` (`build` + `format`), `snapshot.yml`, `version-and-release.yml`, and CodeQL.

### Java-8 guarantee — four automated guards
| Guard | Proves |
|---|---|
| `--release 8` | our source compiles against the Java-8 API, emits class-file 52 |
| **Animal Sniffer** (`java18`, at `verify`) | our main code calls only the Java-8 **API** |
| **Enforcer `enforceBytecodeVersion`** (`maxJdkVersion=1.8`, test scope excluded, at `validate`) | every **shipped** dependency is Java-8 bytecode |
| **`smoke-jdk8` job / `just verify-jdk8`** | the packaged jar + full runtime graph **runs on a real JDK 8** against a **pinned** FalkorDB via the no-arg `driver()` |

The smoke consumer is a **standalone, non-deployable** `smoke-test/` project (not a reactor module), so it never affects the published artifact.

### `just` = CI (golden rule)
Publish workflows no longer call raw `mvn`: `snapshot.yml` → `just fetch-deps` + `just deploy-snapshot`; `version-and-release.yml` → `just set-version` + `just deploy-release`; CodeQL → a **manual `just build`** on JDK 21 (autobuild removed). New recipes: `verify-jdk8`, `deploy-snapshot`, `deploy-release`, `set-version`, `fetch-deps`.

### Docs
Updated to the new reality: `.github/copilot-instructions.md`, `CONTRIBUTING.md`, `AGENTS.md`, the `pom.xml` quality-profile comment, and the `.github/dependabot.yml` rationale. `junit-jupiter` (5.x) / `equalsverifier` (3.x) **stay pinned deliberately** — unpinning is a separate later follow-up (default decision #2).

### Validation (local, JDK 21 + JDK 8)
- `just verify` → **214 tests** pass on JDK 21; Enforcer + Animal Sniffer green; built class is **major version 52**.
- `just verify-jdk8` → smoke passes on **Java 1.8.0** against a live FalkorDB via no-arg `driver()`.
- `just build` (CodeQL recipe), `just fmt-check`, `just spellcheck` all green; all workflow YAML validated.

### Post-merge follow-up (not in this PR)
Per the plan's explicit rollout order, once this lands and the `smoke-jdk8` check has run on `master`, I'll add its context to branch protection as a required check (existing `build`/`format` names are preserved).

Not merging — for your review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Compatibility**
  * Builds now use JDK 21 while producing artifacts compatible with Java 8.
  * Added automated Java 8 runtime smoke testing against a live FalkorDB service.
  * Added safeguards to verify Java 8 API and bytecode compatibility.

* **Release Automation**
  * Simplified snapshot and release publishing through standardized build commands.
  * Added automated version setting and dependency preparation steps.

* **CI**
  * Updated build, formatting, and CodeQL workflows to use JDK 21 and consistent build procedures.

* **Documentation**
  * Updated contributor and repository guidance to reflect the Java 8 compatibility guarantee and new build requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->