### PR TITLE
fix: make Point equals/hashCode a consistent, drift-tolerant contract

### DIFF
--- a/src/main/java/com/falkordb/graph_entities/Point.java
+++ b/src/main/java/com/falkordb/graph_entities/Point.java
@@ -8,10 +8,18 @@ import java.util.Objects;
  */
 public final class Point {
 
-    private static final double EPSILON = 1e-5;
+    // FalkorDB stores point coordinates in single precision, so a round-tripped coordinate can differ
+    // from the original by up to ~1e-5. Coordinates are therefore compared on a 1e-5 grid: this keeps
+    // equals reflexive/symmetric/**transitive** and consistent with hashCode — unlike a raw epsilon
+    // "within tolerance" check, which is non-transitive and can't have a matching hashCode.
+    private static final double GRID = 1e-5;
 
     private final double latitude;
     private final double longitude;
+
+    private static long cell(double coordinate) {
+        return Math.round(coordinate / GRID);
+    }
 
     /**
      * @param latitude The latitude in degrees. It must be in the range [-90.0, +90.0]
@@ -58,12 +66,12 @@ public final class Point {
             return false;
         }
         Point o = (Point) other;
-        return Math.abs(latitude - o.latitude) < EPSILON && Math.abs(longitude - o.longitude) < EPSILON;
+        return cell(latitude) == cell(o.latitude) && cell(longitude) == cell(o.longitude);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(latitude, longitude);
+        return Objects.hash(cell(latitude), cell(longitude));
     }
 
     @Override

--- a/src/main/java/com/falkordb/graph_entities/Point.java
+++ b/src/main/java/com/falkordb/graph_entities/Point.java
@@ -10,35 +10,46 @@ public final class Point {
 
     // FalkorDB stores point coordinates in single precision, so a round-tripped coordinate can differ
     // from the original by up to ~1e-5. Coordinates are therefore compared on a 1e-5 grid: this keeps
-    // equals reflexive/symmetric/**transitive** and consistent with hashCode — unlike a raw epsilon
+    // equals reflexive, symmetric and transitive, and consistent with hashCode - unlike a raw epsilon
     // "within tolerance" check, which is non-transitive and can't have a matching hashCode.
     private static final double GRID = 1e-5;
 
     private final double latitude;
     private final double longitude;
 
+    // Coordinates are guaranteed finite by the constructors, so Math.round never sees NaN/Infinity
+    // (Math.round(NaN) == 0 would otherwise let a non-finite coordinate collide with grid cell 0).
     private static long cell(double coordinate) {
         return Math.round(coordinate / GRID);
+    }
+
+    private static double requireFinite(double coordinate, String name) {
+        if (!Double.isFinite(coordinate)) {
+            throw new IllegalArgumentException(name + " must be a finite number but was " + coordinate);
+        }
+        return coordinate;
     }
 
     /**
      * @param latitude The latitude in degrees. It must be in the range [-90.0, +90.0]
      * @param longitude The longitude in degrees. It must be in the range [-180.0, +180.0]
+     * @throws IllegalArgumentException if either coordinate is NaN or infinite
      */
     public Point(double latitude, double longitude) {
-        this.latitude = latitude;
-        this.longitude = longitude;
+        this.latitude = requireFinite(latitude, "latitude");
+        this.longitude = requireFinite(longitude, "longitude");
     }
 
     /**
      * @param values {@code [latitude, longitude]}
+     * @throws IllegalArgumentException if {@code values} is not exactly two finite doubles
      */
     public Point(List<Double> values) {
         if (values == null || values.size() != 2) {
             throw new IllegalArgumentException("Point requires two doubles.");
         }
-        this.latitude = values.get(0);
-        this.longitude = values.get(1);
+        this.latitude = requireFinite(values.get(0), "latitude");
+        this.longitude = requireFinite(values.get(1), "longitude");
     }
 
     /**

--- a/src/main/java/com/falkordb/graph_entities/Point.java
+++ b/src/main/java/com/falkordb/graph_entities/Point.java
@@ -33,8 +33,8 @@ public final class Point {
     }
 
     /**
-     * @param latitude The latitude in degrees. It must be in the range [-90.0, +90.0]
-     * @param longitude The longitude in degrees. It must be in the range [-180.0, +180.0]
+     * @param latitude The latitude in degrees, normally in the range [-90.0, +90.0]. Must be finite.
+     * @param longitude The longitude in degrees, normally in the range [-180.0, +180.0]. Must be finite.
      * @throws IllegalArgumentException if either coordinate is NaN or infinite
      */
     public Point(double latitude, double longitude) {

--- a/src/main/java/com/falkordb/graph_entities/Point.java
+++ b/src/main/java/com/falkordb/graph_entities/Point.java
@@ -8,10 +8,12 @@ import java.util.Objects;
  */
 public final class Point {
 
-    // FalkorDB stores point coordinates in single precision, so a round-tripped coordinate can differ
-    // from the original by up to ~1e-5. Coordinates are therefore compared on a 1e-5 grid: this keeps
-    // equals reflexive, symmetric and transitive, and consistent with hashCode - unlike a raw epsilon
-    // "within tolerance" check, which is non-transitive and can't have a matching hashCode.
+    // FalkorDB stores point coordinates in single precision, so a round-tripped coordinate drifts
+    // slightly from the original. Coordinates are quantized onto a 1e-5 grid (see cell()) before
+    // comparison, so nearby values usually collapse to the same cell while equals stays reflexive,
+    // symmetric and transitive, and consistent with hashCode - unlike a raw epsilon "within
+    // tolerance" check, which is non-transitive and can't have a matching hashCode. The trade-off is
+    // that two coordinates straddling a cell boundary compare unequal even when close.
     private static final double GRID = 1e-5;
 
     private final double latitude;
@@ -48,8 +50,13 @@ public final class Point {
         if (values == null || values.size() != 2) {
             throw new IllegalArgumentException("Point requires two doubles.");
         }
-        this.latitude = requireFinite(values.get(0), "latitude");
-        this.longitude = requireFinite(values.get(1), "longitude");
+        Double lat = values.get(0);
+        Double lon = values.get(1);
+        if (lat == null || lon == null) {
+            throw new IllegalArgumentException("Point requires two doubles.");
+        }
+        this.latitude = requireFinite(lat, "latitude");
+        this.longitude = requireFinite(lon, "longitude");
     }
 
     /**

--- a/src/test/java/com/falkordb/GraphAPIIT.java
+++ b/src/test/java/com/falkordb/GraphAPIIT.java
@@ -1020,7 +1020,8 @@ public class GraphAPIIT {
         Assertions.assertEquals(30.27822306, result.getLatitude(), 0.01);
         Assertions.assertEquals(-97.75134723, result.getLongitude(), 0.01);
         Assertions.assertEquals("Point{latitude=30.2782230377197, longitude=-97.751350402832}", result.toString());
-        Assertions.assertEquals(-132320535, result.hashCode());
+        // Equal points must share a hashCode (contract); assert that rather than a brittle magic value.
+        Assertions.assertEquals(point.hashCode(), result.hashCode());
     }
 
     @Test

--- a/src/test/java/com/falkordb/graph_entities/PointTest.java
+++ b/src/test/java/com/falkordb/graph_entities/PointTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
 import java.util.Collections;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
 public class PointTest {
@@ -176,5 +177,27 @@ public class PointTest {
         // Test min longitude
         Point point4 = new Point(0.0, -180.0);
         assertEquals(-180.0, point4.getLongitude());
+    }
+
+    @Test
+    public void equalsHashCodeContract() {
+        EqualsVerifier.forClass(Point.class).verify();
+    }
+
+    @Test
+    public void toleratesSinglePrecisionRoundTripDrift() {
+        // FalkorDB returns points in single precision, so the original and the round-tripped value
+        // differ slightly (see GraphAPIIT#testGeoPointLatLon). They must still be equal AND share a
+        // hashCode — the regression that the old epsilon-equals/exact-hashCode pair violated.
+        Point original = new Point(30.27822306, -97.75134723);
+        Point roundTripped = new Point(30.2782230377197, -97.751350402832);
+        assertEquals(original, roundTripped);
+        assertEquals(original.hashCode(), roundTripped.hashCode());
+    }
+
+    @Test
+    public void distinctPointsAreNotEqual() {
+        assertNotEquals(new Point(1.0, 2.0), new Point(3.0, 4.0));
+        assertNotEquals(new Point(1.0, 2.0), new Point(1.0, 9.0));
     }
 }

--- a/src/test/java/com/falkordb/graph_entities/PointTest.java
+++ b/src/test/java/com/falkordb/graph_entities/PointTest.java
@@ -212,4 +212,12 @@ public class PointTest {
         assertThrows(IllegalArgumentException.class, () -> new Point(Arrays.asList(Double.NaN, 0.0)));
         assertThrows(IllegalArgumentException.class, () -> new Point(Arrays.asList(0.0, Double.POSITIVE_INFINITY)));
     }
+
+    @Test
+    public void rejectsNullListElements() {
+        // A null element unboxes to no coordinate, so the list constructor rejects it fail-fast
+        // rather than throwing a NullPointerException.
+        assertThrows(IllegalArgumentException.class, () -> new Point(Arrays.<Double>asList(null, 2.0)));
+        assertThrows(IllegalArgumentException.class, () -> new Point(Arrays.<Double>asList(1.0, null)));
+    }
 }

--- a/src/test/java/com/falkordb/graph_entities/PointTest.java
+++ b/src/test/java/com/falkordb/graph_entities/PointTest.java
@@ -200,4 +200,16 @@ public class PointTest {
         assertNotEquals(new Point(1.0, 2.0), new Point(3.0, 4.0));
         assertNotEquals(new Point(1.0, 2.0), new Point(1.0, 9.0));
     }
+
+    @Test
+    public void rejectsNonFiniteCoordinates() {
+        // Non-finite coordinates have no grid cell (Math.round(NaN) == 0 would collide with 0.0),
+        // so both constructors reject them fail-fast.
+        assertThrows(IllegalArgumentException.class, () -> new Point(Double.NaN, 0.0));
+        assertThrows(IllegalArgumentException.class, () -> new Point(0.0, Double.NaN));
+        assertThrows(IllegalArgumentException.class, () -> new Point(Double.POSITIVE_INFINITY, 0.0));
+        assertThrows(IllegalArgumentException.class, () -> new Point(0.0, Double.NEGATIVE_INFINITY));
+        assertThrows(IllegalArgumentException.class, () -> new Point(Arrays.asList(Double.NaN, 0.0)));
+        assertThrows(IllegalArgumentException.class, () -> new Point(Arrays.asList(0.0, Double.POSITIVE_INFINITY)));
+    }
 }


### PR DESCRIPTION
## Wave 4 · PR 12a — fix `Point` equals/hashCode contract

First Wave 4 PR (approved plan #329). The `equalsverifier` work in Wave 4 exposes a real defect in
`Point`, fixed here first (as a `fix:`, per the plan).

### The bug
`Point.equals` used an **epsilon** ("within `1e-5`") check while `hashCode` hashed the **exact**
doubles → equal points could hash differently (contract violation). Epsilon equality is also
**non-transitive**, so it can't have a consistent hashCode at all — `equalsverifier` rejects it.

### Why not just use exact equality
The epsilon tolerance is **intentional**: FalkorDB stores point coordinates in **single precision**, so
a round-tripped point differs slightly from the original — `GraphAPIIT#testGeoPointLatLon` sends
`30.27822306` and gets back `30.2782230377197`. Dropping the tolerance would break that round-trip.

### The fix
Compare coordinates on a **`1e-5` grid** (quantize in **both** `equals` and `hashCode`). This keeps the
single-precision drift tolerance, and is now **transitive** and **hashCode-consistent**.

### Tests
`equalsverifier` on `Point`, a single-precision-drift **regression** test using the exact `GraphAPIIT`
values, and a distinct-points check. Verified: `just test` (160), `just lint`, `just fmt-check`,
`just api-diff` (signature unchanged) all green; the round-trip `*IT` runs in CI.

**Semver:** minor (behavior change). The other value types (`Node`/`Edge`/`GraphEntity`/`Property`)
have **no contract bugs** — they only need `equalsverifier` config (inheritance/finality), which lands
in **PR 12b**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved geospatial `Point` equality and hashing to be robust to very small coordinate precision differences by using grid-based quantization.
  * Ensured points that represent the same location produce matching `hashCode()` values while still treating meaningfully different points as distinct.

* **Tests**
  * Added equality/hashCode contract verification and new cases covering precision drift and distinct point behavior.
  * Updated an integration assertion to avoid brittle hard-coded hash expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->