### PR TITLE
test: split server-backed tests into *IT (Failsafe) + merged coverage (Wave 2, PR 6b)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,14 +19,16 @@ recipe; recipes call the pinned Maven Wrapper (`./mvnw`).
 | --- | --- |
 | `just verify` | Build + tests + coverage (the CI `build` gate). Auto-starts FalkorDB via Testcontainers (Docker). |
 | `just verify-local` | Run `verify` against a `just db-up` server (reused via `FALKORDB_HOST/PORT`), then tear it down — handy when Testcontainers can't reach your Docker. |
-| `just build` / `just test` | Compile-only / tests-only. |
+| `just build` / `just test` | Compile-only / fast **unit** tests only (`*Test`, no server). |
 | `just fmt` / `just fmt-check` | Apply / check palantir-java-format (runs in the `-Pquality` profile). |
 | `just spellcheck` | Spellcheck the Markdown docs (the CI `spellcheck` gate). |
 | `just db-up` / `just db-down` | Manage a local FalkorDB container. |
 
-Tests start a FalkorDB automatically via **Testcontainers** (Docker required) — no manual server
-setup. Set both `FALKORDB_HOST`/`FALKORDB_PORT` (or use `just verify-local`) to reuse an existing
-server instead.
+Server-backed **system tests are `*IT`** (run by Failsafe in `verify`) and start a FalkorDB
+automatically via **Testcontainers** (Docker required) — no manual server setup; set both
+`FALKORDB_HOST`/`FALKORDB_PORT` (or use `just verify-local`) to reuse an existing server instead.
+Pure **unit tests are `*Test`** (Surefire, no server) and run in `just test`. Name new tests
+accordingly, and use the `TestServer` helper for server access.
 
 ## Definition of done
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Common recipes:
 just verify-local   # spin up FalkorDB (Docker), run the full build + tests, then tear it down
 just verify         # same build + tests; auto-starts FalkorDB via Testcontainers (Docker)
 just build          # compile + package, no tests
-just test           # tests only (auto-starts a Testcontainers server, or set FALKORDB_HOST/PORT)
+just test           # fast unit tests only (no server); system tests are *IT, run by just verify
 just fmt            # apply palantir-java-format
 just fmt-check      # check formatting
 just db-up          # start a local FalkorDB container

--- a/Justfile
+++ b/Justfile
@@ -31,8 +31,8 @@ spellcheck:
 build:
     ./mvnw -B -DskipTests -Dgpg.skip=true package
 
-# Run the test suite. Requires a FalkorDB on {{port}} (use `just verify-local`, or `just db-up`),
-# or set FALKORDB_HOST/FALKORDB_PORT — otherwise the tests start their own Testcontainers server.
+# Run the fast unit tests only (Surefire, *Test — no server needed). System tests are *IT
+# and run under Failsafe in `just verify` / `just verify-local`.
 test:
     ./mvnw -B -Dgpg.skip=true test
 

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,26 @@
 				<version>3.5.6</version>
 			</plugin>
 
+			<!-- Integration tests (*IT, server-backed via Testcontainers) run in integration-test/verify.
+			     @{argLine} makes Failsafe load the JaCoCo agent (append=true), so IT coverage is added
+			     to the same jacoco.exec the unit tests write, and the report at `verify` covers both. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>3.5.6</version>
+				<configuration>
+					<argLine>@{argLine}</argLine>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
@@ -132,7 +152,7 @@
 					</execution>
 					<execution>
 						<id>report</id>
-						<phase>test</phase>
+						<phase>verify</phase>
 						<goals>
 							<goal>report</goal>
 						</goals>

--- a/src/test/java/com/falkordb/ConfigIT.java
+++ b/src/test/java/com/falkordb/ConfigIT.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import redis.clients.jedis.exceptions.JedisDataException;
 
-public class ConfigTest {
+public class ConfigIT {
 
     private Driver driver;
 

--- a/src/test/java/com/falkordb/GraphAPIIT.java
+++ b/src/test/java/com/falkordb/GraphAPIIT.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class GraphAPITest {
+public class GraphAPIIT {
 
     private GraphContextGenerator client;
 

--- a/src/test/java/com/falkordb/InstantiationIT.java
+++ b/src/test/java/com/falkordb/InstantiationIT.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
-public class InstantiationTest {
+public class InstantiationIT {
     private GraphContextGenerator client;
 
     @Test

--- a/src/test/java/com/falkordb/IterableIT.java
+++ b/src/test/java/com/falkordb/IterableIT.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class IterableTest {
+public class IterableIT {
 
     private GraphContextGenerator api;
 

--- a/src/test/java/com/falkordb/ListGraphsIT.java
+++ b/src/test/java/com/falkordb/ListGraphsIT.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ListGraphsTest {
+public class ListGraphsIT {
 
     private Driver driver;
 

--- a/src/test/java/com/falkordb/PipelineIT.java
+++ b/src/test/java/com/falkordb/PipelineIT.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class PipelineTest {
+public class PipelineIT {
 
     private GraphContextGenerator api;
 

--- a/src/test/java/com/falkordb/TestServer.java
+++ b/src/test/java/com/falkordb/TestServer.java
@@ -14,7 +14,7 @@ import org.testcontainers.utility.DockerImageName;
  * one is rejected.
  *
  * <p><strong>External-server safety:</strong> some system tests mutate server-wide state (for example
- * {@code UdfTest} globally lists/deletes UDF libraries). When you point this at an external server via
+ * {@code UdfIT} globally lists/deletes UDF libraries). When you point this at an external server via
  * the env override, use a <em>dedicated disposable</em> instance — never a shared or production
  * server. The default container path is always safe because the container is throwaway.
  */

--- a/src/test/java/com/falkordb/TransactionIT.java
+++ b/src/test/java/com/falkordb/TransactionIT.java
@@ -13,11 +13,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class TransactionTest {
+public class TransactionIT {
 
     private GraphContextGenerator api;
 
-    public TransactionTest() {}
+    public TransactionIT() {}
 
     @BeforeEach
     public void createApi() {

--- a/src/test/java/com/falkordb/UdfIT.java
+++ b/src/test/java/com/falkordb/UdfIT.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class UdfTest {
+public class UdfIT {
 
     private Driver driver;
 

--- a/src/test/java/com/falkordb/exceptions/GraphErrorIT.java
+++ b/src/test/java/com/falkordb/exceptions/GraphErrorIT.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class GraphErrorTest {
+public class GraphErrorIT {
 
     private GraphContextGenerator api;
 


### PR DESCRIPTION
## Wave 2 — PR 6b: Failsafe `*IT` split + merged coverage

Completes the test split **deferred from #312** (Testcontainers). Separates fast unit tests from server-backed system tests, cleanly and with coverage intact.

### What changed
- The **9 server-backed suites** are renamed to **`*IT`** (GraphAPIIT, TransactionIT, PipelineIT, IterableIT, ListGraphsIT, ConfigIT, UdfIT, InstantiationIT, exceptions/GraphErrorIT) and run under **`maven-failsafe-plugin`** in `integration-test`/`verify`. Pure **unit tests stay `*Test`** on Surefire.
- **`just test`** now runs only the fast unit tests — **no server/Docker needed**. **`just verify`** runs unit + IT.
- **Coverage stays combined**: Failsafe loads the JaCoCo agent via `@{argLine}` (append), so IT coverage is added to the same `jacoco.exec`, and the report moves to **`verify`**.

### Why the rename
It's the standard Surefire/Failsafe convention (`*Test` = unit, `*IT` = integration) and the prerequisite for the Wave 4 FalkorDB-version matrix. The diff is large but mechanical (renames + class names; only `TestServer`/pom/docs are logic).

### Validation (JDK 21)
- `just test` → **135 unit tests**, no Docker, `BUILD SUCCESS`.
- `just verify-local` → **135 unit + 79 IT = 214**, `BUILD SUCCESS`.
- Merged coverage report generated at `verify`: **~80.3% overall**, and system-only classes (e.g. `GraphImpl`) show IT coverage **included** — confirming the append/merge works.
- `just fmt-check` + `just spellcheck` green.

Not merging — for your review. This is the last test-harness PR of Wave 2; **PR 7 (JMH benchmark radar)** is next.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved separation between fast unit tests and server-backed integration tests.
  * Integration tests now run during verification, with coverage reporting including both unit and integration results.
  * Standardized integration-test naming for reliable test discovery.

* **Documentation**
  * Clarified test commands, server usage, and guidance for creating and running tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->