### PR TITLE
ci: add PR-title lint + japicmp public-API diff gates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,7 +23,7 @@ recipe; recipes call the pinned Maven Wrapper (`./mvnw`).
 | `just fmt` / `just fmt-check` | Apply / check palantir-java-format (runs in the `-Pquality` profile). |
 | `just lint` | Static analysis (the CI `lint` gate): format check + **SpotBugs/FindSecBugs** + **Error Prone**, all in the off-by-default `-Pquality` profile. |
 | `just audit` | OWASP dependency-check CVE scan of the shipped deps. Slow + needs `NVD_API_KEY`; run by the scheduled/manual **`audit`** workflow, not on every PR. |
-| `just api-diff` | Public-API compatibility diff vs the last release on Maven Central (japicmp, the CI **`api-diff`** gate): fails on binary/source-incompatible changes to the public API (`com.falkordb.impl` excluded), in the off-by-default `-Pquality` profile. Approve a reviewed break with the `breaking-change` PR label. |
+| `just api-diff` | Public-API compatibility diff vs the last release on Maven Central (japicmp, the CI **`api-diff`** gate): fails on binary/source-incompatible changes to the public/protected API (`com.falkordb.impl` excluded), in the off-by-default `-Pquality` profile. Approve a reviewed break with the `breaking-change` PR label. |
 | `just spellcheck` | Spellcheck the Markdown docs (the CI `spellcheck` gate). |
 | `just db-up` / `just db-down` | Manage a local FalkorDB container. |
 | `just bench` / `just bench-one <loads>` | Client load-sweep benchmark — client latency (total − server) vs throughput across concurrency levels; feeds the per-PR-vs-`master` radar + Pages curve. |
@@ -68,9 +68,10 @@ accordingly, and use the `TestServer` helper for server access.
   separate explicit gate off the aggregate lifecycle (`just lint` / `just audit` / `just api-diff`).
   Static analysis is in-build and reproducible; there is no external DeepSource integration.
 - The **`api-diff`** gate (japicmp, `just api-diff`) is a **PR-only** check that diffs the built jar
-  against the last release on Maven Central and fails on public-API breaks (`com.falkordb.impl` is
-  internal and excluded); approve a reviewed, intentional break with the `breaking-change` PR label.
-  A user-facing break is at least a **minor** bump (the project is pre-1.0).
+  against the last release on Maven Central and fails on public/protected-API breaks
+  (`com.falkordb.impl` is internal and excluded); approve a reviewed, intentional break with the
+  `breaking-change` PR label. A user-facing break is at least a **minor** bump (the project is
+  pre-1.0).
 
 ## Releasing
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,6 +23,7 @@ recipe; recipes call the pinned Maven Wrapper (`./mvnw`).
 | `just fmt` / `just fmt-check` | Apply / check palantir-java-format (runs in the `-Pquality` profile). |
 | `just lint` | Static analysis (the CI `lint` gate): format check + **SpotBugs/FindSecBugs** + **Error Prone**, all in the off-by-default `-Pquality` profile. |
 | `just audit` | OWASP dependency-check CVE scan of the shipped deps. Slow + needs `NVD_API_KEY`; run by the scheduled/manual **`audit`** workflow, not on every PR. |
+| `just api-diff` | Public-API compatibility diff vs the last release on Maven Central (japicmp, the CI **`api-diff`** gate): fails on binary/source-incompatible changes to the public API (`com.falkordb.impl` excluded), in the off-by-default `-Pquality` profile. Approve a reviewed break with the `breaking-change` PR label. |
 | `just spellcheck` | Spellcheck the Markdown docs (the CI `spellcheck` gate). |
 | `just db-up` / `just db-down` | Manage a local FalkorDB container. |
 | `just bench` / `just bench-one <loads>` | Client load-sweep benchmark — client latency (total − server) vs throughput across concurrency levels; feeds the per-PR-vs-`master` radar + Pages curve. |
@@ -40,7 +41,8 @@ accordingly, and use the `TestServer` helper for server access.
 3. **Validate locally via `just`** — `just verify` (or `just verify-local`) green, and **`just
    spellcheck`** whenever you touch Markdown (new technical terms go in `.github/wordlist.txt`).
 4. Open a PR on a **Conventional-Commit** branch (`feat:` / `fix:` / `build:` / `docs:` / `ci:` /
-   `chore:`); the PR **title** must be a Conventional Commit.
+   `chore:` / `bench:`); the PR **title** must be a Conventional Commit (enforced by the **`PR
+   title`** check).
 5. **Resolve every AI review thread** — Copilot **and** CodeRabbit — reply *and* mark resolved —
    before merge.
 6. **Never self-merge to `master`.** Open the PR, get it green, and wait for a maintainer to approve
@@ -62,13 +64,18 @@ accordingly, and use the `TestServer` helper for server access.
   semver-major bumps). The JDK-21 build *could* now compile their 6.x/4.x, but raising them is a
   deliberate later change, not automatic — so keep the pins for now.
 - Any Java-11+ tool (e.g. Spotless / palantir-java-format, SpotBugs/FindSecBugs, Error Prone, OWASP
-  dependency-check) still lives in the **off-by-default `quality` Maven profile**, kept as a separate
-  explicit gate off the aggregate lifecycle (`just lint` / `just audit`). Static analysis is in-build
-  and reproducible; there is no external DeepSource integration.
+  dependency-check, japicmp) still lives in the **off-by-default `quality` Maven profile**, kept as a
+  separate explicit gate off the aggregate lifecycle (`just lint` / `just audit` / `just api-diff`).
+  Static analysis is in-build and reproducible; there is no external DeepSource integration.
+- The **`api-diff`** gate (japicmp, `just api-diff`) is a **PR-only** check that diffs the built jar
+  against the last release on Maven Central and fails on public-API breaks (`com.falkordb.impl` is
+  internal and excluded); approve a reviewed, intentional break with the `breaking-change` PR label.
+  A user-facing break is at least a **minor** bump (the project is pre-1.0).
 
 ## Releasing
 
 Cut a release by publishing a **GitHub Release tagged `vX.Y.Z`** on `master` (`version-and-release.yml`
 derives the version from the tag and deploys to Maven Central with `autoPublish`). Afterward, bump the
-pom to the next `-SNAPSHOT`. Use semver — a user-facing behavior change is at least a **minor** bump
-(the project is pre-1.0).
+pom to the next `-SNAPSHOT`, and bump the `api.diff.baseline` property to the just-released version so
+the **`api-diff`** gate compares against the new release (a later Wave-3 release PR automates this).
+Use semver — a user-facing behavior change is at least a **minor** bump (the project is pre-1.0).

--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -20,3 +20,4 @@ PRs
 JMH
 encodable
 untrusted
+japicmp

--- a/.github/workflows/api-diff.yml
+++ b/.github/workflows/api-diff.yml
@@ -1,0 +1,45 @@
+name: API diff
+
+# PR-only public-API compatibility gate (japicmp): fails on binary/source-incompatible changes to the
+# published API vs the last release on Maven Central. A reviewed, intentional break is approved by
+# adding the `breaking-change` label to the PR — hence the `labeled`/`unlabeled` triggers, so
+# adding/removing the label re-runs the gate without needing a new commit. This lives in its own
+# workflow (not a `Java CI with Maven` job) so label toggles don't needlessly re-run the whole
+# build/test matrix. Runs only on PRs: a reviewed break is approved per-PR via the label, so the
+# post-merge master push (which has no PR label) would re-flag an already approved break; direct
+# pushes to master are disallowed, so PR coverage is sufficient.
+
+on:
+  pull_request:
+    branches: [ "master" ]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+concurrency:
+  group: api-diff-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  api-diff:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
+    - name: Set up JDK 21
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+    - name: Install just
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+    - name: Public-API compatibility diff vs the last release (via just)
+      # Fails on binary/source-incompatible PUBLIC/PROTECTED-API changes vs the last release on Maven
+      # Central. Approve a reviewed, intentional break by adding the `breaking-change` label to the PR,
+      # which flips the japicmp gate to non-failing for this run.
+      run: just api-diff ${{ contains(github.event.pull_request.labels.*.name, 'breaking-change') && '-Dapi.diff.fail=false' || '' }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,45 @@
+name: PR title
+
+# Enforces a Conventional-Commit PR title so squash-merge subjects stay conventional and feed the
+# (Wave 3) release automation. NOTE: this only constrains history when the repository is set to
+# squash-only merges with the squash commit title taken from the PR title
+# (Settings → General → Pull Requests: "Allow squash merging" only, default message = "Pull request
+# title"). That is an admin/repo setting a workflow cannot set itself.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  lint-title:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check the PR title is a Conventional Commit
+      uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        # Allowed types. Includes the repo's own `bench:` and the release-automation types
+        # (`release`, and `chore` for release-please's `chore(main): release …` PRs).
+        types: |
+          feat
+          fix
+          build
+          chore
+          ci
+          docs
+          perf
+          refactor
+          style
+          test
+          bench
+          release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ just fmt            # apply palantir-java-format
 just fmt-check      # check formatting
 just lint           # static analysis: format check + SpotBugs/FindSecBugs + Error Prone (-Pquality)
 just audit          # OWASP dependency-check CVE scan (slow; needs NVD_API_KEY; run by the audit workflow)
+just api-diff       # public-API compatibility diff vs the last release (japicmp; the CI api-diff gate)
 just db-up          # start a local FalkorDB container
 just db-down        # stop it
 just bench          # client load-sweep benchmark (client latency vs throughput; feeds the radar)
@@ -41,7 +42,7 @@ just bench          # client load-sweep benchmark (client latency vs throughput;
 
 - Run `just verify-local` and keep documentation in sync with your change.
 - Use a **Conventional-Commit** branch and PR title (`feat:`, `fix:`, `build:`, `docs:`, `ci:`,
-  `chore:`).
+  `chore:`, `bench:`); the PR title is checked by the **`PR title`** workflow.
 - After opening the PR, **resolve every Copilot and CodeRabbit review thread** (reply + mark
   resolved).
 - **Don't merge to `master` yourself** — a maintainer reviews and merges.

--- a/Justfile
+++ b/Justfile
@@ -34,6 +34,14 @@ lint:
 audit:
     ./mvnw -B -Pquality -DskipTests -Dgpg.skip=true org.owasp:dependency-check-maven:check
 
+# Public-API compatibility diff (japicmp): package the jar, then compare it against the last release
+# on Maven Central and fail on binary/source-incompatible PUBLIC-API changes (`com.falkordb.impl` is
+# internal and excluded). This is the CI `api-diff` gate. A reviewed, intentional break is approved
+# with `just api-diff -Dapi.diff.fail=false` (the CI job passes this when the PR carries the
+# `breaking-change` label). Not part of `verify`.
+api-diff *ARGS:
+    ./mvnw -B -Pquality -DskipTests -Dgpg.skip=true package com.github.siom79.japicmp:japicmp-maven-plugin:cmp {{ARGS}}
+
 # Spellcheck the Markdown docs (CI gate). Needs `pyspelling` + `aspell` (see CONTRIBUTING.md).
 spellcheck:
     pyspelling -c .github/spellcheck-settings.yml -n Markdown

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,14 @@
 
 	<properties>
 		<maven.compiler.release>8</maven.compiler.release>
+		<!-- API-diff gate (japicmp, `-Pquality`). `api.diff.baseline` is the last PUBLISHED release the
+		     public API is compared against — it must be bumped to the new version as part of releasing
+		     (a later Wave-3 release PR automates this). `api.diff.fail` fails the build on public-API
+		     breaks by default; a reviewed, intentional break is approved by overriding it to false (the
+		     CI `api-diff` job sets -Dapi.diff.fail=false when the PR carries the `breaking-change`
+		     label). -->
+		<api.diff.baseline>0.9.0</api.diff.baseline>
+		<api.diff.fail>true</api.diff.fail>
 	</properties>
 
 	<dependencies>
@@ -375,6 +383,47 @@
 							<suppressionFiles>
 								<suppressionFile>owasp-suppressions.xml</suppressionFile>
 							</suppressionFiles>
+						</configuration>
+					</plugin>
+					<!-- japicmp: public-API compatibility diff of the freshly built jar against the last
+					     release on Maven Central (`api.diff.baseline`). Unbound (like OWASP above) —
+					     invoked on demand via `just api-diff` (the dedicated `api-diff` workflow), never
+					     in `verify`/`deploy`. Fails on binary- OR source-incompatible changes to the
+					     PUBLIC/PROTECTED API only (`com.falkordb.impl` and its subpackages are internal
+					     and excluded; `accessModifier=protected` also guards the protected subclassing
+					     surface of the public value classes). A reviewed, intentional break is approved
+					     by overriding -Dapi.diff.fail=false. Fails loudly when the baseline can't be
+					     resolved (ignoreMissingOldVersion=false). -->
+					<plugin>
+						<groupId>com.github.siom79.japicmp</groupId>
+						<artifactId>japicmp-maven-plugin</artifactId>
+						<version>0.26.1</version>
+						<configuration>
+							<oldVersion>
+								<dependency>
+									<groupId>com.falkordb</groupId>
+									<artifactId>jfalkordb</artifactId>
+									<version>${api.diff.baseline}</version>
+									<type>jar</type>
+								</dependency>
+							</oldVersion>
+							<newVersion>
+								<file>
+									<path>${project.build.directory}/${project.build.finalName}.jar</path>
+								</file>
+							</newVersion>
+							<parameter>
+								<onlyModified>true</onlyModified>
+								<accessModifier>protected</accessModifier>
+								<breakBuildOnBinaryIncompatibleModifications>${api.diff.fail}</breakBuildOnBinaryIncompatibleModifications>
+								<breakBuildOnSourceIncompatibleModifications>${api.diff.fail}</breakBuildOnSourceIncompatibleModifications>
+								<ignoreMissingOldVersion>false</ignoreMissingOldVersion>
+								<ignoreMissingNewVersion>false</ignoreMissingNewVersion>
+								<excludes>
+									<exclude>com.falkordb.impl</exclude>
+								</excludes>
+								<skipXmlReport>true</skipXmlReport>
+							</parameter>
 						</configuration>
 					</plugin>
 				</plugins>


### PR DESCRIPTION
## Wave 3 — PR 10a: PR-title gate + public-API diff gate

Adds the two release-readiness gates from the approved Wave 3 plan. Both are **off the default
lifecycle**, so the Java-8 artifact and `just verify` are untouched.

### 1. PR-title lint — `.github/workflows/pr-title.yml`
`amannn/action-semantic-pull-request` (pinned `48f2562…` = v6.1.1) enforces a **Conventional-Commit
PR title** on `pull_request` [opened, edited, reopened, synchronize], `permissions: pull-requests:
read`. Allowed types: `feat fix build chore ci docs perf refactor style test bench release`.

### 2. API-diff gate — japicmp
Compares the freshly built jar against the **last release** (`api.diff.baseline`, currently `0.9.0`)
on Maven Central and **fails on binary/source-incompatible public/protected API changes**.
`com.falkordb.impl` and its subpackages are internal and excluded.

- `pom.xml`: `japicmp-maven-plugin` 0.26.1 added **unbound** to the off-by-default `-Pquality` profile
  (like OWASP). `accessModifier=protected` (guards the protected subclassing surface of the public
  value classes, e.g. `GraphEntity`), `ignoreMissingOldVersion=false` (fail loud if the baseline can't
  be resolved). Baseline + fail-toggle are properties (`api.diff.baseline`, `api.diff.fail`).
- `Justfile`: `just api-diff` recipe.
- `.github/workflows/api-diff.yml`: **PR-only** dedicated workflow, triggers include
  `labeled`/`unlabeled`. A reviewed, intentional break is approved by adding the **`breaking-change`**
  label, which flips the gate to non-failing (`-Dapi.diff.fail=false`) — label add/remove re-runs the
  gate without a new commit.

### Verified locally (JDK 21)
- `just api-diff` vs real `0.9.0`: green ("No changes") — master's public/protected API is compatible.
- Proved the `com.falkordb.impl` exclude covers **all subpackages** and that the gate genuinely
  enforces: temporarily made an internal `impl.graph_cache` class `final` (binary-incompatible) →
  green **with** the exclude, and **without** it japicmp correctly failed flagging both that class and
  a real internal `impl.resultset` change. Reverted.
- `just fmt-check`, `just build` (default lifecycle, quality off), `just spellcheck`: green. YAML valid.

### ⚠️ Operational follow-ups (admin/repo settings — a workflow can't set these)
The gates only fully bind once these are applied:
1. **Squash-only + title from PR:** repo currently allows **rebase** merges and squash title is
   `COMMIT_OR_PR_TITLE`. Set **squash commit title = `PR_TITLE`** and **disable rebase merging** so the
   PR-title check actually constrains master history.
2. **Required checks:** master branch protection currently requires only `build`, `format`,
   `smoke-jdk8`. Add **`pr-title`**, **`api-diff`**, and **`lint`** (the last is a missed follow-up
   from PR 9). Consider enabling **enforce admins**.

### Known limitation (by design; automated later)
`api.diff.baseline` is a fixed release version. It must be **bumped to each new release** as part of
releasing (documented in `copilot-instructions.md` → Releasing) — a later Wave-3 release PR (10b/10c)
will automate this. Until bumped, an approved+merged breaking change would make the gate fail for
subsequent unrelated PRs, so bump the baseline promptly on release.

Part of Wave 3. Next: **PR 10b** (release safeguards) → **PR 10c** (release-please).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks for public API compatibility on pull requests.
  * Added pull request title validation using Conventional Commits.
  * Added a command for locally comparing API compatibility with the latest release.

* **Documentation**
  * Updated contributor and AI guidance with API compatibility, pull request labeling, and release instructions.
  * Added terminology for API compatibility tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->