### PR TITLE
test: make the FalkorDB test image overridable via FALKORDB_IMAGE

### DIFF
--- a/src/test/java/com/falkordb/FalkorDbImage.java
+++ b/src/test/java/com/falkordb/FalkorDbImage.java
@@ -1,5 +1,6 @@
 package com.falkordb;
 
+import java.util.function.Supplier;
 import org.testcontainers.utility.DockerImageName;
 
 /**
@@ -21,15 +22,17 @@ final class FalkorDbImage {
 
     /**
      * Picks the effective override from its two sources: the system {@code property} if non-blank,
-     * otherwise the {@code env} value (which may itself be null/blank). A blank system property (e.g.
-     * {@code -DFALKORDB_IMAGE=}) therefore does not shadow a non-blank environment variable.
+     * otherwise the value from {@code env} (which may itself be null/blank). A blank system property
+     * (e.g. {@code -DFALKORDB_IMAGE=}) therefore does not shadow a non-blank environment variable. The
+     * {@code env} supplier is consulted lazily — only when the property is blank.
      *
      * @param property the {@code FALKORDB_IMAGE} system property value; may be null
-     * @param env the {@code FALKORDB_IMAGE} environment value; may be null
+     * @param env supplies the {@code FALKORDB_IMAGE} environment value; read only if {@code property}
+     *     is blank
      * @return the value to hand to {@link #resolve(String)}
      */
-    static String pickOverride(String property, String env) {
-        return (property != null && !property.trim().isEmpty()) ? property : env;
+    static String pickOverride(String property, Supplier<String> env) {
+        return (property != null && !property.trim().isEmpty()) ? property : env.get();
     }
 
     /**

--- a/src/test/java/com/falkordb/FalkorDbImage.java
+++ b/src/test/java/com/falkordb/FalkorDbImage.java
@@ -45,7 +45,8 @@ final class FalkorDbImage {
      * @throws IllegalStateException if {@code override} is not a well-formed Docker image reference
      */
     static DockerImageName resolve(String override) {
-        String image = (override == null || override.trim().isEmpty()) ? DEFAULT : override.trim();
+        String trimmed = (override == null) ? "" : override.trim();
+        String image = trimmed.isEmpty() ? DEFAULT : trimmed;
         try {
             return DockerImageName.parse(image).asCompatibleSubstituteFor("falkordb/falkordb");
         } catch (RuntimeException e) {

--- a/src/test/java/com/falkordb/FalkorDbImage.java
+++ b/src/test/java/com/falkordb/FalkorDbImage.java
@@ -1,0 +1,40 @@
+package com.falkordb;
+
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Resolves the FalkorDB container image used by {@link TestServer}.
+ *
+ * <p>Extracted from {@code TestServer} so the resolution logic is unit-testable without triggering
+ * {@code TestServer}'s static initializer (which starts a container). The image can be overridden with
+ * the {@code FALKORDB_IMAGE} system property or environment variable (e.g. {@code
+ * falkordb/falkordb:edge}) to matrix the suite over FalkorDB versions; unset/blank uses the pinned
+ * {@link #DEFAULT} digest.
+ */
+final class FalkorDbImage {
+
+    /** Default pinned digest (v4.20.1) for a reproducible suite; matches the {@code smoke-jdk8} CI image. */
+    static final String DEFAULT =
+            "falkordb/falkordb@sha256:9042fdc4e53f5390ca5a3993aa71506523970efb40ffb9a98e6a4b1a9a4f8862";
+
+    private FalkorDbImage() {}
+
+    /**
+     * Resolves the container image: the trimmed {@code override} if non-blank, otherwise
+     * {@link #DEFAULT}. The result is marked as a compatible substitute for {@code falkordb/falkordb}
+     * so Testcontainers accepts a custom tag or digest.
+     *
+     * @param override the raw {@code FALKORDB_IMAGE} value (system property or env var); may be null
+     * @return the image to run
+     * @throws IllegalStateException if {@code override} is not a well-formed Docker image reference
+     */
+    static DockerImageName resolve(String override) {
+        String image = (override == null || override.trim().isEmpty()) ? DEFAULT : override.trim();
+        try {
+            return DockerImageName.parse(image).asCompatibleSubstituteFor("falkordb/falkordb");
+        } catch (RuntimeException e) {
+            throw new IllegalStateException(
+                    "FALKORDB_IMAGE is not a valid Docker image reference: \"" + image + "\"", e);
+        }
+    }
+}

--- a/src/test/java/com/falkordb/FalkorDbImage.java
+++ b/src/test/java/com/falkordb/FalkorDbImage.java
@@ -20,6 +20,19 @@ final class FalkorDbImage {
     private FalkorDbImage() {}
 
     /**
+     * Picks the effective override from its two sources: the system {@code property} if non-blank,
+     * otherwise the {@code env} value (which may itself be null/blank). A blank system property (e.g.
+     * {@code -DFALKORDB_IMAGE=}) therefore does not shadow a non-blank environment variable.
+     *
+     * @param property the {@code FALKORDB_IMAGE} system property value; may be null
+     * @param env the {@code FALKORDB_IMAGE} environment value; may be null
+     * @return the value to hand to {@link #resolve(String)}
+     */
+    static String pickOverride(String property, String env) {
+        return (property != null && !property.trim().isEmpty()) ? property : env;
+    }
+
+    /**
      * Resolves the container image: the trimmed {@code override} if non-blank, otherwise
      * {@link #DEFAULT}. The result is marked as a compatible substitute for {@code falkordb/falkordb}
      * so Testcontainers accepts a custom tag or digest.

--- a/src/test/java/com/falkordb/FalkorDbImageTest.java
+++ b/src/test/java/com/falkordb/FalkorDbImageTest.java
@@ -1,6 +1,7 @@
 package com.falkordb;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -32,5 +33,29 @@ class FalkorDbImageTest {
     @Test
     void rejectsMalformedOverride() {
         assertThrows(IllegalStateException.class, () -> FalkorDbImage.resolve("bad image::"));
+    }
+
+    @Test
+    void pickOverridePrefersNonBlankProperty() {
+        assertEquals("prop", FalkorDbImage.pickOverride("prop", "env"));
+        assertEquals("  prop  ", FalkorDbImage.pickOverride("  prop  ", null));
+    }
+
+    @Test
+    void pickOverrideFallsBackToEnvWhenPropertyBlankOrNull() {
+        assertEquals("env", FalkorDbImage.pickOverride(null, "env"));
+        assertEquals("env", FalkorDbImage.pickOverride("", "env"));
+        assertEquals("env", FalkorDbImage.pickOverride("   ", "env"));
+        assertNull(FalkorDbImage.pickOverride(null, null));
+    }
+
+    @Test
+    void blankPropertyDoesNotShadowEnvImage() {
+        // Regression: -DFALKORDB_IMAGE= (blank) must not override a real env image and fall back to the
+        // default; the non-blank env value wins.
+        assertEquals(
+                "falkordb/falkordb:edge",
+                FalkorDbImage.resolve(FalkorDbImage.pickOverride("", "falkordb/falkordb:edge"))
+                        .asCanonicalNameString());
     }
 }

--- a/src/test/java/com/falkordb/FalkorDbImageTest.java
+++ b/src/test/java/com/falkordb/FalkorDbImageTest.java
@@ -37,16 +37,24 @@ class FalkorDbImageTest {
 
     @Test
     void pickOverridePrefersNonBlankProperty() {
-        assertEquals("prop", FalkorDbImage.pickOverride("prop", "env"));
-        assertEquals("  prop  ", FalkorDbImage.pickOverride("  prop  ", null));
+        assertEquals("prop", FalkorDbImage.pickOverride("prop", () -> "env"));
+        assertEquals("  prop  ", FalkorDbImage.pickOverride("  prop  ", () -> null));
     }
 
     @Test
     void pickOverrideFallsBackToEnvWhenPropertyBlankOrNull() {
-        assertEquals("env", FalkorDbImage.pickOverride(null, "env"));
-        assertEquals("env", FalkorDbImage.pickOverride("", "env"));
-        assertEquals("env", FalkorDbImage.pickOverride("   ", "env"));
-        assertNull(FalkorDbImage.pickOverride(null, null));
+        assertEquals("env", FalkorDbImage.pickOverride(null, () -> "env"));
+        assertEquals("env", FalkorDbImage.pickOverride("", () -> "env"));
+        assertEquals("env", FalkorDbImage.pickOverride("   ", () -> "env"));
+        assertNull(FalkorDbImage.pickOverride(null, () -> null));
+    }
+
+    @Test
+    void pickOverrideDoesNotReadEnvWhenPropertyIsSet() {
+        // The env supplier must be consulted lazily — not at all when the property is non-blank.
+        assertEquals("prop", FalkorDbImage.pickOverride("prop", () -> {
+            throw new AssertionError("env supplier must not be read when the property is set");
+        }));
     }
 
     @Test
@@ -55,7 +63,7 @@ class FalkorDbImageTest {
         // default; the non-blank env value wins.
         assertEquals(
                 "falkordb/falkordb:edge",
-                FalkorDbImage.resolve(FalkorDbImage.pickOverride("", "falkordb/falkordb:edge"))
+                FalkorDbImage.resolve(FalkorDbImage.pickOverride("", () -> "falkordb/falkordb:edge"))
                         .asCanonicalNameString());
     }
 }

--- a/src/test/java/com/falkordb/FalkorDbImageTest.java
+++ b/src/test/java/com/falkordb/FalkorDbImageTest.java
@@ -1,0 +1,36 @@
+package com.falkordb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link FalkorDbImage#resolve} — the {@code FALKORDB_IMAGE} override resolution. These
+ * only parse image names, so they run without Docker (and without loading {@link TestServer}, whose
+ * static initializer would start a container).
+ */
+class FalkorDbImageTest {
+
+    @Test
+    void defaultsWhenUnsetOrBlank() {
+        assertEquals(FalkorDbImage.DEFAULT, FalkorDbImage.resolve(null).asCanonicalNameString());
+        assertEquals(FalkorDbImage.DEFAULT, FalkorDbImage.resolve("").asCanonicalNameString());
+        assertEquals(FalkorDbImage.DEFAULT, FalkorDbImage.resolve("   ").asCanonicalNameString());
+    }
+
+    @Test
+    void usesTrimmedOverride() {
+        assertEquals(
+                "falkordb/falkordb:edge",
+                FalkorDbImage.resolve("falkordb/falkordb:edge").asCanonicalNameString());
+        assertEquals(
+                "falkordb/falkordb:v4.20.1",
+                FalkorDbImage.resolve("  falkordb/falkordb:v4.20.1  ").asCanonicalNameString());
+    }
+
+    @Test
+    void rejectsMalformedOverride() {
+        assertThrows(IllegalStateException.class, () -> FalkorDbImage.resolve("bad image::"));
+    }
+}

--- a/src/test/java/com/falkordb/TestServer.java
+++ b/src/test/java/com/falkordb/TestServer.java
@@ -13,16 +13,17 @@ import org.testcontainers.utility.DockerImageName;
  * FALKORDB_PORT} to reuse an already-running server instead (no container is started); setting only
  * one is rejected.
  *
+ * <p>Set {@code FALKORDB_IMAGE} (system property or env var, e.g. {@code falkordb/falkordb:edge}) to
+ * run the container against a specific image/tag — used to matrix over FalkorDB versions; unset/blank
+ * uses the pinned {@link FalkorDbImage#DEFAULT} digest. Ignored when the {@code FALKORDB_HOST}/{@code
+ * FALKORDB_PORT} external override is in effect.
+ *
  * <p><strong>External-server safety:</strong> some system tests mutate server-wide state (for example
  * {@code UdfIT} globally lists/deletes UDF libraries). When you point this at an external server via
  * the env override, use a <em>dedicated disposable</em> instance — never a shared or production
  * server. The default container path is always safe because the container is throwaway.
  */
 public final class TestServer {
-
-    // Pinned digest (v4.20.1) so the suite is reproducible; matches the smoke-jdk8 CI job's image.
-    private static final DockerImageName IMAGE = DockerImageName.parse(
-            "falkordb/falkordb@sha256:9042fdc4e53f5390ca5a3993aa71506523970efb40ffb9a98e6a4b1a9a4f8862");
 
     private static final String host;
     private static final int port;
@@ -46,8 +47,10 @@ public final class TestServer {
             port = parsePort(envPort);
         } else {
             external = false;
+            DockerImageName image =
+                    FalkorDbImage.resolve(System.getProperty("FALKORDB_IMAGE", System.getenv("FALKORDB_IMAGE")));
             GenericContainer<?> container =
-                    new GenericContainer<>(IMAGE).withExposedPorts(6379).waitingFor(Wait.forListeningPort());
+                    new GenericContainer<>(image).withExposedPorts(6379).waitingFor(Wait.forListeningPort());
             container.start(); // shared for the whole JVM; Testcontainers' Ryuk stops it at exit
             host = container.getHost();
             port = container.getMappedPort(6379);

--- a/src/test/java/com/falkordb/TestServer.java
+++ b/src/test/java/com/falkordb/TestServer.java
@@ -47,8 +47,8 @@ public final class TestServer {
             port = parsePort(envPort);
         } else {
             external = false;
-            DockerImageName image =
-                    FalkorDbImage.resolve(System.getProperty("FALKORDB_IMAGE", System.getenv("FALKORDB_IMAGE")));
+            DockerImageName image = FalkorDbImage.resolve(
+                    FalkorDbImage.pickOverride(System.getProperty("FALKORDB_IMAGE"), System.getenv("FALKORDB_IMAGE")));
             GenericContainer<?> container =
                     new GenericContainer<>(image).withExposedPorts(6379).waitingFor(Wait.forListeningPort());
             container.start(); // shared for the whole JVM; Testcontainers' Ryuk stops it at exit

--- a/src/test/java/com/falkordb/TestServer.java
+++ b/src/test/java/com/falkordb/TestServer.java
@@ -47,8 +47,8 @@ public final class TestServer {
             port = parsePort(envPort);
         } else {
             external = false;
-            DockerImageName image = FalkorDbImage.resolve(
-                    FalkorDbImage.pickOverride(System.getProperty("FALKORDB_IMAGE"), System.getenv("FALKORDB_IMAGE")));
+            DockerImageName image = FalkorDbImage.resolve(FalkorDbImage.pickOverride(
+                    System.getProperty("FALKORDB_IMAGE"), () -> System.getenv("FALKORDB_IMAGE")));
             GenericContainer<?> container =
                     new GenericContainer<>(image).withExposedPorts(6379).waitingFor(Wait.forListeningPort());
             container.start(); // shared for the whole JVM; Testcontainers' Ryuk stops it at exit


### PR DESCRIPTION
## Wave 4 · PR 13a — overridable FalkorDB test image (`FALKORDB_IMAGE`)

Part of the approved Wave 4 plan (#329), tracked by #332. This is the **foundation** for PR 13's
compatibility matrices: the container image was a hardcoded pinned digest, so the harness couldn't be
pointed at other FalkorDB versions.

### Change
Extract the image into `FalkorDbImage.resolve(override)`:
- Uses the trimmed **`FALKORDB_IMAGE`** system property or env var when non-blank, else the pinned
  **`DEFAULT`** digest (unchanged default behaviour).
- Marks it `asCompatibleSubstituteFor("falkordb/falkordb")` so Testcontainers accepts a custom tag or
  digest (e.g. `falkordb/falkordb:edge`).
- Wraps `DockerImageName.parse` so a malformed value fails with a clear `IllegalStateException`
  instead of the raw `ArrayIndexOutOfBoundsException` that `parse` throws.

It lives in its own class specifically so the resolution is **unit-testable without starting a
container** — referencing `TestServer` triggers its static initializer, which starts one.

### Tests
- `FalkorDbImageTest` (unit, no Docker): default/blank → pinned digest, trimmed override, malformed →
  clear error.
- `TestServer` Javadoc documents the override.

### Validation (via `just`, same as CI)
`just test` — **173 unit tests green** (+3). `ConfigIT` green via **Testcontainers** (default path, so
the container wiring is exercised). `just fmt-check` + `just lint` green.

### Follow-up (13b)
The CI **FalkorDB version matrix** (min + current required, `edge`/`latest` scheduled canaries) and
**JDK runtime matrix** (8/11/17/21 via the `smoke-test` module) that consume this override.
