### PR TITLE
test: parameterized value/round-trip matrices (boundaries, unicode, collections)

### DIFF
--- a/src/test/java/com/falkordb/ParameterRoundTripIT.java
+++ b/src/test/java/com/falkordb/ParameterRoundTripIT.java
@@ -2,6 +2,7 @@ package com.falkordb;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.falkordb.graph_entities.Node;
@@ -11,9 +12,13 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * End-to-end verification that {@link com.falkordb.impl.Utils#prepareQuery} encodes parameters so
@@ -93,6 +98,79 @@ public class ParameterRoundTripIT {
         Map<String, Object> map = (Map<String, Object>) out;
         assertEquals(1L, ((Number) map.get("bareKey")).longValue());
         assertEquals("value with \" quote", map.get("needs quoting!"));
+    }
+
+    @ParameterizedTest(name = "integer {0} round-trips as long")
+    @MethodSource("integerBoundaries")
+    public void integerBoundariesRoundTrip(Object input, long expected) {
+        assertEquals(expected, ((Number) roundTrip(input)).longValue());
+    }
+
+    static Stream<Arguments> integerBoundaries() {
+        return Stream.of(
+                Arguments.of(0, 0L),
+                Arguments.of(-1, -1L),
+                Arguments.of(Integer.MIN_VALUE, (long) Integer.MIN_VALUE),
+                Arguments.of(Integer.MAX_VALUE, (long) Integer.MAX_VALUE),
+                Arguments.of(Long.MIN_VALUE, Long.MIN_VALUE),
+                Arguments.of(Long.MAX_VALUE, Long.MAX_VALUE));
+    }
+
+    @ParameterizedTest(name = "double {0} round-trips")
+    @MethodSource("doubleBoundaries")
+    public void doubleBoundariesRoundTrip(double input) {
+        assertEquals(input, ((Number) roundTrip(input)).doubleValue(), 0.0);
+    }
+
+    static Stream<Double> doubleBoundaries() {
+        // FalkorDB returns doubles with ~15 significant digits and a finite range: full-precision values
+        // such as Math.PI (17 digits) come back rounded, and Double.MAX_VALUE overflows to Infinity. This
+        // matrix therefore exercises representative magnitudes/signs that round-trip within that fidelity.
+        return Stream.of(0.0, 1.5, -1.5, 0.25, 1.0e-10, 1.0e10, 6.022e23, -2.5e-100);
+    }
+
+    @ParameterizedTest(name = "unicode [{index}] round-trips")
+    @MethodSource("unicodeStrings")
+    public void unicodeStringsRoundTrip(String value) {
+        assertEquals(value, roundTrip(value), () -> "round-trip mismatch for: " + escape(value));
+    }
+
+    static Stream<String> unicodeStrings() {
+        return Stream.of(
+                "café ☕ 😀", // accents, symbol, astral emoji
+                "日本語のテキスト", // CJK
+                "Ålesund Øystein Þórr", // Nordic letters
+                "family 👨‍👩‍👧‍👦 zwj", // ZWJ emoji sequence
+                "flag 🇮🇱 regional", // regional-indicator surrogate pairs
+                "combining e\u0301 = é", // combining acute accent
+                "rtl مرحبا שלום ltr", // bidirectional scripts
+                "astral 𝕏 𝟛 math"); // astral-plane math alphanumerics
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void emptyAndNestedCollectionsRoundTrip() {
+        assertTrue(((List<Object>) roundTrip(Collections.emptyList())).isEmpty());
+        assertTrue(((Map<String, Object>) roundTrip(Collections.emptyMap())).isEmpty());
+
+        Map<String, Object> inner = new LinkedHashMap<>();
+        inner.put("nums", Arrays.asList(1, 2));
+        Object out = roundTrip(Arrays.asList(Collections.emptyList(), inner));
+        List<Object> list = (List<Object>) out;
+        assertEquals(2, list.size());
+        assertTrue(((List<Object>) list.get(0)).isEmpty());
+        Map<String, Object> outMap = (Map<String, Object>) list.get(1);
+        assertEquals(2, ((List<Object>) outMap.get("nums")).size());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void nullInsideCollectionsRoundTrips() {
+        List<Object> list = (List<Object>) roundTrip(Arrays.asList("a", null, 3));
+        assertEquals(3, list.size());
+        assertEquals("a", list.get(0));
+        assertNull(list.get(1));
+        assertEquals(3L, ((Number) list.get(2)).longValue());
     }
 
     @Test

--- a/src/test/java/com/falkordb/ParameterRoundTripIT.java
+++ b/src/test/java/com/falkordb/ParameterRoundTripIT.java
@@ -160,7 +160,10 @@ public class ParameterRoundTripIT {
         assertEquals(2, list.size());
         assertTrue(((List<Object>) list.get(0)).isEmpty());
         Map<String, Object> outMap = (Map<String, Object>) list.get(1);
-        assertEquals(2, ((List<Object>) outMap.get("nums")).size());
+        List<Object> nums = (List<Object>) outMap.get("nums");
+        assertEquals(2, nums.size());
+        assertEquals(1L, ((Number) nums.get(0)).longValue());
+        assertEquals(2L, ((Number) nums.get(1)).longValue());
     }
 
     @Test


### PR DESCRIPTION
## Wave 4 · 12b (part 2) — parameterized value/round-trip matrices

Part of the approved Wave 4 plan (#329), tracked by #332. Follows #337 (EqualsVerifier coverage).
**Test-only.** Adds `@ParameterizedTest` round-trip matrices to `ParameterRoundTripIT`, filling
genuine gaps beyond the existing ad-hoc `stringsRoundTripExactly`/`scalarsRoundTrip`/`listRoundTrips`/
`mapRoundTrips` cases:

- **Integer boundaries** — `0`, `-1`, `Integer.MIN/MAX`, `Long.MIN/MAX` (all come back as `long`).
- **Doubles** — representative magnitudes/signs. FalkorDB returns doubles with **~15 significant
  digits** and a **finite range**, so `Math.PI` (17 digits) comes back rounded and `Double.MAX_VALUE`
  overflows to `Infinity`. That is **server-side numeric fidelity, not a client bug** — the provider is
  tuned to values that round-trip and documents the limit.
- **Unicode** — accents, CJK, Nordic letters, a **ZWJ emoji sequence** (👨‍👩‍👧‍👦), **regional-indicator**
  pairs (🇮🇱), a **combining** mark, **bidirectional** (RTL+LTR) text, and **astral-plane** math
  alphanumerics — exercising surrogate pairs the encoder must preserve.
- **Collections** — empty list, empty map, nested list/map, and **null inside a list**.

Each `@ParameterizedTest` reports per case, so a failure names the exact offending input.

### Validation (via `just`, same as CI)
Ran against a real FalkorDB (`just db-up`): **`ParameterRoundTripIT` = 31 tests green**. `just fmt-check`
and `just lint` green. (The double matrix was arrived at empirically — the first draft asserting
full-precision/overflow doubles correctly failed against the live server, confirming the ~15-digit
fidelity note above.)

### Follow-ups (rest of 12b)
Broader jqwik serialize→parse round-trip properties; a shared fixture-loader JUnit 5 extension.
