### PR TITLE
build(deps): combined Dependabot bumps (testcontainers 2, Error Prone 2.50, SpotBugs, FindSecBugs, jqwik)

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.21.3</version>
+            <version>2.0.5</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -104,13 +104,13 @@
 		<dependency>
 			<groupId>net.jqwik</groupId>
 			<artifactId>jqwik</artifactId>
-			<version>1.9.3</version>
+			<version>1.10.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>testcontainers</artifactId>
-			<version>1.21.3</version>
+			<version>2.0.5</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -303,6 +303,8 @@
 							<fork>true</fork>
 							<compilerArgs>
 								<arg>-XDcompilePolicy=simple</arg>
+								<!-- Required by Error Prone on JDK 16+ (enforced since EP 2.4x). -->
+								<arg>-XDaddTypeAnnotationsToSymbol=true</arg>
 								<arg>--should-stop=ifError=FLOW</arg>
 								<arg>-Xplugin:ErrorProne</arg>
 								<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
@@ -320,7 +322,7 @@
 								<path>
 									<groupId>com.google.errorprone</groupId>
 									<artifactId>error_prone_core</artifactId>
-									<version>2.36.0</version>
+									<version>2.50.0</version>
 								</path>
 							</annotationProcessorPaths>
 						</configuration>
@@ -344,7 +346,7 @@
 					<plugin>
 						<groupId>com.github.spotbugs</groupId>
 						<artifactId>spotbugs-maven-plugin</artifactId>
-						<version>4.8.6.6</version>
+						<version>4.10.3.0</version>
 						<configuration>
 							<effort>Max</effort>
 							<threshold>Medium</threshold>
@@ -354,7 +356,7 @@
 								<plugin>
 									<groupId>com.h3xstream.findsecbugs</groupId>
 									<artifactId>findsecbugs-plugin</artifactId>
-									<version>1.13.0</version>
+									<version>1.14.0</version>
 								</plugin>
 							</plugins>
 						</configuration>


### PR DESCRIPTION
## Combined Dependabot bumps

Consolidates the open Dependabot bump PRs (**#320–#324**) into one green PR.

| Dependency | From | To | Notes |
| --- | --- | --- | --- |
| `org.testcontainers:testcontainers` | 1.21.3 | **2.0.5** | major; test-compiles cleanly against our `*IT`/TestServer usage |
| `com.google.errorprone:error_prone_core` | 2.36.0 | **2.50.0** | needs a compiler flag (below) |
| `com.github.spotbugs:spotbugs-maven-plugin` | 4.8.6.6 | **4.10.3.0** | no new failing findings |
| `com.h3xstream.findsecbugs:findsecbugs-plugin` | 1.13.0 | **1.14.0** | no new failing findings |
| `net.jqwik:jqwik` | 1.9.3 | **1.10.1** | property tests pass |

### Error Prone 2.50 fix
EP 2.50 requires `-XDaddTypeAnnotationsToSymbol=true` on JDK 16+, or the `-Pquality`
compile fails at plugin init (`InvalidCommandLineOptionException`). Added it to the Error Prone
`compilerArgs` (this was the sole cause of the `lint`/`api-diff` failures on the standalone #323).

### Verified locally (JDK 21)
`just lint` (SpotBugs 4.10 + FindSecBugs 1.14 + Error Prone 2.50 + **test-compile against
testcontainers 2.x**), `just test` (157 unit tests incl. jqwik property tests), `just fmt-check`,
`just api-diff` — all green. The server-backed `*IT` (testcontainers 2.x) runs in CI (`build` +
`smoke-jdk8`).

Supersedes #320, #321, #322, #323, #324 (to be closed).
