### PR TITLE
ci: disable the CodeRabbit commit status (still red on rate limit)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,9 +2,10 @@
 reviews:
   # Fewer nitpicks; focus on substantive issues.
   profile: chill
-  # Don't fail the "CodeRabbit" commit status when a review can't run (e.g. transient "Review rate
-  # limited"); that is not a code problem and shouldn't show as a failing check. Overrides the
-  # org-level setting. Successful reviews still report via the normal (pending -> success) commit status.
-  fail_commit_status: false
+  # Don't post a "CodeRabbit" commit status at all. `fail_commit_status: false` alone did NOT stop the
+  # transient "Review rate limited" status from showing up red (that status isn't governed by it), so
+  # disable the commit status entirely. CodeRabbit still posts its review comments/walkthrough; it just
+  # no longer adds a pass/fail check that can go red on a rate limit.
+  commit_status: false
   auto_review:
     enabled: true


### PR DESCRIPTION
## Make the `CodeRabbit` check stop going red on `Review rate limited`

Follow-up to #336. That PR set `fail_commit_status: false`, but the transient **`Review rate limited`**
status **still shows the `CodeRabbit` check as red** (seen again on #338) — that rate-limit status is
**not** governed by `fail_commit_status` (which only covers the "PR is unreviewable" case).

### Fix
Switch to **`commit_status: false`**, which disables CodeRabbit's commit status **entirely** — no
`pending`, `success`, or `failure`:

```yaml
reviews:
  commit_status: false
```

CodeRabbit still runs and still posts its **review comments / walkthrough**; it just no longer adds a
pass/fail check that can go red on a rate limit. Per the
[reference](https://docs.coderabbit.ai/reference/configuration), `commit_status` is the master switch
for the status check (`fail_commit_status` only flips the failure case, which didn't cover rate limits).

### Effect
Takes effect for PRs once merged to `master` (CodeRabbit reads `.coderabbit.yaml` from the default
branch). Existing already-posted statuses on open PRs won't retro-change, but new/re-reviewed PRs will
no longer carry a red CodeRabbit check.
