### PR TITLE
ci: require a '!' title when the breaking-change label is present

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -8,7 +8,7 @@ name: PR title
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
 
 permissions:
   pull-requests: read
@@ -43,3 +43,22 @@ jobs:
           test
           bench
           release
+
+    # Closes the semver label<->commit gap: the `breaking-change` label approves an intentional
+    # public-API break in the `api-diff` gate, but release-please derives the bump from the commit
+    # subject - so a `breaking-change`-labelled `fix:`/`feat:` (no `!`) would still release as a
+    # patch/minor instead of a breaking bump. Require the `!` marker whenever the label is present.
+    # Triggering on labeled/unlabeled (above) makes this re-check when the label is toggled.
+    - name: Breaking-change label requires a "!"-marked title
+      if: contains(github.event.pull_request.labels.*.name, 'breaking-change')
+      env:
+        # Read the title via env (never interpolate ${{ }} into the script) to avoid shell injection.
+        PR_TITLE: ${{ github.event.pull_request.title }}
+      run: |
+        if [[ "$PR_TITLE" =~ ^[a-zA-Z]+(\([^\)]+\))?!: ]]; then
+          echo "OK: 'breaking-change' label matches a '!'-marked Conventional Commit title."
+        else
+          echo "::error::PR carries the 'breaking-change' label but its title is not marked breaking."
+          echo "Add a '!' before the colon so release-please cuts the right version, e.g. 'fix!: ...' or 'feat(scope)!: ...'."
+          exit 1
+        fi


### PR DESCRIPTION
## Wave 4 · PR 18 — require a `!` title when the `breaking-change` label is present

Part of the approved Wave 4 plan (#329), tracked by #332. Tiny, independent `ci:` change (the plan
notes it "can land early").

### The gap (flagged in Wave 3 / 10c)
The **`breaking-change`** label approves an intentional public-API break in the **`api-diff`** gate.
But **release-please** derives the version bump from the **commit subject**, so a
`breaking-change`-labelled `fix:`/`feat:` **without** a `!` would still release as a **patch/minor**
instead of a breaking bump — a silent semver-vs-commit mismatch.

### The fix (`.github/workflows/pr-title.yml`)
1. Trigger the workflow on **`labeled`/`unlabeled`** (in addition to the existing events) so it
   re-checks when the label is toggled.
2. Add a step that, **when the `breaking-change` label is present**, requires the title to carry a
   `!` marker (`^type(scope)?!:`) — e.g. `fix!:` / `feat(scope)!:`. The PR title is read via an **env
   var** (never interpolated into the shell) to avoid script injection.

Behaviour is unchanged for PRs without the label (the step is `if`-gated on the label).

### Validation
- YAML parses; `on.pull_request.types` now includes `labeled, unlabeled`.
- Regex checked against samples: `fix!:`, `feat(api)!:`, `chore!:` pass; `fix:`, `feat(scope):`,
  `docs:` correctly fail (only enforced when the label is present).

This PR itself is not a breaking change (no `breaking-change` label), so the new check is inert here.
