### PR TITLE
ci: add a scheduled FalkorDB edge/latest version canary

### DIFF
--- a/.github/workflows/version-canary.yml
+++ b/.github/workflows/version-canary.yml
@@ -1,0 +1,50 @@
+name: FalkorDB version canary
+
+# Non-blocking early warning that the client still works against the moving FalkorDB `edge` and
+# `latest` images. Runs on a schedule (and on demand) — NOT on pushes/PRs — so upstream breakage never
+# gates a merge: the required `build`/`smoke-jdk8`/`smoke-jdk` jobs pin the digest (v4.20.1), which is
+# also the current minimum supported version. Uses the `FALKORDB_IMAGE` override so Testcontainers runs
+# the full `just verify` suite against each tag.
+
+on:
+  schedule:
+    - cron: '0 5 * * 1' # weekly, Mondays 05:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: version-canary-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  canary:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - falkordb/falkordb:edge
+          - falkordb/falkordb:latest
+
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
+    - name: Set up JDK 21
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+    - name: Install just
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+    # FALKORDB_IMAGE is read by the TestServer harness (FalkorDbImage.resolve) so the whole suite runs
+    # against this tag instead of the pinned default digest.
+    - name: Build & test against ${{ matrix.image }} (via just)
+      env:
+        FALKORDB_IMAGE: ${{ matrix.image }}
+      run: just verify


### PR DESCRIPTION
## Wave 4 · 13b (part 2) — scheduled FalkorDB `edge`/`latest` version canary

Part of the approved Wave 4 plan (#329), tracked by #332. Completes PR 13's compatibility matrices,
building on the `FALKORDB_IMAGE` override (#342) and the JDK matrix (#343).

### What & why
A new **non-blocking** workflow (`version-canary.yml`) that runs the full `just verify` suite against
the moving **`falkordb/falkordb:edge`** and **`:latest`** images via the `FALKORDB_IMAGE` override — an
early warning of upstream breakage.

- Triggers: **`schedule`** (weekly, Mondays 05:00 UTC) + **`workflow_dispatch`** — **never on
  pushes/PRs**, so upstream breakage can't gate a merge.
- `fail-fast: false` so `edge` and `latest` both run.

### Why no separate required "min" job
Per your call, the **minimum supported == current == v4.20.1**, which the required `build` /
`smoke-jdk8` / `smoke-jdk` jobs already pin. So "min + current" *required* coverage already exists; this
PR adds only the moving-target canaries.

### Validation
- Locally: `FALKORDB_IMAGE=falkordb/falkordb:latest` + a Testcontainers IT runs against that tag
  (ConfigIT green); `FalkorDbImage.resolve` reading the env override is unit-tested (#342).
- Workflow YAML validated (triggers, matrix, `FALKORDB_IMAGE` env wiring).

The scheduled runs against `edge`/`latest` will exercise end-to-end after merge (and can be kicked off
manually via **Run workflow**).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added scheduled and manually triggered verification runs against the latest and edge FalkorDB container images.
  * Verification runs now use a consistent Java 21 environment and can automatically cancel outdated concurrent runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->