### PR TITLE
fix: align Property.hashCode with its Integer/Long-normalizing equals

### DIFF
--- a/src/main/java/com/falkordb/graph_entities/Property.java
+++ b/src/main/java/com/falkordb/graph_entities/Property.java
@@ -55,10 +55,18 @@ public class Property<T> {
         this.value = value;
     }
 
+    // equals() treats an Integer value as equal to the numerically-equal Long (the server can return
+    // either width for the same value). hashCode() must apply the SAME normalization, otherwise equal
+    // properties can hash differently - e.g. Integer(-1).hashCode() == -1 but Long(-1L).hashCode() == 0.
+    private static Object normalizeValue(Object value) {
+        if (value instanceof Integer) {
+            return Long.valueOf(((Integer) value).longValue());
+        }
+        return value;
+    }
+
     private boolean valueEquals(Object value1, Object value2) {
-        if (value1 instanceof Integer) value1 = Long.valueOf(((Integer) value1).longValue());
-        if (value2 instanceof Integer) value2 = Long.valueOf(((Integer) value2).longValue());
-        return Objects.equals(value1, value2);
+        return Objects.equals(normalizeValue(value1), normalizeValue(value2));
     }
 
     @Override
@@ -71,7 +79,7 @@ public class Property<T> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, value);
+        return Objects.hash(name, normalizeValue(value));
     }
 
     /**

--- a/src/test/java/com/falkordb/graph_entities/PropertyTest.java
+++ b/src/test/java/com/falkordb/graph_entities/PropertyTest.java
@@ -2,6 +2,8 @@ package com.falkordb.graph_entities;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.Test;
 
 public class PropertyTest {
@@ -83,6 +85,26 @@ public class PropertyTest {
         Property<Long> property2 = new Property<>("count", 42L);
 
         assertEquals(property1, property2);
+    }
+
+    @Test
+    public void integerAndLongValuesShareHashCode() {
+        // equals() normalizes Integer to Long, so hashCode() must agree. Use a negative value, where
+        // Integer.hashCode() != Long.hashCode(), so this actually exercises the contract (42 wouldn't).
+        Property<Integer> intProperty = new Property<>("count", -1);
+        Property<Long> longProperty = new Property<>("count", -1L);
+
+        assertEquals(intProperty, longProperty);
+        assertEquals(intProperty.hashCode(), longProperty.hashCode());
+    }
+
+    @Test
+    public void equalsHashCodeContract() {
+        // Property is a mutable, non-final entity compared with instanceof, so relax those checks;
+        // the equals/hashCode contract itself (incl. the Integer/Long normalization) must still hold.
+        EqualsVerifier.forClass(Property.class)
+                .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
+                .verify();
     }
 
     @Test


### PR DESCRIPTION
## Wave 4 · PR 12a — fix `Property` equals/hashCode contract

Second Wave 4 `12a` equality fix, following #330 (`Point`). Part of the approved Wave 4 plan (#329)
and tracked by #332.

### The bug
`Property.equals` treats an `Integer` value as equal to the numerically-equal `Long` — `valueEquals`
normalizes `Integer`→`Long` before comparing (the server can return either width for the same value).
But `hashCode` hashed the **raw** value. For **negative** values `Integer.hashCode() != Long.hashCode()`:

| value | `Integer.hashCode()` | `Long.hashCode()` |
| --- | --- | --- |
| `42` | 42 | 42 |
| `-1` | **-1** | **0** |
| `-100000` | **-100000** | **99999** |

So `new Property<>("count", -1)` and `new Property<>("count", -1L)` are **equal** yet hash
**differently** — an `equals`/`hashCode` contract violation that breaks `HashMap`/`HashSet` lookups
(and which the `equalsverifier` work later in Wave 4 rejects).

> The existing `testEqualsWithIntegerValues` only checked `42`, where the two hashCodes happen to
> coincide, so it never caught this.

### The fix
Extract a shared `normalizeValue()` (`Integer`→`Long`) and apply it in **both** `valueEquals` and
`hashCode`. `equals` behaviour is unchanged; only `hashCode` is corrected to agree with it.

### Tests
- `integerAndLongValuesShareHashCode` — asserts equal **and** same `hashCode` using `-1` (a value that
  actually exercises the divergence).
- `equalsHashCodeContract` — `EqualsVerifier.forClass(Property.class)` with `NONFINAL_FIELDS` +
  `STRICT_INHERITANCE` suppressed (Property is a mutable, non-final, `instanceof`-compared entity).

### Validation (via `just`, same as CI)
`just test` (164 unit tests green, incl. Node/Edge which hash `Property` via their property maps),
`just fmt-check`, `just lint` all green.

### Semver
User-visible behaviour change (a `fix:`, semver-minor pre-1.0). `hashCode` signature is unchanged, so
`api-diff` stays green; no `breaking-change` label needed.

### Audit note (rest of `12a`)
Audited every value type's `equals`/`hashCode`. `Property` was the **only** remaining contract
violation: `Node`, `Edge`, `Path`, `GraphEntity`, `StatisticsImpl`, `RecordImpl`, `HeaderImpl` all use
the same fields in `equals` and `hashCode`. (`StatisticsImpl` compares `List<byte[]>` by identity —
consistent between equals/hashCode, so not a contract bug; a prefab concern for the `12b` verifier.)
This completes `12a`; `12b` (verifiers for every value type + round-trip matrices) is next.
