### PR TITLE
ci: harden release + snapshot publish workflows

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -7,8 +7,42 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Guard: only publish when the POM is a -SNAPSHOT. A release-version commit on a deploy branch
+  # (e.g. the release-please PR that bumps the POM to the release version) must NOT trigger an
+  # unsigned/duplicate snapshot deploy — this job gates the deploy below on `is_snapshot`.
+  check-version:
+    name: Check version is -SNAPSHOT
+    runs-on: ubuntu-latest
+    outputs:
+      is_snapshot: ${{ steps.check.outputs.is_snapshot }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - name: Set up JDK 21
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+      - name: Install just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+      - name: Read project.version and check for -SNAPSHOT
+        id: check
+        run: |
+          version="$(just project-version)"
+          echo "project.version = $version"
+          if [[ "$version" == *-SNAPSHOT ]]; then
+            echo "is_snapshot=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_snapshot=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping snapshot deploy: project.version '$version' is not a -SNAPSHOT."
+          fi
+
   snapshot:
     name: Deploy Snapshot
+    needs: check-version
+    if: needs.check-version.outputs.is_snapshot == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -36,12 +36,14 @@ jobs:
         id: check
         run: |
           version="$(just project-version)"
-          echo "project.version = $version"
+          # %q escapes the value to a single line so a stray newline can't inject `::workflow::`
+          # commands into the log stream.
+          printf 'project.version = %q\n' "$version"
           if [[ "$version" == *-SNAPSHOT ]]; then
             echo "is_snapshot=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_snapshot=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping snapshot deploy: project.version '$version' is not a -SNAPSHOT."
+            printf '::notice::Skipping snapshot deploy: project.version %q is not a -SNAPSHOT.\n' "$version"
           fi
 
   snapshot:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -6,6 +6,11 @@ on:
       - '[0-9].x'
   workflow_dispatch:
 
+# Least privilege: the deploy authenticates to Maven Central with its own secrets (not the
+# GITHUB_TOKEN) and only needs to read the repository.
+permissions:
+  contents: read
+
 jobs:
   # Guard: only publish when the POM is a -SNAPSHOT. A release-version commit on a deploy branch
   # (e.g. the release-please PR that bumps the POM to the release version) must NOT trigger an

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -3,32 +3,63 @@ name: Release
 on:
   release:
     types: [published]
+  # Manual re-run / recovery path: deploy a specific already-published tag. Needed because gating a
+  # deploy only on `release: published` can't be retried (and a bot-created release under the default
+  # GITHUB_TOKEN doesn't emit that event at all).
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to (re)deploy, e.g. v0.10.0'
+        required: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
-    # Service containers to run with `test-job`
-    services:
-      # Label used to access the service container
-      falkordb:
-        # Docker Hub image
-        image: falkordb/falkordb:edge
-        # Map port 6379 on the Docker host to port 6379 on the FalkorDB container
-        ports:
-          - 6379:6379
+    # No FalkorDB service container on purpose: the deploy skips tests (`just deploy-release`), since
+    # the required PR CI already validated the commit against the pinned FalkorDB digest — so the
+    # release must not re-run *IT against a moving image.
 
     steps:
+      - name: Resolve the release tag, version, and ref
+        id: release
+        # Prefer the workflow_dispatch input; otherwise use the release event's tag. Values pass via
+        # env (never inlined into the script) to avoid injection, and the tag is strictly validated so
+        # the derived `version` is safe to hand to Maven.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_SHA: ${{ github.sha }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            tag="$INPUT_TAG"
+            # Manual recovery: deploy the commit this tag currently points at (fully-qualified ref so
+            # a like-named branch can't shadow the tag).
+            ref="refs/tags/$tag"
+          else
+            tag="$RELEASE_TAG"
+            # Automatic release: pin to the exact commit the release points at, immune to a moved tag.
+            ref="$RELEASE_SHA"
+          fi
+          if ! printf '%s' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+            echo "::error::Refusing to deploy: '$tag' is not a valid vX.Y.Z release tag." >&2
+            exit 1
+          fi
+          version="${tag#v}"
+          {
+            echo "tag=$tag"
+            echo "version=$version"
+            echo "ref=$ref"
+          } >> "$GITHUB_OUTPUT"
+          echo "Releasing tag '$tag' (ref '$ref') as version '$version'"
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          # Check out the resolved commit/tag so a release deploys its exact commit and a
+          # workflow_dispatch re-run deploys the requested tag, not the default branch.
+          ref: ${{ steps.release.outputs.ref }}
           persist-credentials: false
-
-      - name: Get version from tag
-        id: get_version
-        run: |
-          realversion="${GITHUB_REF/refs\/tags\//}"
-          realversion="${realversion//v/}"
-          echo "VERSION=$realversion" >> $GITHUB_OUTPUT
 
       - name: Set up JDK 21 for publishing to Maven Central
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
@@ -46,7 +77,7 @@ jobs:
       - name: Update version in POM
         run: just set-version "$VERSION"
         env:
-          VERSION: ${{ steps.get_version.outputs.VERSION }}
+          VERSION: ${{ steps.release.outputs.version }}
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -12,6 +12,11 @@ on:
         description: 'Release tag to (re)deploy, e.g. v0.10.0'
         required: true
 
+# Least privilege: the deploy authenticates to Maven Central with its own secrets (not the
+# GITHUB_TOKEN) and only needs to read the repository.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -42,7 +47,7 @@ jobs:
             # Automatic release: pin to the exact commit the release points at, immune to a moved tag.
             ref="$RELEASE_SHA"
           fi
-          if ! printf '%s' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
             echo "::error::Refusing to deploy: '$tag' is not a valid vX.Y.Z release tag." >&2
             exit 1
           fi

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -48,7 +48,8 @@ jobs:
             ref="$RELEASE_SHA"
           fi
           if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
-            echo "::error::Refusing to deploy: '$tag' is not a valid vX.Y.Z release tag." >&2
+            # %q escapes the untrusted tag to a single line so it can't inject `::workflow::` commands.
+            printf '::error::Refusing to deploy: %q is not a valid vX.Y.Z release tag.\n' "$tag" >&2
             exit 1
           fi
           version="${tag#v}"

--- a/Justfile
+++ b/Justfile
@@ -104,9 +104,10 @@ bench-baseline:
 fetch-deps:
     ./mvnw -B -q dependency:go-offline
 
-# Set the project version (release workflow, from the git tag).
+# Set the project version (release workflow, from the git tag). `quote(...)` shell-escapes the value
+# so it is always passed to Maven as a single literal argument (defense-in-depth for any caller).
 set-version version:
-    ./mvnw -B versions:set -DnewVersion={{version}} -DgenerateBackupPoms=false
+    ./mvnw -B versions:set -DnewVersion={{ quote(version) }} -DgenerateBackupPoms=false
 
 # Print the resolved project version (used by the snapshot-publish -SNAPSHOT guard in CI). The
 # `-q -DforceStdout` form yields an [INFO]-free, parseable single line.

--- a/Justfile
+++ b/Justfile
@@ -108,13 +108,21 @@ fetch-deps:
 set-version version:
     ./mvnw -B versions:set -DnewVersion={{version}} -DgenerateBackupPoms=false
 
+# Print the resolved project version (used by the snapshot-publish -SNAPSHOT guard in CI). The
+# `-q -DforceStdout` form yields an [INFO]-free, parseable single line.
+project-version:
+    @./mvnw -q -DforceStdout help:evaluate -Dexpression=project.version
+
 # Deploy a -SNAPSHOT to Maven Central (no signing, no tests).
 deploy-snapshot:
     ./mvnw -B -DskipTests -Dgpg.skip=true deploy
 
-# Build, sign, test, and deploy a release to Maven Central.
+# Build, sign, and deploy a release to Maven Central. Skips tests on purpose: the required PR CI
+# already validated the commit (Testcontainers *IT on the pinned FalkorDB digest), so the deploy
+# must not re-run tests against a moving image. The Java-8 guardrails (enforcer + animal-sniffer)
+# still run, and there is no JaCoCo coverage `check` to trip on the missing test data.
 deploy-release:
-    ./mvnw -B --no-transfer-progress clean deploy
+    ./mvnw -B --no-transfer-progress -Dmaven.test.skip=true clean deploy
 
 # --- Dockerized FalkorDB for local runs (readiness-probed) ---
 


### PR DESCRIPTION
## Wave 3 — PR 10b: release-workflow safeguards

Hardens the two Maven Central publish workflows (per the approved Wave 3 plan). No changes to the
default build/`just verify`.

### 1. Snapshot guard — `snapshot.yml`
New `check-version` job reads the POM version (`just project-version`) and only runs **Deploy
Snapshot** when it ends in `-SNAPSHOT` (`needs` + `if` gate). A release-version commit on a deploy
branch — e.g. a future **release-please** PR that bumps the POM to the release version — therefore
**can't trigger an unsigned/duplicate snapshot publish**; the deploy job is skipped (green), not run.

### 2. Deterministic release deploy — `version-and-release.yml`
- **`workflow_dispatch(tag)`** added as a **retriable recovery path** (a deploy gated only on
  `release: published` can't be re-run; a bot-created release under the default `GITHUB_TOKEN` emits
  no event at all).
- **Immutable checkout:** release events check out **`github.sha`** (the exact released commit, immune
  to a moved tag); dispatch checks out **`refs/tags/<tag>`** (a like-named branch can't shadow it).
- **Strict tag validation** (`^v[0-9]+\.[0-9]+\.[0-9]+(-…)?$`) — rejects malformed tags and closes any
  shell-injection path into `just set-version`; context values pass via `env:`, never inlined.
- **Dropped the `services: falkordb` (moving `edge` image)** container — the deploy skips tests.

### 3. Skip tests on deploy — `just deploy-release`
`-Dmaven.test.skip=true`: the required PR CI already validated the commit against the **pinned**
FalkorDB digest, so the deploy must not re-run `*IT` against a moving image. Also added a
`just project-version` recipe (keeps the snapshot guard on the `just = CI` rule).

### Verified locally (JDK 21)
- `./mvnw -B -Dmaven.test.skip=true -Dgpg.skip=true clean verify` → **BUILD SUCCESS**: enforcer
  `enforce-bytecode-8` ✅ and animal-sniffer `check-java8-api` ✅ (Java-8 guardrails intact), JaCoCo
  `report` degrades gracefully (no coverage `check` exists), and the **main + `-sources` + `-javadoc`
  jars all build** (required for Central).
- `just project-version` → `0.10.0-SNAPSHOT`. Tag regex accepts `vX.Y.Z`/`-rc1`, rejects `0.10.0`,
  `v1.2`, and injection attempts (`;touch…`, `&& id`, `$(whoami)`). Both YAMLs parse.

### Rubber-duck fixes folded in
Pinned the release checkout to `github.sha` (was a bare tag ref → moved-tag risk), added strict tag
validation (closed the `{{version}}` injection surface), and routed the guard through
`just project-version` (the `just = CI` rule).

### Not in scope (→ PR 10c)
The **App/PAT** for release-please (so its bot-created release/PRs trigger CI and the required checks
aren't absent) is coupled to the release-please setup and lands in **PR 10c**, which also bumps
`api.diff.baseline` automatically on release.

Part of Wave 3. Follows merged PR 10a (#319). Next: **PR 10c** (enable release-please).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual redeploy option for already-published releases by supplying a version tag.
  * Release workflows now resolve the exact deploy target (tag/ref) and validate tag format before deploying.

* **Bug Fixes**
  * Snapshot deployment is now blocked unless the project version ends with `-SNAPSHOT`.
  * Release deployments now skip tests to avoid unnecessary test execution.

* **Chores**
  * Improved release/version resolution and Maven version handling for more reliable version updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->