### PR TITLE
test: generative server round-trip property for params (jqwik)

### DIFF
--- a/src/test/java/com/falkordb/ParamRoundTripPropertyIT.java
+++ b/src/test/java/com/falkordb/ParamRoundTripPropertyIT.java
@@ -1,8 +1,10 @@
 package com.falkordb;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
+import java.util.Iterator;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.ForAll;
@@ -38,7 +40,9 @@ class ParamRoundTripPropertyIT {
 
     private Object roundTrip(Object value) {
         ResultSet rs = client.query("RETURN $p AS v", Collections.singletonMap("p", value));
-        return rs.iterator().next().getValue("v");
+        Iterator<Record> it = rs.iterator();
+        assertTrue(it.hasNext(), "expected a row");
+        return it.next().getValue("v");
     }
 
     @Property(tries = 300)

--- a/src/test/java/com/falkordb/ParamRoundTripPropertyIT.java
+++ b/src/test/java/com/falkordb/ParamRoundTripPropertyIT.java
@@ -33,8 +33,12 @@ class ParamRoundTripPropertyIT {
     @AfterProperty
     void deleteGraph() {
         if (client != null) {
-            client.deleteGraph();
-            client.close();
+            try {
+                client.deleteGraph();
+            } finally {
+                client.close();
+                client = null;
+            }
         }
     }
 
@@ -56,8 +60,10 @@ class ParamRoundTripPropertyIT {
     }
 
     /**
-     * Strings biased toward the dangerous characters (backslash, quote, control chars) but excluding NUL
-     * and surrogates, which the encoder rejects outright (covered by {@code UtilsTest}).
+     * Strings biased toward the dangerous characters (backslash, quote, control chars), drawn from the
+     * BMP but excluding NUL and the surrogate range — so the generator never emits an unpaired
+     * surrogate, which (along with NUL) is what the encoder rejects (see {@code UtilsTest}). Valid
+     * surrogate pairs (e.g. emoji) round-trip and are exercised by {@code ParameterRoundTripIT}.
      */
     @Provide
     Arbitrary<String> safeStrings() {

--- a/src/test/java/com/falkordb/ParamRoundTripPropertyIT.java
+++ b/src/test/java/com/falkordb/ParamRoundTripPropertyIT.java
@@ -1,0 +1,73 @@
+package com.falkordb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.Tuple;
+import net.jqwik.api.lifecycle.AfterProperty;
+import net.jqwik.api.lifecycle.BeforeProperty;
+
+/**
+ * Property-based end-to-end round-trip: a generated value sent as a parameter must come back from a
+ * real FalkorDB server unchanged. This is the generative, full serialize→server→deserialize counterpart
+ * to {@link ParameterRoundTripIT} (fixed cases) and {@code UtilsParamPropertyTest} (serialize-side
+ * well-formedness only, no server) — so an escaping bug that produced a well-formed but semantically
+ * wrong literal would be caught here.
+ */
+class ParamRoundTripPropertyIT {
+
+    private GraphContextGenerator client;
+
+    @BeforeProperty
+    void createApi() {
+        client = TestServer.graph("param-roundtrip-prop");
+    }
+
+    @AfterProperty
+    void deleteGraph() {
+        if (client != null) {
+            client.deleteGraph();
+            client.close();
+        }
+    }
+
+    private Object roundTrip(Object value) {
+        ResultSet rs = client.query("RETURN $p AS v", Collections.singletonMap("p", value));
+        return rs.iterator().next().getValue("v");
+    }
+
+    @Property(tries = 300)
+    void arbitraryStringRoundTripsThroughServer(@ForAll("safeStrings") String value) {
+        assertEquals(value, roundTrip(value));
+    }
+
+    @Property(tries = 200)
+    void arbitraryLongRoundTripsThroughServer(@ForAll long value) {
+        assertEquals(value, ((Number) roundTrip(value)).longValue());
+    }
+
+    /**
+     * Strings biased toward the dangerous characters (backslash, quote, control chars) but excluding NUL
+     * and surrogates, which the encoder rejects outright (covered by {@code UtilsTest}).
+     */
+    @Provide
+    Arbitrary<String> safeStrings() {
+        Arbitrary<Character> chars = Arbitraries.frequencyOf(
+                Tuple.of(3, Arbitraries.of('\\', '"', '\n', '\r', '\t', '\b', '\f', '\'', '/')),
+                Tuple.of(2, Arbitraries.chars().range('\u0001', '~')),
+                Tuple.of(1, Arbitraries.chars().range('\u00a1', '\ud7ff')),
+                Tuple.of(1, Arbitraries.chars().range('\ue000', '\uffff')));
+        return chars.list().ofMaxSize(64).map(list -> {
+            StringBuilder sb = new StringBuilder(list.size());
+            for (char c : list) {
+                sb.append(c);
+            }
+            return sb.toString();
+        });
+    }
+}

--- a/src/test/java/com/falkordb/ParameterRoundTripPropertyIT.java
+++ b/src/test/java/com/falkordb/ParameterRoundTripPropertyIT.java
@@ -21,7 +21,7 @@ import net.jqwik.api.lifecycle.BeforeProperty;
  * well-formedness only, no server) — so an escaping bug that produced a well-formed but semantically
  * wrong literal would be caught here.
  */
-class ParamRoundTripPropertyIT {
+public class ParameterRoundTripPropertyIT {
 
     private GraphContextGenerator client;
 


### PR DESCRIPTION
## Wave 4 · 12b (part 3) — generative server round-trip property (jqwik)

Part of the approved Wave 4 plan (#329), tracked by #332. Follows #337 (EqualsVerifier) and #338
(parameterized matrices). **Test-only.**

Adds `ParamRoundTripPropertyIT`: jqwik `@Property` tests that send a **generated** value as a query
parameter to a real FalkorDB server and assert it comes back unchanged — the full
**serialize → server → deserialize** round-trip. This closes the last generative gap:

| Existing | What it checks |
| --- | --- |
| `ParameterRoundTripIT` | fixed round-trip cases |
| `UtilsParamPropertyTest` | generative but **serialize-side only** (well-formed literal, no server) |
| **`ParamRoundTripPropertyIT` (new)** | **generative, end-to-end** round-trip fidelity |

So an escaping bug that emitted a well-formed *but semantically wrong* literal is now caught
generatively end-to-end, not just as fixed cases.

- **Strings** — biased toward backslash/quote/control chars, excluding NUL and surrogates (which the
  encoder rejects by design), 300 tries.
- **Longs** — arbitrary 64-bit values, 200 tries.

Server-backed (`*IT`, Failsafe + Testcontainers); jqwik runs under the same JUnit platform Failsafe
uses. Client is created once per property via `@BeforeProperty`/`@AfterProperty`.

### Validation (via `just`, same as CI)
Ran against a real FalkorDB (`just db-up`): both properties green (300 + 200 tries) in ~1s.
`just fmt-check` and `just lint` green.

### 12b status
With this, the 12b test-depth slices are complete: EqualsVerifier (#337), parameterized value/round-trip
matrices (#338), and generative round-trip properties (this). The optional shared fixture-loader
extension is deferred — no current test needs a shared seeded graph (per "fill genuine gaps only").


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added property-based integration coverage for parameter round trips.
  * Validates that safe strings—including escaping-sensitive characters—and long values are returned correctly.
  * Includes automatic graph setup and cleanup for isolated test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->