### PR TITLE
build(deps): combined Dependabot updates (compiler/enforcer/animal-sniffer + Actions)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up JDK 21
-        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,6 +48,6 @@ jobs:
         run: just build
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up JDK 21
-      uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -71,7 +71,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up JDK 21
-      uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -98,7 +98,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up JDK 21 (build) and JDK 8 (runtime)
-      uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
       with:
         java-version: |
           8

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -27,7 +27,7 @@ jobs:
           # gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private ke
 
       - name: Cache dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             ~/.m2/repository

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up publishing to maven central
-        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -27,7 +27,7 @@ jobs:
           # gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private ke
 
       - name: Cache dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |
             ~/.m2/repository

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -31,7 +31,7 @@ jobs:
           echo "VERSION=$realversion" >> $GITHUB_OUTPUT
 
       - name: Set up JDK 21 for publishing to Maven Central
-        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.13.0</version>
+				<version>3.15.0</version>
 			</plugin>
 
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
 					<dependency>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>extra-enforcer-rules</artifactId>
-						<version>1.10.0</version>
+						<version>1.12.0</version>
 					</dependency>
 				</dependencies>
 				<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.5.0</version>
+				<version>3.6.3</version>
 				<dependencies>
 					<dependency>
 						<groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>animal-sniffer-maven-plugin</artifactId>
-				<version>1.24</version>
+				<version>1.27</version>
 				<configuration>
 					<signature>
 						<groupId>org.codehaus.mojo.signature</groupId>

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -49,7 +49,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Combined Dependabot updates

Consolidates the 8 open Dependabot PRs (#303–#310) into one, validated together against the new JDK-21 build so they land as a single green change.

### Maven build plugins
| Dependency | From | To | Dependabot |
|---|---|---|---|
| `maven-compiler-plugin` | 3.13.0 | **3.15.0** | #305 |
| `maven-enforcer-plugin` | 3.5.0 | **3.6.3** | #308 |
| `extra-enforcer-rules` | 1.10.0 | **1.12.0** | #306 |
| `animal-sniffer-maven-plugin` | 1.24 | **1.27** | #310 |

### GitHub Actions (SHA-pinned)
| Action | From | To | Dependabot |
|---|---|---|---|
| `actions/setup-java` | 5.5.0 | **5.6.0** | #309 |
| `actions/cache` | 5.0.5 | **6.1.0** | #303 |
| `github/codeql-action/init` | 4.37.0 | **4.37.1** | #304 |
| `github/codeql-action/analyze` | 4.37.0 | **4.37.1** | #307 |

### Extra consistency fixes
- Bumped **`smoke-test/pom.xml`** `maven-compiler-plugin` to 3.15.0 too (Dependabot only scans the root pom).
- Corrected the stale **`actions/cache` version comment** left by Dependabot (`# v5` → `# v6`; `55cc8345…` is v6.1.0).

### Validation (local, JDK 21 + JDK 8)
- `just verify` → **214 tests** pass on JDK 21; the bumped **Enforcer** (`enforceBytecodeVersion`) + **Animal Sniffer** guards stay green.
- `just verify-jdk8` → JDK-8 runtime smoke passes with the new compiler plugin.
- All four workflow YAMLs validated; `setup-java` updated consistently across all six occurrences.

Closes #303, #304, #305, #306, #307, #308, #309, #310.
