### PR TITLE
test: manage the FalkorDB server with Testcontainers (Wave 2, PR 6)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,14 +17,16 @@ recipe; recipes call the pinned Maven Wrapper (`./mvnw`).
 
 | Recipe | Purpose |
 | --- | --- |
-| `just verify` | Build + tests + coverage (the CI `build` gate). Needs a FalkorDB on `:6379`. |
-| `just verify-local` | Spin up a Dockerized FalkorDB, run `verify`, tear it down. |
+| `just verify` | Build + tests + coverage (the CI `build` gate). Auto-starts FalkorDB via Testcontainers (Docker). |
+| `just verify-local` | Run `verify` against a `just db-up` server (reused via `FALKORDB_HOST/PORT`), then tear it down — handy when Testcontainers can't reach your Docker. |
 | `just build` / `just test` | Compile-only / tests-only. |
 | `just fmt` / `just fmt-check` | Apply / check palantir-java-format (runs in the `-Pquality` profile). |
 | `just spellcheck` | Spellcheck the Markdown docs (the CI `spellcheck` gate). |
 | `just db-up` / `just db-down` | Manage a local FalkorDB container. |
 
-Tests connect to `localhost:6379`; prefer `just verify-local`, which manages Docker for you.
+Tests start a FalkorDB automatically via **Testcontainers** (Docker required) — no manual server
+setup. Set both `FALKORDB_HOST`/`FALKORDB_PORT` (or use `just verify-local`) to reuse an existing
+server instead.
 
 ## Definition of done
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,16 +27,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    # Service containers to run with `test-job`
-    services:
-      # Label used to access the service container
-      falkordb:
-        # Docker Hub image
-        image: falkordb/falkordb:edge
-        # Map port 6379 on the Docker host to port 6379 on the FalkorDB container
-        ports:
-          - 6379:6379
-
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,9 @@ Common recipes:
 
 ```bash
 just verify-local   # spin up FalkorDB (Docker), run the full build + tests, then tear it down
-just verify         # same build + tests, against a FalkorDB you already run on localhost:6379
+just verify         # same build + tests; auto-starts FalkorDB via Testcontainers (Docker)
 just build          # compile + package, no tests
-just test           # tests only (needs a server)
+just test           # tests only (auto-starts a Testcontainers server, or set FALKORDB_HOST/PORT)
 just fmt            # apply palantir-java-format
 just fmt-check      # check formatting
 just db-up          # start a local FalkorDB container

--- a/Justfile
+++ b/Justfile
@@ -31,11 +31,13 @@ spellcheck:
 build:
     ./mvnw -B -DskipTests -Dgpg.skip=true package
 
-# Run the test suite. Requires a FalkorDB on {{port}} (use `just verify-local`, or `just db-up`).
+# Run the test suite. Requires a FalkorDB on {{port}} (use `just verify-local`, or `just db-up`),
+# or set FALKORDB_HOST/FALKORDB_PORT — otherwise the tests start their own Testcontainers server.
 test:
     ./mvnw -B -Dgpg.skip=true test
 
-# Full build + tests + coverage (JaCoCo) — the aggregate gate CI runs. Requires a server.
+# Full build + tests + coverage (JaCoCo) — the aggregate gate CI runs. Tests start a FalkorDB
+# automatically via Testcontainers (Docker required); no manual server needed.
 verify:
     ./mvnw -B -Dgpg.skip=true verify
 
@@ -87,10 +89,12 @@ db-up:
 db-down:
     -docker rm -f {{container}}
 
-# Manage Docker and run the full `verify` locally; tears the server down even on failure.
+# Manage Docker and run the full `verify` locally against that server, reusing it via the
+# FALKORDB_HOST/PORT override so the tests don't also start a Testcontainers server; tears the
+# server down even on failure. Handy when Testcontainers can't reach your local Docker.
 verify-local:
     #!/usr/bin/env bash
     set -euo pipefail
     trap 'just db-down' EXIT
     just db-up
-    just verify
+    FALKORDB_HOST=localhost FALKORDB_PORT={{port}} just verify

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,12 @@
 			<version>3.19.4</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers</artifactId>
+			<version>1.21.3</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/test/java/com/falkordb/ConfigTest.java
+++ b/src/test/java/com/falkordb/ConfigTest.java
@@ -13,7 +13,7 @@ public class ConfigTest {
 
     @BeforeEach
     public void setUp() {
-        driver = FalkorDB.driver();
+        driver = TestServer.driver();
     }
 
     @AfterEach

--- a/src/test/java/com/falkordb/GraphAPITest.java
+++ b/src/test/java/com/falkordb/GraphAPITest.java
@@ -25,7 +25,7 @@ public class GraphAPITest {
 
     @BeforeEach
     public void createApi() {
-        client = FalkorDB.driver().graph("social");
+        client = TestServer.graph("social");
     }
 
     @AfterEach
@@ -1141,7 +1141,7 @@ public class GraphAPITest {
         // Copy the graph
         client.copyGraph("social-copied");
 
-        GraphContextGenerator client2 = FalkorDB.driver().graph("social-copied");
+        GraphContextGenerator client2 = TestServer.graph("social-copied");
         try {
             // Compare graph contents
             ResultSet copiedResultSet = client2.query("MATCH (p:person)-[rel:knows]->(p2:person) RETURN p,rel,p2");
@@ -1170,7 +1170,7 @@ public class GraphAPITest {
             c.copyGraph("social-copied");
         }
 
-        GraphContextGenerator client2 = FalkorDB.driver().graph("social-copied");
+        GraphContextGenerator client2 = TestServer.graph("social-copied");
         try {
             // Compare graph contents
             ResultSet copiedResultSet = client2.query("MATCH (p:person)-[rel:knows]->(p2:person) RETURN p,rel,p2");

--- a/src/test/java/com/falkordb/InstantiationTest.java
+++ b/src/test/java/com/falkordb/InstantiationTest.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 public class InstantiationTest {
@@ -11,6 +12,12 @@ public class InstantiationTest {
 
     @Test
     public void createDefaultClient() {
+        // The no-arg driver() targets localhost:6379; this is only meaningful when the test server
+        // actually runs there (external FALKORDB_HOST/PORT override, or local). The dynamic-port
+        // Testcontainers path is covered by the smoke-jdk8 job, so skip otherwise.
+        Assumptions.assumeTrue(
+                "localhost".equals(TestServer.host()) && TestServer.port() == 6379,
+                "no-arg driver() requires a server on localhost:6379");
         client = FalkorDB.driver().graph("g");
         ResultSet resultSet = client.query("CREATE ({name:'bsb'})");
         Assertions.assertEquals(1, resultSet.getStatistics().nodesCreated());
@@ -18,14 +25,15 @@ public class InstantiationTest {
 
     @Test
     public void createClientWithHostAndPort() {
-        client = FalkorDB.driver("localhost", 6379).graph("g");
+        client = FalkorDB.driver(TestServer.host(), TestServer.port()).graph("g");
         ResultSet resultSet = client.query("CREATE ({name:'bsb'})");
         Assertions.assertEquals(1, resultSet.getStatistics().nodesCreated());
     }
 
     @Test
     public void createClientWithHostAndPortNoUser() {
-        client = FalkorDB.driver("localhost", 6379, null, null).graph("g");
+        client = FalkorDB.driver(TestServer.host(), TestServer.port(), null, null)
+                .graph("g");
         ResultSet resultSet = client.query("CREATE ({name:'bsb'})");
         Assertions.assertEquals(1, resultSet.getStatistics().nodesCreated());
     }
@@ -35,11 +43,11 @@ public class InstantiationTest {
         // Unique username so the test never overwrites or deletes a pre-existing
         // ACL user when run against a shared/dev server.
         String username = "jfalkordb_test_" + UUID.randomUUID().toString().replace("-", "");
-        try (redis.clients.jedis.Jedis admin = new redis.clients.jedis.Jedis("localhost", 6379)) {
+        try (redis.clients.jedis.Jedis admin = new redis.clients.jedis.Jedis(TestServer.host(), TestServer.port())) {
             admin.aclSetUser(username, "on", ">testpass", "~*", "+@all");
             try {
-                client =
-                        FalkorDB.driver("localhost", 6379, username, "testpass").graph("g");
+                client = FalkorDB.driver(TestServer.host(), TestServer.port(), username, "testpass")
+                        .graph("g");
                 ResultSet resultSet = client.query("CREATE ({name:'bsb'})");
                 Assertions.assertEquals(1, resultSet.getStatistics().nodesCreated());
                 client.deleteGraph();
@@ -57,9 +65,9 @@ public class InstantiationTest {
         // read timeout would abort a read that takes longer than 2s. With the driver
         // disabling the client-side socket timeout, a command issued while the server
         // is paused for >2s must still succeed instead of failing with a read timeout.
-        client = FalkorDB.driver("localhost", 6379).graph("g");
+        client = FalkorDB.driver(TestServer.host(), TestServer.port()).graph("g");
         client.query("RETURN 1"); // establish a pooled connection before pausing the server
-        try (redis.clients.jedis.Jedis admin = new redis.clients.jedis.Jedis("localhost", 6379)) {
+        try (redis.clients.jedis.Jedis admin = new redis.clients.jedis.Jedis(TestServer.host(), TestServer.port())) {
             admin.clientPause(2500L); // pause command processing for 2.5s (> old 2000ms timeout)
         }
         long start = System.currentTimeMillis();
@@ -74,7 +82,8 @@ public class InstantiationTest {
 
     @Test
     public void createClientWithURL() {
-        client = FalkorDB.driver(URI.create("redis://localhost:6379")).graph("g");
+        client = FalkorDB.driver(URI.create("redis://" + TestServer.host() + ":" + TestServer.port()))
+                .graph("g");
         ResultSet resultSet = client.query("CREATE ({name:'bsb'})");
         Assertions.assertEquals(1, resultSet.getStatistics().nodesCreated());
     }

--- a/src/test/java/com/falkordb/IterableTest.java
+++ b/src/test/java/com/falkordb/IterableTest.java
@@ -13,7 +13,7 @@ public class IterableTest {
 
     @BeforeEach
     public void createApi() {
-        api = FalkorDB.driver().graph("social");
+        api = TestServer.graph("social");
     }
 
     @AfterEach

--- a/src/test/java/com/falkordb/ListGraphsTest.java
+++ b/src/test/java/com/falkordb/ListGraphsTest.java
@@ -11,7 +11,7 @@ public class ListGraphsTest {
 
     @BeforeEach
     public void setUp() {
-        driver = FalkorDB.driver();
+        driver = TestServer.driver();
     }
 
     @Test

--- a/src/test/java/com/falkordb/PipelineTest.java
+++ b/src/test/java/com/falkordb/PipelineTest.java
@@ -15,7 +15,7 @@ public class PipelineTest {
 
     @BeforeEach
     public void createApi() {
-        api = FalkorDB.driver().graph("social");
+        api = TestServer.graph("social");
     }
 
     @AfterEach
@@ -257,7 +257,7 @@ public class PipelineTest {
             originalResultSetIterator = originalResultSet.iterator();
         }
 
-        GraphContextGenerator api2 = FalkorDB.driver().graph("social-copied");
+        GraphContextGenerator api2 = TestServer.graph("social-copied");
         try {
             // Compare graph contents
             ResultSet copiedResultSet = api2.query("MATCH (p:person)-[rel:knows]->(p2:person) RETURN p,rel,p2");

--- a/src/test/java/com/falkordb/TestServer.java
+++ b/src/test/java/com/falkordb/TestServer.java
@@ -28,6 +28,9 @@ public final class TestServer {
     private static final int port;
     private static final boolean external;
 
+    // One driver/pool shared by all graph() callers, closed once at JVM shutdown (see graph()).
+    private static Driver sharedDriver;
+
     static {
         String envHost = System.getenv("FALKORDB_HOST");
         String envPort = System.getenv("FALKORDB_PORT");
@@ -81,8 +84,27 @@ public final class TestServer {
         return FalkorDB.driver(host, port);
     }
 
-    /** A graph context on the shared test server; the caller is responsible for closing it. */
+    /**
+     * A graph context on the shared test server, backed by a single suite-wide driver/pool that is
+     * closed once at JVM shutdown. Closing the returned graph only clears its cache (it does not own
+     * the driver), so callers must not close the underlying driver — this is what keeps each call
+     * from leaking a {@code JedisPool}.
+     */
     public static GraphContextGenerator graph(String name) {
-        return FalkorDB.driver(host, port).graph(name);
+        return sharedDriver().graph(name);
+    }
+
+    private static synchronized Driver sharedDriver() {
+        if (sharedDriver == null) {
+            sharedDriver = FalkorDB.driver(host, port);
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                try {
+                    sharedDriver.close();
+                } catch (Exception ignored) {
+                    // best-effort cleanup at JVM exit
+                }
+            }));
+        }
+        return sharedDriver;
     }
 }

--- a/src/test/java/com/falkordb/TestServer.java
+++ b/src/test/java/com/falkordb/TestServer.java
@@ -33,14 +33,14 @@ public final class TestServer {
         String envPort = System.getenv("FALKORDB_PORT");
         boolean hasHost = envHost != null && !envHost.isEmpty();
         boolean hasPort = envPort != null && !envPort.isEmpty();
-        if (hasHost ^ hasPort) {
+        if (hasHost != hasPort) {
             throw new IllegalStateException(
                     "Set BOTH FALKORDB_HOST and FALKORDB_PORT to use an external FalkorDB, or neither.");
         }
-        if (hasHost) {
+        if (hasHost && hasPort) {
             external = true;
             host = envHost;
-            port = Integer.parseInt(envPort.trim());
+            port = parsePort(envPort);
         } else {
             external = false;
             GenericContainer<?> container =
@@ -52,6 +52,14 @@ public final class TestServer {
     }
 
     private TestServer() {}
+
+    private static int parsePort(String value) {
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException("FALKORDB_PORT must be a valid integer, but was \"" + value + "\"", e);
+        }
+    }
 
     /** Host of the shared test server (container host, or the {@code FALKORDB_HOST} override). */
     public static String host() {

--- a/src/test/java/com/falkordb/TestServer.java
+++ b/src/test/java/com/falkordb/TestServer.java
@@ -1,0 +1,80 @@
+package com.falkordb;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Test-only endpoint factory for a FalkorDB server.
+ *
+ * <p>By default it starts a single, shared Testcontainers-managed {@code falkordb/falkordb} container
+ * (on a dynamic port), reused across the whole test suite and torn down at JVM exit — so {@code just
+ * verify} needs zero manual server setup. Set <strong>both</strong> {@code FALKORDB_HOST} and {@code
+ * FALKORDB_PORT} to reuse an already-running server instead (no container is started); setting only
+ * one is rejected.
+ *
+ * <p><strong>External-server safety:</strong> some system tests mutate server-wide state (for example
+ * {@code UdfTest} globally lists/deletes UDF libraries). When you point this at an external server via
+ * the env override, use a <em>dedicated disposable</em> instance — never a shared or production
+ * server. The default container path is always safe because the container is throwaway.
+ */
+public final class TestServer {
+
+    // Pinned digest (v4.20.1) so the suite is reproducible; matches the smoke-jdk8 CI job's image.
+    private static final DockerImageName IMAGE = DockerImageName.parse(
+            "falkordb/falkordb@sha256:9042fdc4e53f5390ca5a3993aa71506523970efb40ffb9a98e6a4b1a9a4f8862");
+
+    private static final String host;
+    private static final int port;
+    private static final boolean external;
+
+    static {
+        String envHost = System.getenv("FALKORDB_HOST");
+        String envPort = System.getenv("FALKORDB_PORT");
+        boolean hasHost = envHost != null && !envHost.isEmpty();
+        boolean hasPort = envPort != null && !envPort.isEmpty();
+        if (hasHost ^ hasPort) {
+            throw new IllegalStateException(
+                    "Set BOTH FALKORDB_HOST and FALKORDB_PORT to use an external FalkorDB, or neither.");
+        }
+        if (hasHost) {
+            external = true;
+            host = envHost;
+            port = Integer.parseInt(envPort.trim());
+        } else {
+            external = false;
+            GenericContainer<?> container =
+                    new GenericContainer<>(IMAGE).withExposedPorts(6379).waitingFor(Wait.forListeningPort());
+            container.start(); // shared for the whole JVM; Testcontainers' Ryuk stops it at exit
+            host = container.getHost();
+            port = container.getMappedPort(6379);
+        }
+    }
+
+    private TestServer() {}
+
+    /** Host of the shared test server (container host, or the {@code FALKORDB_HOST} override). */
+    public static String host() {
+        return host;
+    }
+
+    /** Port of the shared test server (mapped container port, or the {@code FALKORDB_PORT} override). */
+    public static int port() {
+        return port;
+    }
+
+    /** {@code true} when tests run against an external (env-override) server rather than a container. */
+    public static boolean isExternal() {
+        return external;
+    }
+
+    /** A new driver connected to the shared test server; the caller is responsible for closing it. */
+    public static Driver driver() {
+        return FalkorDB.driver(host, port);
+    }
+
+    /** A graph context on the shared test server; the caller is responsible for closing it. */
+    public static GraphContextGenerator graph(String name) {
+        return FalkorDB.driver(host, port).graph(name);
+    }
+}

--- a/src/test/java/com/falkordb/TransactionTest.java
+++ b/src/test/java/com/falkordb/TransactionTest.java
@@ -21,7 +21,7 @@ public class TransactionTest {
 
     @BeforeEach
     public void createApi() {
-        api = FalkorDB.driver().graph("social");
+        api = TestServer.graph("social");
     }
 
     @AfterEach
@@ -314,7 +314,7 @@ public class TransactionTest {
             originalResultSetIterator = originalResultSet.iterator();
         }
 
-        GraphContextGenerator api2 = FalkorDB.driver().graph("social-copied");
+        GraphContextGenerator api2 = TestServer.graph("social-copied");
         try {
             // Compare graph contents
             ResultSet copiedResultSet = api2.query("MATCH (p:person)-[rel:knows]->(p2:person) RETURN p,rel,p2");

--- a/src/test/java/com/falkordb/UdfTest.java
+++ b/src/test/java/com/falkordb/UdfTest.java
@@ -12,7 +12,7 @@ public class UdfTest {
 
     @BeforeEach
     public void setUp() {
-        driver = FalkorDB.driver();
+        driver = TestServer.driver();
         // Clean up any existing UDF libraries before each test
         try {
             driver.udfFlush();

--- a/src/test/java/com/falkordb/exceptions/GraphErrorTest.java
+++ b/src/test/java/com/falkordb/exceptions/GraphErrorTest.java
@@ -3,9 +3,9 @@ package com.falkordb.exceptions;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.falkordb.FalkorDB;
 import com.falkordb.GraphContext;
 import com.falkordb.GraphContextGenerator;
+import com.falkordb.TestServer;
 import java.util.HashMap;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -18,7 +18,7 @@ public class GraphErrorTest {
 
     @BeforeEach
     public void createApi() {
-        api = FalkorDB.driver().graph("social");
+        api = TestServer.graph("social");
         Assertions.assertNotNull(api.query("CREATE (:person{mixed_prop: 'strval'}), (:person{mixed_prop: 50})"));
     }
 


### PR DESCRIPTION
## Wave 2 — PR 6: manage the FalkorDB server with Testcontainers

Makes `just verify` start a FalkorDB **automatically** — zero manual server setup, locally and in CI. This is the test-harness half of the approved Wave 2 plan (#300).

### What changed
- **New `TestServer` test-only endpoint factory** — starts a single, shared **Testcontainers**-managed `falkordb/falkordb` container (pinned digest, dynamic port), reused across the whole suite and torn down at JVM exit. Honors a **`FALKORDB_HOST`/`FALKORDB_PORT` override** (both required) to reuse an external server; documents the external-server safety caveat for globally-mutating tests.
- **Every test connection site migrated** to the harness (9 files). The public **no-arg `FalkorDB.driver()`** contract is untouched — `InstantiationTest`'s explicit-endpoint tests use `TestServer.host()/port()`, and its no-arg localhost test runs only when a server is actually on `localhost:6379` (otherwise skipped; the `smoke-jdk8` job covers that contract).
- **CI (`build` job) drops the FalkorDB service container** and lets Testcontainers manage it (decision #4 — exercises the real lifecycle).
- **`just verify-local`** now starts `db-up` and reuses it via the override, so it never double-starts a server — and works even where Testcontainers can't reach local Docker.

### Validation
- `just verify-local` → **214 tests pass** on JDK 21 (harness routes through the override to a `db-up` server).
- The Testcontainers container-start path is exercised by CI's `build` job (standard ubuntu Docker); my local Docker is too new (29.6.1 / API 1.55) for the bundled docker-java, hence the override path for local runs.
- `just fmt-check` + `just spellcheck` green.

### Scope note
To keep this reviewable, the **Failsafe `*IT` split + moving the JaCoCo report to `verify`** are deferred to a focused follow-up (PR 6b). This PR is the Testcontainers migration only — all tests still run under Surefire, so coverage reporting is unchanged.

Not merging — for your review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated test runs now start a FalkorDB server when Docker is available.
  * Local testing can connect to an externally hosted FalkorDB instance using configurable host and port settings.

* **Documentation**
  * Updated development and verification guidance to reflect automated server startup and external-server support.

* **Tests**
  * Improved test reliability across different server locations and environments.
  * Added validation for incomplete or invalid server connection settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->