### PR TITLE
build: add SpotBugs/FindSecBugs + Error Prone + OWASP quality gates; retire DeepSource

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,8 +1,0 @@
-version = 1
-
-[[analyzers]]
-name = "java"
-enabled = true
-
-  [analyzers.meta]
-  runtime_version = "8"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,6 +21,8 @@ recipe; recipes call the pinned Maven Wrapper (`./mvnw`).
 | `just verify-local` | Run `verify` against a `just db-up` server (reused via `FALKORDB_HOST/PORT`), then tear it down — handy when Testcontainers can't reach your Docker. |
 | `just build` / `just test` | Compile-only / fast **unit** tests only (`*Test`, no server). |
 | `just fmt` / `just fmt-check` | Apply / check palantir-java-format (runs in the `-Pquality` profile). |
+| `just lint` | Static analysis (the CI `lint` gate): format check + **SpotBugs/FindSecBugs** + **Error Prone**, all in the off-by-default `-Pquality` profile. |
+| `just audit` | OWASP dependency-check CVE scan of the shipped deps. Slow + needs `NVD_API_KEY`; run by the scheduled/manual **`audit`** workflow, not on every PR. |
 | `just spellcheck` | Spellcheck the Markdown docs (the CI `spellcheck` gate). |
 | `just db-up` / `just db-down` | Manage a local FalkorDB container. |
 | `just bench` / `just bench-one <loads>` | Client load-sweep benchmark — client latency (total − server) vs throughput across concurrency levels; feeds the per-PR-vs-`master` radar + Pages curve. |
@@ -59,8 +61,10 @@ accordingly, and use the `TestServer` helper for server access.
 - **`junit-jupiter` stays on 5.x** and **`equalsverifier` on 3.x** (Dependabot ignores their
   semver-major bumps). The JDK-21 build *could* now compile their 6.x/4.x, but raising them is a
   deliberate later change, not automatic — so keep the pins for now.
-- Any Java-11+ tool (e.g. Spotless / palantir-java-format) still lives in the **off-by-default
-  `quality` Maven profile**, kept as a separate explicit gate off the aggregate lifecycle.
+- Any Java-11+ tool (e.g. Spotless / palantir-java-format, SpotBugs/FindSecBugs, Error Prone, OWASP
+  dependency-check) still lives in the **off-by-default `quality` Maven profile**, kept as a separate
+  explicit gate off the aggregate lifecycle (`just lint` / `just audit`). Static analysis is in-build
+  and reproducible; there is no external DeepSource integration.
 
 ## Releasing
 

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,46 @@
+name: Dependency audit (OWASP)
+
+# OWASP dependency-check is slow and needs an NVD API key, so it runs on a schedule (and on demand)
+# rather than on every push/PR. It scans the shipped dependency graph for known CVEs via `just audit`.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # weekly, Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
+    - name: Set up JDK 21
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+    - name: Install just
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+    # Cache the NVD data the plugin downloads so subsequent runs only fetch the delta.
+    - name: Cache OWASP dependency-check data
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: ~/.m2/repository/org/owasp/dependency-check-data
+        key: owasp-data-${{ github.run_id }}
+        restore-keys: |
+          owasp-data-
+    - name: Dependency CVE scan (via just)
+      env:
+        NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+      run: just audit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -32,14 +32,20 @@ jobs:
         cache: maven
     - name: Install just
       uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
-    # Cache the NVD data the plugin downloads so subsequent runs only fetch the delta.
+    # Cache the NVD data the plugin downloads so subsequent runs only fetch the delta. The key is
+    # bucketed by ISO week so re-runs/dispatches within a week reuse it exactly (a true hit, no
+    # re-save), while it rotates weekly and picks up the previous week's data via restore-keys — so
+    # the cache stays fresh without growing unbounded from a per-run key.
+    - name: Compute weekly cache bucket
+      id: cache-bucket
+      run: echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
     - name: Cache OWASP dependency-check data
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ~/.m2/repository/org/owasp/dependency-check-data
-        key: owasp-data-${{ github.run_id }}
+        key: owasp-data-${{ runner.os }}-${{ steps.cache-bucket.outputs.week }}
         restore-keys: |
-          owasp-data-
+          owasp-data-${{ runner.os }}-
     - name: Dependency CVE scan (via just)
       env:
         NVD_API_KEY: ${{ secrets.NVD_API_KEY }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -71,6 +71,25 @@ jobs:
     - name: Check formatting (via just)
       run: just fmt-check
 
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
+    - name: Set up JDK 21
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+    - name: Install just
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+    - name: Static analysis — SpotBugs/FindSecBugs + Error Prone (via just)
+      run: just lint
+
   smoke-jdk8:
 
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,8 @@ just build          # compile + package, no tests
 just test           # fast unit tests only (no server); system tests are *IT, run by just verify
 just fmt            # apply palantir-java-format
 just fmt-check      # check formatting
+just lint           # static analysis: format check + SpotBugs/FindSecBugs + Error Prone (-Pquality)
+just audit          # OWASP dependency-check CVE scan (slow; needs NVD_API_KEY; run by the audit workflow)
 just db-up          # start a local FalkorDB container
 just db-down        # stop it
 just bench          # client load-sweep benchmark (client latency vs throughput; feeds the radar)

--- a/Justfile
+++ b/Justfile
@@ -23,6 +23,17 @@ fmt:
 fmt-check:
     ./mvnw -B -Pquality spotless:check
 
+# Static analysis (no server): format check + SpotBugs/FindSecBugs + Error Prone, all in the
+# off-by-default `quality` profile. This is the CI `lint` gate. `clean` forces a full recompile so
+# Error Prone always runs (incremental compilation would otherwise skip up-to-date sources).
+lint:
+    ./mvnw -B -Pquality -Dgpg.skip=true clean spotless:check test-compile spotbugs:check
+
+# Dependency CVE scan (OWASP dependency-check). Slow + wants an NVD API key: set NVD_API_KEY in the
+# environment (the scheduled/manual `audit` workflow provides it). Not part of `verify`.
+audit:
+    ./mvnw -B -Pquality -DskipTests -Dgpg.skip=true org.owasp:dependency-check-maven:check
+
 # Spellcheck the Markdown docs (CI gate). Needs `pyspelling` + `aspell` (see CONTRIBUTING.md).
 spellcheck:
     pyspelling -c .github/spellcheck-settings.yml -n Markdown

--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  OWASP dependency-check suppressions for JFalkorDB. Add an entry (with a justification and,
+  ideally, a link to the advisory) only for a vetted false positive or an accepted, non-exploitable
+  CVE — never to blanket-silence real vulnerabilities.
+-->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -285,6 +285,38 @@
 			<id>quality</id>
 			<build>
 				<plugins>
+					<!-- Error Prone: compile-time bug patterns. Runs only in this profile (JDK 16+ needs
+					     the compiler add-exports/add-opens flags and a forked compiler), so the default
+					     release-8 build stays untouched. -->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<configuration>
+							<fork>true</fork>
+							<compilerArgs>
+								<arg>-XDcompilePolicy=simple</arg>
+								<arg>--should-stop=ifError=FLOW</arg>
+								<arg>-Xplugin:ErrorProne</arg>
+								<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+								<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+								<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+								<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+								<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+								<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+								<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+								<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+								<arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+								<arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+							</compilerArgs>
+							<annotationProcessorPaths>
+								<path>
+									<groupId>com.google.errorprone</groupId>
+									<artifactId>error_prone_core</artifactId>
+									<version>2.36.0</version>
+								</path>
+							</annotationProcessorPaths>
+						</configuration>
+					</plugin>
 					<plugin>
 						<groupId>com.diffplug.spotless</groupId>
 						<artifactId>spotless-maven-plugin</artifactId>
@@ -297,6 +329,52 @@
 								<removeUnusedImports/>
 								<importOrder/>
 							</java>
+						</configuration>
+					</plugin>
+					<!-- SpotBugs + FindSecBugs: bytecode bug & security analysis of the shipped classes.
+					     Runs on the JDK-21 build; never part of the default lifecycle (Java-8 guarantee). -->
+					<plugin>
+						<groupId>com.github.spotbugs</groupId>
+						<artifactId>spotbugs-maven-plugin</artifactId>
+						<version>4.8.6.6</version>
+						<configuration>
+							<effort>Max</effort>
+							<threshold>Medium</threshold>
+							<includeTests>false</includeTests>
+							<excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
+							<plugins>
+								<plugin>
+									<groupId>com.h3xstream.findsecbugs</groupId>
+									<artifactId>findsecbugs-plugin</artifactId>
+									<version>1.13.0</version>
+								</plugin>
+							</plugins>
+						</configuration>
+						<executions>
+							<execution>
+								<id>spotbugs-check</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>check</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<!-- OWASP dependency-check: known-CVE scan of the shipped dependency graph. Slow and
+					     needs an NVD API key, so it is NOT bound to a phase — it is invoked on demand via
+					     `just audit` (the dedicated scheduled/manual `audit` workflow), never in `verify`. -->
+					<plugin>
+						<groupId>org.owasp</groupId>
+						<artifactId>dependency-check-maven</artifactId>
+						<version>12.2.2</version>
+						<configuration>
+							<failBuildOnCVSS>7</failBuildOnCVSS>
+							<skipProvidedScope>true</skipProvidedScope>
+							<skipTestScope>true</skipTestScope>
+							<nvdApiKeyEnvironmentVariable>NVD_API_KEY</nvdApiKeyEnvironmentVariable>
+							<suppressionFiles>
+								<suppressionFile>owasp-suppressions.xml</suppressionFile>
+							</suppressionFiles>
 						</configuration>
 					</plugin>
 				</plugins>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SpotBugs/FindSecBugs exclusions for JFalkorDB. Keep this list small and justified — each entry
+  documents a deliberate false positive, not a way to silence real findings.
+-->
+<FindBugsFilter
+    xmlns="https://github.com/spotbugs/filter/3.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/master/spotbugs/etc/findbugsfilter.xsd">
+    <!--
+      EI_EXPOSE_REP / EI_EXPOSE_REP2: "may expose internal representation" defensive-copy nags. Our
+      value objects (Path, HeaderImpl, RecordImpl, GraphCommand, ...) are lightweight result holders,
+      and the connection/pool/cache references (DriverImpl, GraphContextImpl, ...) are intentionally
+      shared, not copied. Defensive-copying every getter/constructor would add cost for no real safety
+      benefit here, so this well-known-noisy pattern is excluded (kept out of the security gate).
+    -->
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
+    </Match>
+</FindBugsFilter>

--- a/src/main/java/com/falkordb/impl/Utils.java
+++ b/src/main/java/com/falkordb/impl/Utils.java
@@ -2,9 +2,7 @@ package com.falkordb.impl;
 
 import java.lang.reflect.Array;
 import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,13 +21,13 @@ import java.util.regex.Pattern;
  */
 public class Utils {
     /**
-     * A dummy list.
+     * An immutable empty list, used as an empty default argument.
      */
-    public static final List<String> DUMMY_LIST = new ArrayList<>(0);
+    public static final List<String> DUMMY_LIST = Collections.emptyList();
     /**
-     * A dummy map.
+     * An immutable empty map, used as an empty default argument.
      */
-    public static final Map<String, List<String>> DUMMY_MAP = new HashMap<>(0);
+    public static final Map<String, List<String>> DUMMY_MAP = Collections.emptyMap();
     /**
      * The compact string.
      */

--- a/src/main/java/com/falkordb/impl/graph_cache/GraphCacheList.java
+++ b/src/main/java/com/falkordb/impl/graph_cache/GraphCacheList.java
@@ -14,6 +14,8 @@ class GraphCacheList {
 
     private final String procedure;
     private final List<String> data = new CopyOnWriteArrayList<>();
+    // Serializes cache refresh; don't synchronize on `data` itself (it's a concurrent collection).
+    private final Object refreshLock = new Object();
 
     /**
      * @param procedure - exact procedure command
@@ -29,7 +31,7 @@ class GraphCacheList {
      */
     public String getCachedData(int index, Graph graph) {
         if (index >= data.size()) {
-            synchronized (data) {
+            synchronized (refreshLock) {
                 if (index >= data.size()) {
                     getProcedureInfo(graph);
                 }

--- a/src/main/java/com/falkordb/impl/resultset/ResultSetImpl.java
+++ b/src/main/java/com/falkordb/impl/resultset/ResultSetImpl.java
@@ -18,7 +18,7 @@ import redis.clients.jedis.util.SafeEncoder;
 /**
  * An implementation of the ResultSet interface.
  */
-public class ResultSetImpl implements ResultSet {
+public final class ResultSetImpl implements ResultSet {
 
     private final Header header;
     private final Statistics statistics;

--- a/src/test/java/com/falkordb/GraphAPIIT.java
+++ b/src/test/java/com/falkordb/GraphAPIIT.java
@@ -904,7 +904,7 @@ public class GraphAPIIT {
 
     @Test
     public void test64bitnumber() {
-        long value = 1 << 40;
+        long value = 1L << 40;
         Map<String, Object> params = new HashMap<>();
         params.put("val", value);
         ResultSet resultSet = client.query("CREATE (n {val:$val}) RETURN n.val", params);

--- a/src/test/java/com/falkordb/impl/api/GraphExplainBuilderUnitTest.java
+++ b/src/test/java/com/falkordb/impl/api/GraphExplainBuilderUnitTest.java
@@ -2,6 +2,7 @@ package com.falkordb.impl.api;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -66,7 +67,7 @@ public class GraphExplainBuilderUnitTest {
     @Test
     public void testExplainBuilderWithSingleItemResponse() {
         // Test Builder logic with single item response
-        List<Object> singleItemResponse = Arrays.asList(SafeEncoder.encode("Single result"));
+        List<Object> singleItemResponse = Collections.<Object>singletonList(SafeEncoder.encode("Single result"));
 
         List<String> result = buildExplainResponse(singleItemResponse);
 

--- a/src/test/java/com/falkordb/impl/api/GraphExplainUnitTest.java
+++ b/src/test/java/com/falkordb/impl/api/GraphExplainUnitTest.java
@@ -4,6 +4,7 @@ import com.falkordb.ResultSet;
 import com.falkordb.impl.Utils;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -158,7 +159,7 @@ public class GraphExplainUnitTest {
         Map<String, Object> params = new HashMap<>();
         params.put("name", "John \"The Rock\" Doe");
 
-        List<Object> mockResponse = Arrays.asList(SafeEncoder.encode("Results"));
+        List<Object> mockResponse = Collections.<Object>singletonList(SafeEncoder.encode("Results"));
         testGraph.setMockExplainResponse(mockResponse);
 
         List<String> result = testGraph.explain(query, params);


### PR DESCRIPTION
## Wave 3 · PR 9 — Quality gates (SpotBugs/FindSecBugs + Error Prone + OWASP; retire DeepSource)

Second implementation PR of the approved **Wave 3** plan (#316). Adds high-signal, locally-reproducible static-analysis gates. Everything Java-11+ stays in the **off-by-default `quality` profile**, so the shipped **Java-8 artifact and the default `just verify`/deploy lifecycle are untouched** (Enforcer bytecode + Animal Sniffer + `smoke-jdk8` still pass).

### What changed
- **SpotBugs + FindSecBugs** (`spotbugs-maven-plugin` + `findsecbugs-plugin`): `effort=Max`, `threshold=Medium` (so FindSecBugs security detectors actually fire), `check` bound to `verify` in-profile. The well-known-noisy `EI_EXPOSE_REP`/`EI_EXPOSE_REP2` defensive-copy pattern is excluded (documented in `spotbugs-exclude.xml`).
- **Error Prone** (`error_prone_core`): via `annotationProcessorPaths` + forked compiler + the JDK-16+ `--add-exports/--add-opens jdk.compiler/...` args, all inside the `quality` profile so `--release 8` is unaffected.
- **OWASP dependency-check** (unbound plugin; `failBuildOnCVSS=7`, `skipProvided/skipTestScope`, NVD key via `NVD_API_KEY` env). Runs on demand, not on every PR.
- **`just` recipes**: `just lint` (Spotless-check + SpotBugs/FindSecBugs + Error Prone) and `just audit` (OWASP). New **`lint`** job in `maven.yml`; new **`.github/workflows/audit.yml`** (weekly `schedule` + `workflow_dispatch`, caches the NVD data dir).
- **Retire DeepSource** (D4b): delete `.deepsource.toml`; document the in-build gates in `.github/copilot-instructions.md` + `CONTRIBUTING.md`.

### Findings the tools surfaced (all fixed)
- **SpotBugs (High):** `Utils.DUMMY_LIST`/`DUMMY_MAP` were public mutable statics → `Collections.emptyList()/emptyMap()`; `GraphCacheList` synchronized on its `CopyOnWriteArrayList` → now a private lock; `ResultSetImpl` made `final` (`CT_CONSTRUCTOR_THROW`).
- **Error Prone:** a **real bug** — `test64bitnumber` used `1 << 40` (int shift = 256) → `1L << 40`; two `Arrays.asList(SafeEncoder.encode(...))` primitive-array footguns → `Collections.<Object>singletonList(...)`.

### Validation
`just lint` green; `just verify` green against the pinned FalkorDB (157 unit + full IT suite, Enforcer bytecode + Animal Sniffer pass); `just fmt-check` + `just spellcheck` green; OWASP plugin (12.2.2) resolves (full NVD scan runs in the `audit` workflow with the key). Rubber-duck reviewed (findings folded in: OWASP version bump 11→12.2.2, `just lint` uses `clean` so Error Prone always runs, NVD key via env-var not CLI, threshold lowered to Medium).

### Operational follow-ups (admin, not code)
- Add the new **`lint`** status check to `master` branch protection (after it first runs on `master`).
- Add the **`NVD_API_KEY`** repo secret and **disable the external DeepSource app** now that the in-build gate replaces it.

Not self-merging — for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added CI linting for formatting, compile-time checks, and static analysis.
  - Added scheduled and on-demand dependency vulnerability audits.
  - Documented new local `lint`/`audit` workflows.

- **Bug Fixes**
  - Improved cache refresh synchronization to reduce concurrency risks.
  - Made default empty collections immutable.
  - Hardened a result set implementation to prevent subclassing.

- **Tests**
  - Updated explain-related tests to use immutable singleton lists.
  - Fixed 64-bit numeric handling in an integration test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->