### PR TITLE
ci: add a JDK runtime matrix (smoke-jdk 11/17/21) via generalized verify-jdk

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -60,6 +60,8 @@ accordingly, and use the `TestServer` helper for server access.
     every **shipped** dependency is Java-8 bytecode.
   - **`just verify-jdk8`** (the `smoke-jdk8` CI job) — runs the packaged jar + full runtime graph on a
     real **JDK 8** against FalkorDB via the no-arg `driver()`, proving Java-8 *runtime* compatibility.
+    The generalized **`just verify-jdk <home>`** runs that same smoke on any JDK, and the **`smoke-jdk`**
+    CI matrix exercises **JDK 11/17/21** too (8 stays in `smoke-jdk8` for its branch-protection context).
 - **`junit-jupiter` stays on 5.x** and **`equalsverifier` on 3.x** (Dependabot ignores their
   semver-major bumps). The JDK-21 build *could* now compile their 6.x/4.x, but raising them is a
   deliberate later change, not automatic — so keep the pins for now.

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -118,4 +118,40 @@ jobs:
       uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
     - name: Build on JDK 21, run the packaged-artifact smoke on JDK 8 (via just)
       run: just verify-jdk8 "$JAVA_HOME_8_X64"
-            
+
+  # JDK runtime matrix: prove the packaged Java-8 artifact also loads and runs on newer JDKs (the
+  # runtime guarantee the compile-time guards can't give). JDK 8 stays in the required `smoke-jdk8`
+  # job above (kept for its branch-protection context); once branch protection requires this matrix,
+  # 8 can be folded in and `smoke-jdk8` retired.
+  smoke-jdk:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: ['11', '17', '21']
+
+    # Same pinned FalkorDB (v4.20.1) as smoke-jdk8, so a runtime regression is isolated from image drift.
+    services:
+      falkordb:
+        image: falkordb/falkordb@sha256:9042fdc4e53f5390ca5a3993aa71506523970efb40ffb9a98e6a4b1a9a4f8862
+        ports:
+          - 6379:6379
+
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
+    - name: Set up JDK ${{ matrix.jdk }} (runtime) and JDK 21 (build)
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      with:
+        java-version: |
+          ${{ matrix.jdk }}
+          21
+        distribution: 'temurin'
+        cache: maven
+    - name: Install just
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+    - name: Build on JDK 21, run the packaged-artifact smoke on JDK ${{ matrix.jdk }} (via just)
+      run: just verify-jdk "$JAVA_HOME_${{ matrix.jdk }}_X64"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for contributing! This guide covers the local workflow and the `just` rec
 - **JDK 21** (the build JDK for PRs, snapshots, and releases). The artifact still targets Java 8
   (compiled with `--release 8`); for day-to-day work you don't need a JDK 8 — only the
   `just verify-jdk8` runtime smoke uses one (`just verify-jdk <home>` runs the same smoke on any JDK;
-  the `smoke-jdk` CI matrix covers 8/11/17/21).
+  CI covers 8/11/17/21 via `smoke-jdk8` plus the `smoke-jdk` 11/17/21 matrix).
 - **[`just`](https://github.com/casey/just)** — `brew install just`, `cargo install just`, or your
   package manager.
 - **Docker** — for a local FalkorDB (the tests need a running server).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,8 @@ Thanks for contributing! This guide covers the local workflow and the `just` rec
 
 - **JDK 21** (the build JDK for PRs, snapshots, and releases). The artifact still targets Java 8
   (compiled with `--release 8`); for day-to-day work you don't need a JDK 8 — only the
-  `just verify-jdk8` runtime smoke uses one.
+  `just verify-jdk8` runtime smoke uses one (`just verify-jdk <home>` runs the same smoke on any JDK;
+  the `smoke-jdk` CI matrix covers 8/11/17/21).
 - **[`just`](https://github.com/casey/just)** — `brew install just`, `cargo install just`, or your
   package manager.
 - **Docker** — for a local FalkorDB (the tests need a running server).

--- a/Justfile
+++ b/Justfile
@@ -60,16 +60,22 @@ test:
 verify:
     ./mvnw -B -Dgpg.skip=true verify
 
-# Prove the PUBLISHED artifact runs on a Java-8 runtime: build+install the jar on the build JDK,
-# then compile+run the standalone JDK-8 runtime smoke against it (pinned to the root project's
-# version). Pass the JDK-8 home, and run a FalkorDB on {{port}} first. CI provides both; locally
-# e.g. `just db-up && just verify-jdk8 ~/.sdkman/candidates/java/8.0.492-zulu`.
-verify-jdk8 jdk8_home:
+# Prove the PUBLISHED artifact runs on a given JDK runtime: build+install the jar on the build JDK,
+# then compile (with `release 8`) + run the standalone runtime smoke against it on the JDK at
+# `jdk_home` (pinned to the root project's version). Proves the Java-8 artifact loads and works on
+# that runtime. Pass the target JDK home, and run a FalkorDB on {{port}} first. CI provides both;
+# locally e.g. `just db-up && just verify-jdk ~/.sdkman/candidates/java/11.0.24-tem`.
+verify-jdk jdk_home:
     #!/usr/bin/env bash
     set -euo pipefail
     ./mvnw -B -DskipTests -Dgpg.skip=true install
     version="$(./mvnw -q -DforceStdout help:evaluate -Dexpression=project.version)"
-    JAVA_HOME="{{jdk8_home}}" ./mvnw -B -f smoke-test/pom.xml -Djfalkordb.version="$version" test
+    JAVA_HOME="{{jdk_home}}" ./mvnw -B -f smoke-test/pom.xml -Djfalkordb.version="$version" test
+
+# Java-8 runtime smoke — the required `smoke-jdk8` CI context; a thin alias for `verify-jdk`.
+# e.g. `just db-up && just verify-jdk8 ~/.sdkman/candidates/java/8.0.492-zulu`.
+verify-jdk8 jdk8_home:
+    just verify-jdk "{{jdk8_home}}"
 
 # --- Benchmarks (client load-sweep; standalone module in benchmarks/, never shipped) ---
 


### PR DESCRIPTION
## Wave 4 · 13b (part 1) — JDK runtime matrix (`smoke-jdk` on 11/17/21)

Part of the approved Wave 4 plan (#329), tracked by #332. Follows #342 (the `FALKORDB_IMAGE`
override). Proves the packaged **Java-8 artifact** also loads and runs on newer JDK runtimes — the
runtime guarantee the compile-time guards (`--release 8`, Animal Sniffer, Enforcer) can't give.

### Change
- **Generalize the recipe:** `verify-jdk8 <home>` → **`verify-jdk <home>`** (JDK-agnostic — the smoke
  module is compiled with `release 8` and *run* on the given JDK). `verify-jdk8` stays as a thin alias
  so the required **`smoke-jdk8`** CI context is unchanged.
- **New `smoke-jdk` CI matrix** over **JDK 11/17/21**, each running the packaged-artifact smoke against
  the same pinned FalkorDB (`fail-fast: false`).

Full runtime coverage is now **8** (`smoke-jdk8`) + **11/17/21** (`smoke-jdk`). JDK 8 stays in
`smoke-jdk8` for its branch-protection context; once branch protection requires `smoke-jdk`, 8 folds in
and `smoke-jdk8` retires (an operator step).

### Validation (via `just`, same as CI)
Ran locally against a `just db-up` FalkorDB:
- `just verify-jdk ~/.sdkman/.../11.0.24-tem` → smoke green on **JDK 11**.
- `just verify-jdk8 ~/.sdkman/.../8.0.492-zulu` (the alias) → smoke green on **JDK 8**.

`just spellcheck` green; docs (`copilot-instructions.md`, `CONTRIBUTING.md`) updated.

### Operator step
After merge, update branch protection to require the `smoke-jdk` matrix checks (then 8 can move into
the matrix and `smoke-jdk8` be dropped).

### Follow-up (13b part 2)
The **FalkorDB version matrix** (min + current required, `edge`/`latest` scheduled canaries) via the
`FALKORDB_IMAGE` override — needs a decision on the **minimum supported FalkorDB version** (not
currently documented).
