### PR TITLE
test: EqualsVerifier contracts for all value-type implementations

### DIFF
--- a/src/test/java/com/falkordb/graph_entities/EdgeTest.java
+++ b/src/test/java/com/falkordb/graph_entities/EdgeTest.java
@@ -2,6 +2,8 @@ package com.falkordb.graph_entities;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.Test;
 
 public class EdgeTest {
@@ -185,5 +187,15 @@ public class EdgeTest {
 
         assertNotNull(result);
         assertTrue(result.contains("Edge{"));
+    }
+
+    @Test
+    public void equalsHashCodeContract() {
+        // Edge is a mutable, non-final entity extending the stateful GraphEntity base and comparing
+        // with instanceof; it has no subclasses, so relax the mutability/inheritance checks. The
+        // contract itself (id + properties + relationshipType + source + destination) is still verified.
+        EqualsVerifier.forClass(Edge.class)
+                .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
+                .verify();
     }
 }

--- a/src/test/java/com/falkordb/graph_entities/GraphEntityTest.java
+++ b/src/test/java/com/falkordb/graph_entities/GraphEntityTest.java
@@ -1,0 +1,17 @@
+package com.falkordb.graph_entities;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.Test;
+
+public class GraphEntityTest {
+
+    @Test
+    public void equalsHashCodeContract() {
+        // Abstract base for Node/Edge with mutable fields and instanceof-based equals, so relax the
+        // mutability/inheritance checks. Verifies the shared id + properties contract.
+        EqualsVerifier.forClass(GraphEntity.class)
+                .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
+                .verify();
+    }
+}

--- a/src/test/java/com/falkordb/graph_entities/NodeTest.java
+++ b/src/test/java/com/falkordb/graph_entities/NodeTest.java
@@ -2,6 +2,8 @@ package com.falkordb.graph_entities;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.Test;
 
 public class NodeTest {
@@ -163,5 +165,15 @@ public class NodeTest {
 
         assertNotNull(result);
         assertTrue(result.contains("Node{"));
+    }
+
+    @Test
+    public void equalsHashCodeContract() {
+        // Node is a mutable, non-final entity extending the stateful GraphEntity base and comparing
+        // with instanceof; it has no subclasses, so relax the mutability/inheritance checks. The
+        // contract itself (id + properties + labels) is still fully verified.
+        EqualsVerifier.forClass(Node.class)
+                .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
+                .verify();
     }
 }

--- a/src/test/java/com/falkordb/impl/resultset/HeaderImplTest.java
+++ b/src/test/java/com/falkordb/impl/resultset/HeaderImplTest.java
@@ -1,0 +1,19 @@
+package com.falkordb.impl.resultset;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.Test;
+
+public class HeaderImplTest {
+
+    @Test
+    public void equalsHashCodeContract() {
+        // equals/hashCode compare the schema derived from `raw` (getSchemaTypes/getSchemaNames), not the
+        // raw source list, so `raw` is ignored here. The lazily-built schema lists are always
+        // constructor-initialized, so NULL_FIELDS is safe.
+        EqualsVerifier.forClass(HeaderImpl.class)
+                .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE, Warning.NULL_FIELDS)
+                .withIgnoredFields("raw")
+                .verify();
+    }
+}

--- a/src/test/java/com/falkordb/impl/resultset/RecordImplTest.java
+++ b/src/test/java/com/falkordb/impl/resultset/RecordImplTest.java
@@ -1,0 +1,16 @@
+package com.falkordb.impl.resultset;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.Test;
+
+public class RecordImplTest {
+
+    @Test
+    public void equalsHashCodeContract() {
+        // Internal, mutable, non-final record type compared with instanceof; relax those checks.
+        EqualsVerifier.forClass(RecordImpl.class)
+                .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
+                .verify();
+    }
+}

--- a/src/test/java/com/falkordb/impl/resultset/StatisticsImplTest.java
+++ b/src/test/java/com/falkordb/impl/resultset/StatisticsImplTest.java
@@ -1,0 +1,18 @@
+package com.falkordb.impl.resultset;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.Test;
+
+public class StatisticsImplTest {
+
+    @Test
+    public void equalsHashCodeContract() {
+        // StatisticsImpl is an internal, mutable, non-final result type compared with instanceof. Its
+        // lazily-built statistics map is always constructor-initialized (never null in practice), so
+        // NULL_FIELDS is safe.
+        EqualsVerifier.forClass(StatisticsImpl.class)
+                .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE, Warning.NULL_FIELDS)
+                .verify();
+    }
+}


### PR DESCRIPTION
## Wave 4 · 12b (part 1) — EqualsVerifier contracts for all value-type implementations

Part of the approved Wave 4 plan (#329), tracked by #332. This is the **test-only** first slice of
12b: an `EqualsVerifier` contract test for every value *implementation*. `Point`, `Property` (both
fixed in 12a: #330, #334) and `Path` already had verifiers; this adds the remaining six.

### Added verifiers
| Type | Config | Why |
| --- | --- | --- |
| `Node` | `NONFINAL_FIELDS, STRICT_INHERITANCE` | mutable entity; extends stateful `GraphEntity` with `instanceof` equals; no subclasses |
| `Edge` | `NONFINAL_FIELDS, STRICT_INHERITANCE` | same as `Node` |
| `GraphEntity` | `NONFINAL_FIELDS, STRICT_INHERITANCE` | abstract base; mutable; `instanceof` equals |
| `StatisticsImpl` | `+ NULL_FIELDS` | internal, mutable; lazily-built `statistics` map is always constructor-initialized |
| `RecordImpl` | `NONFINAL_FIELDS, STRICT_INHERITANCE` | internal, mutable, `instanceof` equals |
| `HeaderImpl` | `+ NULL_FIELDS, withIgnoredFields("raw")` | equals compares the schema **derived** from `raw` (`getSchemaTypes/Names()`), not the raw source; schema lists are constructor-initialized |

### No production changes
The audit in 12a already fixed the only real contract violation (`Property`). The suppressions here
are **not** masking reachable bugs, verified case by case:
- **`STRICT_INHERITANCE`** — `Node`/`Edge` have no subclasses and `GraphEntity` is abstract (never
  instantiated bare), so the `instanceof` equals is symmetric for every reachable (concrete) instance.
  The only asymmetry EqualsVerifier objects to is against a synthetic bare-superclass instance, which
  cannot exist at runtime.
- **`NULL_FIELDS`** (StatisticsImpl/HeaderImpl) — the skipped fields are `final`/constructor-initialized
  and never null in practice; these are internal result types the driver builds, not user-constructed.
- **`withIgnoredFields("raw")`** (HeaderImpl) — `equals`/`hashCode` both use the derived schema, so
  `raw` (the source bytes) is legitimately not part of identity; two headers with the same
  types+names are equal regardless of raw representation.

### Validation (via `just`, same as CI)
`just test` — **170 unit tests green** (was 164; +6). `just fmt-check` and `just lint` green.

### Follow-ups (rest of 12b, separate PRs)
`@ParameterizedTest` value/round-trip matrices; broader jqwik serialize→parse round-trip properties; a
shared fixture-loader JUnit 5 extension.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated validation of `equals` and `hashCode` consistency across graph entities and result objects.
  * Expanded test coverage for nodes, edges, graph entities, headers, records, and statistics.
  * Improved confidence that these objects behave reliably in collections and comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->