### PR TITLE
build: add PITest mutation testing (observability, scheduled)

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,45 @@
+name: Mutation testing (PITest)
+
+# PITest is observability, not a gate: it re-runs the fast unit tests against generated mutants to
+# measure test *effectiveness* (are the tests actually asserting behaviour?). It's slow, so it runs on
+# a schedule (and on demand) via `just mutation`, never on push/PR. Scoped to the pure-unit packages,
+# so no FalkorDB server is needed.
+
+on:
+  schedule:
+    - cron: '0 4 * * 1' # weekly, Mondays 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mutation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mutation:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
+    - name: Set up JDK 21
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+    - name: Install just
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+    - name: Mutation testing (via just)
+      run: just mutation
+    - name: Upload PITest HTML report
+      if: always()
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: pit-report
+        path: target/pit-reports
+        if-no-files-found: warn

--- a/Justfile
+++ b/Justfile
@@ -34,6 +34,12 @@ lint:
 audit:
     ./mvnw -B -Pquality -DskipTests -Dgpg.skip=true org.owasp:dependency-check-maven:check
 
+# Mutation testing (PITest) — OBSERVABILITY only, never a gate. Runs under the off-by-default
+# `quality` profile against the pure-unit packages (server-free, so no FalkorDB needed); HTML/XML
+# report in `target/pit-reports`. Run by the scheduled/manual `mutation` workflow.
+mutation:
+    ./mvnw -B -Pquality -Dgpg.skip=true test-compile org.pitest:pitest-maven:mutationCoverage
+
 # Public-API compatibility diff (japicmp): package the jar, then compare it against the last release
 # on Maven Central and fail on binary/source-incompatible PUBLIC-API changes (`com.falkordb.impl` is
 # internal and excluded). This is the CI `api-diff` gate. A reviewed, intentional break is approved

--- a/pom.xml
+++ b/pom.xml
@@ -428,6 +428,42 @@
 							</parameter>
 						</configuration>
 					</plugin>
+					<!-- PITest mutation testing: OBSERVABILITY ONLY — never bound to a phase or a gate.
+					     Invoked on demand via `just mutation` (the scheduled/manual `mutation` workflow).
+					     Scoped to the pure-unit packages whose fast unit tests can actually kill mutants;
+					     `*IT` (server-backed) and the expensive jqwik property test are excluded so PIT
+					     doesn't discover + re-run them per mutation. -->
+					<plugin>
+						<groupId>org.pitest</groupId>
+						<artifactId>pitest-maven</artifactId>
+						<version>1.19.4</version>
+						<dependencies>
+							<dependency>
+								<groupId>org.pitest</groupId>
+								<artifactId>pitest-junit5-plugin</artifactId>
+								<version>1.2.3</version>
+							</dependency>
+						</dependencies>
+						<configuration>
+							<targetClasses>
+								<param>com.falkordb.graph_entities.*</param>
+								<param>com.falkordb.impl.Utils*</param>
+							</targetClasses>
+							<targetTests>
+								<param>com.falkordb.graph_entities.*Test</param>
+								<param>com.falkordb.impl.UtilsTest</param>
+							</targetTests>
+							<excludedTestClasses>
+								<param>com.falkordb.impl.UtilsParamPropertyTest</param>
+							</excludedTestClasses>
+							<outputFormats>
+								<param>HTML</param>
+								<param>XML</param>
+							</outputFormats>
+							<timestampedReports>false</timestampedReports>
+							<failWhenNoMutations>false</failWhenNoMutations>
+						</configuration>
+					</plugin>
 				</plugins>
 			</build>
 		</profile>


### PR DESCRIPTION
## Wave 4 · PR 14 — mutation testing (PITest), observability only

Part of the approved Wave 4 plan (#329), tracked by #332. Adds **PITest** to measure test
*effectiveness* (do the tests actually assert behaviour, not just execute it?). **Never a required
gate** — it's slow, so it runs on a schedule / on demand, like `just audit`.

### What
- **`pitest-maven` 1.19.4 + `pitest-junit5-plugin` 1.2.3** in the off-by-default **`quality`** profile,
  **unbound** (invoked explicitly, never in `verify`).
- **`just mutation`** recipe.
- **`mutation.yml`** workflow — `schedule` (weekly) + `workflow_dispatch`, uploads the HTML report as
  an artifact. No FalkorDB service (scoped to server-free unit code).

### Scope (why it's meaningful, not noisy)
Targets only the **pure-unit packages** whose fast unit tests can actually kill mutants:
`com.falkordb.graph_entities.*` and `com.falkordb.impl.Utils*`. `*IT` (server-backed) and the
expensive jqwik property test (`UtilsParamPropertyTest`) are **excluded** so PIT doesn't discover and
re-run them per mutation.

### Validation (via `just`, same as CI)
`just mutation` locally: **205 mutations, 193 killed (94%), test strength 96%, line coverage 97%**, no
run/memory errors, `BUILD SUCCESS`. `just lint` still green (the `quality` profile is healthy with the
new plugin present). PR checks are unaffected — PITest is not part of `verify`/`lint`.

### Note
PR checks won't run the `mutation` job (it's schedule/dispatch only); kick it off via **Run workflow**
after merge to see the first report.
