### PR TITLE
build: add a strict Javadoc gate (doclint=all) + fix public-API Javadoc

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,7 +23,9 @@ recipe; recipes call the pinned Maven Wrapper (`./mvnw`).
 | `just fmt` / `just fmt-check` | Apply / check palantir-java-format (runs in the `-Pquality` profile). |
 | `just lint` | Static analysis (the CI `lint` gate): format check + **SpotBugs/FindSecBugs** + **Error Prone**, all in the off-by-default `-Pquality` profile. |
 | `just audit` | OWASP dependency-check CVE scan of the shipped deps. Slow + needs `NVD_API_KEY`; run by the scheduled/manual **`audit`** workflow, not on every PR. |
+| `just mutation` | PITest mutation testing of the pure-unit packages (observability, **not** a gate); run by the scheduled/manual **`mutation`** workflow, in the off-by-default `-Pquality` profile. |
 | `just api-diff` | Public-API compatibility diff vs the last release on Maven Central (japicmp, the CI **`api-diff`** gate): fails on binary/source-incompatible changes to the public/protected API (`com.falkordb.impl` excluded), in the off-by-default `-Pquality` profile. Approve a reviewed break with the `breaking-change` PR label. |
+| `just javadoc` | Javadoc gate (the CI **`javadoc`** gate): strict `doclint=all` + `failOnWarnings` on the public/protected API (`com.falkordb.impl` excluded), in the off-by-default `-Pquality` profile. |
 | `just spellcheck` | Spellcheck the Markdown docs (the CI `spellcheck` gate). |
 | `just db-up` / `just db-down` | Manage a local FalkorDB container. |
 | `just bench` / `just bench-one <loads>` | Client load-sweep benchmark — client latency (total − server) vs throughput across concurrency levels; feeds the per-PR-vs-`master` radar + Pages curve. |

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -90,6 +90,25 @@ jobs:
     - name: Static analysis — SpotBugs/FindSecBugs + Error Prone (via just)
       run: just lint
 
+  javadoc:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
+    - name: Set up JDK 21
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+    - name: Install just
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+    - name: Javadoc gate — strict doclint on the public API (via just)
+      run: just javadoc
+
   smoke-jdk8:
 
     runs-on: ubuntu-latest

--- a/Justfile
+++ b/Justfile
@@ -40,6 +40,11 @@ audit:
 mutation:
     ./mvnw -B -Pquality -Dgpg.skip=true test-compile org.pitest:pitest-maven:mutationCoverage
 
+# Javadoc gate: strict doclint (`all`) on the public/protected API, failing on ANY warning. This is
+# the CI `javadoc` gate. `com.falkordb.impl` is internal and excluded (matching `api-diff`).
+javadoc:
+    ./mvnw -B -Pquality -Dgpg.skip=true javadoc:javadoc
+
 # Public-API compatibility diff (japicmp): package the jar, then compare it against the last release
 # on Maven Central and fail on binary/source-incompatible PUBLIC-API changes (`com.falkordb.impl` is
 # internal and excluded). This is the CI `api-diff` gate. A reviewed, intentional break is approved

--- a/pom.xml
+++ b/pom.xml
@@ -478,7 +478,6 @@
 							<failOnWarnings>true</failOnWarnings>
 							<excludePackageNames>com.falkordb.impl:com.falkordb.impl.*</excludePackageNames>
 							<notimestamp>true</notimestamp>
-							<quiet>true</quiet>
 						</configuration>
 					</plugin>
 				</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -464,6 +464,23 @@
 							<failWhenNoMutations>false</failWhenNoMutations>
 						</configuration>
 					</plugin>
+					<!-- Javadoc gate: strict doclint on the PUBLIC/protected API (`com.falkordb.impl` is
+					     internal and excluded, matching the `api-diff` boundary). `failOnWarnings` turns
+					     any doclint gap into a failure. Off-lifecycle — invoked via `just javadoc`. -->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<version>3.12.0</version>
+						<configuration>
+							<source>8</source>
+							<show>protected</show>
+							<doclint>all</doclint>
+							<failOnWarnings>true</failOnWarnings>
+							<excludePackageNames>com.falkordb.impl:com.falkordb.impl.*</excludePackageNames>
+							<notimestamp>true</notimestamp>
+							<quiet>true</quiet>
+						</configuration>
+					</plugin>
 				</plugins>
 			</build>
 		</profile>

--- a/src/main/java/com/falkordb/Header.java
+++ b/src/main/java/com/falkordb/Header.java
@@ -30,11 +30,15 @@ public interface Header {
     }
 
     /**
+     * Returns the schema names.
+     *
      * @return the schema names
      */
     List<String> getSchemaNames();
 
     /**
+     * Returns the schema types.
+     *
      * @return the schema types
      */
     List<ResultSetColumnTypes> getSchemaTypes();

--- a/src/main/java/com/falkordb/ResultSet.java
+++ b/src/main/java/com/falkordb/ResultSet.java
@@ -6,16 +6,22 @@ package com.falkordb;
 public interface ResultSet extends Iterable<Record> {
 
     /**
+     * Returns the number of records in the result set.
+     *
      * @return the number of records in the result set
      */
     int size();
 
     /**
+     * Returns the statistics of the result set.
+     *
      * @return the statistics of the result set
      */
     Statistics getStatistics();
 
     /**
+     * Returns the header of the result set.
+     *
      * @return the header of the result set
      */
     Header getHeader();

--- a/src/main/java/com/falkordb/Statistics.java
+++ b/src/main/java/com/falkordb/Statistics.java
@@ -84,46 +84,64 @@ public interface Statistics {
     String getStringValue(Statistics.Label label);
 
     /**
+     * Returns the number of nodes created.
+     *
      * @return the number of nodes created
      */
     int nodesCreated();
 
     /**
+     * Returns the number of nodes deleted.
+     *
      * @return the number of nodes deleted
      */
     int nodesDeleted();
 
     /**
+     * Returns the number of indices added.
+     *
      * @return the number of indices added
      */
     int indicesAdded();
 
     /**
+     * Returns the number of indices deleted.
+     *
      * @return the number of indices deleted
      */
     int indicesDeleted();
 
     /**
+     * Returns the number of labels added.
+     *
      * @return the number of labels added
      */
     int labelsAdded();
 
     /**
+     * Returns the number of relationships deleted.
+     *
      * @return the number of relationships deleted
      */
     int relationshipsDeleted();
 
     /**
+     * Returns the number of relationships created.
+     *
      * @return the number of relationships created
      */
     int relationshipsCreated();
 
     /**
+     * Returns the number of properties set.
+     *
      * @return the number of properties set
      */
     int propertiesSet();
 
     /**
+     * Returns whether the execution was cached.
+     *
      * @return whether the execution was cached
      */
     boolean cachedExecution();

--- a/src/main/java/com/falkordb/exceptions/GraphException.java
+++ b/src/main/java/com/falkordb/exceptions/GraphException.java
@@ -10,6 +10,8 @@ public class GraphException extends JedisDataException {
     private static final long serialVersionUID = -476099681322055468L;
 
     /**
+     * Creates a GraphException with the given error message.
+     *
      * @param message the error message
      */
     public GraphException(String message) {
@@ -17,6 +19,8 @@ public class GraphException extends JedisDataException {
     }
 
     /**
+     * Creates a GraphException with the given cause.
+     *
      * @param cause the cause of the exception
      */
     public GraphException(Throwable cause) {
@@ -24,6 +28,8 @@ public class GraphException extends JedisDataException {
     }
 
     /**
+     * Creates a GraphException with the given error message and cause.
+     *
      * @param message the error message
      * @param cause the cause of the exception
      */

--- a/src/main/java/com/falkordb/graph_entities/Edge.java
+++ b/src/main/java/com/falkordb/graph_entities/Edge.java
@@ -31,6 +31,8 @@ public class Edge extends GraphEntity {
     // getters & setters
 
     /**
+     * Returns the edge relationship type.
+     *
      * @return the edge relationship type
      */
     public String getRelationshipType() {
@@ -38,6 +40,8 @@ public class Edge extends GraphEntity {
     }
 
     /**
+     * Sets the edge relationship type.
+     *
      * @param relationshipType - the relationship type to be set.
      */
     public void setRelationshipType(String relationshipType) {
@@ -45,6 +49,8 @@ public class Edge extends GraphEntity {
     }
 
     /**
+     * Returns the id of the source node.
+     *
      * @return The id of the source node
      */
     public long getSource() {
@@ -52,6 +58,8 @@ public class Edge extends GraphEntity {
     }
 
     /**
+     * Sets the id of the source node.
+     *
      * @param source - The id of the source node to be set
      */
     public void setSource(long source) {
@@ -59,6 +67,7 @@ public class Edge extends GraphEntity {
     }
 
     /**
+     * Returns the id of the destination node.
      *
      * @return the id of the destination node
      */
@@ -67,6 +76,7 @@ public class Edge extends GraphEntity {
     }
 
     /**
+     * Sets the id of the destination node.
      *
      * @param destination - The id of the destination node to be set
      */

--- a/src/main/java/com/falkordb/graph_entities/GraphEntity.java
+++ b/src/main/java/com/falkordb/graph_entities/GraphEntity.java
@@ -36,6 +36,8 @@ public abstract class GraphEntity {
     // setters & getters
 
     /**
+     * Returns the entity id.
+     *
      * @return entity id
      */
     public long getId() {
@@ -43,6 +45,8 @@ public abstract class GraphEntity {
     }
 
     /**
+     * Sets the entity id.
+     *
      * @param id - entity id to be set
      */
     public void setId(long id) {
@@ -60,6 +64,8 @@ public abstract class GraphEntity {
     }
 
     /**
+     * Returns the entity's property names, as a Set.
+     *
      * @return Entity's property names, as a Set
      */
     public Set<String> getEntityPropertyNames() {
@@ -76,6 +82,8 @@ public abstract class GraphEntity {
     }
 
     /**
+     * Returns the number of properties.
+     *
      * @return number of properties
      */
     public int getNumberOfProperties() {
@@ -83,6 +91,8 @@ public abstract class GraphEntity {
     }
 
     /**
+     * Returns the property with the given name, or {@code null} if not found.
+     *
      * @param propertyName - property name as lookup key (String)
      * @return property object, or null if key is not found
      */
@@ -91,6 +101,8 @@ public abstract class GraphEntity {
     }
 
     /**
+     * Removes the property with the given name.
+     *
      * @param name - the name of the property to be removed
      */
     public void removeProperty(String name) {

--- a/src/main/java/com/falkordb/graph_entities/Node.java
+++ b/src/main/java/com/falkordb/graph_entities/Node.java
@@ -32,6 +32,8 @@ public class Node extends GraphEntity {
     }
 
     /**
+     * Adds a label to the node.
+     *
      * @param label - a label to be add
      */
     public void addLabel(String label) {
@@ -39,6 +41,8 @@ public class Node extends GraphEntity {
     }
 
     /**
+     * Removes a label from the node.
+     *
      * @param label - a label to be removed
      */
     public void removeLabel(String label) {
@@ -46,6 +50,8 @@ public class Node extends GraphEntity {
     }
 
     /**
+     * Returns the label at the given index.
+     *
      * @param index - label index
      * @return the property label
      * @throws IndexOutOfBoundsException if the index is out of range
@@ -56,6 +62,7 @@ public class Node extends GraphEntity {
     }
 
     /**
+     * Returns the number of labels.
      *
      * @return the number of labels
      */

--- a/src/main/java/com/falkordb/graph_entities/Node.java
+++ b/src/main/java/com/falkordb/graph_entities/Node.java
@@ -34,7 +34,7 @@ public class Node extends GraphEntity {
     /**
      * Adds a label to the node.
      *
-     * @param label - a label to be add
+     * @param label - a label to be added
      */
     public void addLabel(String label) {
         labels.add(label);

--- a/src/main/java/com/falkordb/graph_entities/Node.java
+++ b/src/main/java/com/falkordb/graph_entities/Node.java
@@ -53,7 +53,7 @@ public class Node extends GraphEntity {
      * Returns the label at the given index.
      *
      * @param index - label index
-     * @return the property label
+     * @return the label at the given index
      * @throws IndexOutOfBoundsException if the index is out of range
      *                                   ({@code index < 0 || index >= getNumberOfLabels()})
      */

--- a/src/main/java/com/falkordb/graph_entities/Point.java
+++ b/src/main/java/com/falkordb/graph_entities/Point.java
@@ -33,6 +33,8 @@ public final class Point {
     }
 
     /**
+     * Creates a point from a latitude and longitude in degrees.
+     *
      * @param latitude The latitude in degrees, normally in the range [-90.0, +90.0]. Must be finite.
      * @param longitude The longitude in degrees, normally in the range [-180.0, +180.0]. Must be finite.
      * @throws IllegalArgumentException if either coordinate is NaN or infinite
@@ -43,6 +45,8 @@ public final class Point {
     }
 
     /**
+     * Creates a point from a two-element {@code [latitude, longitude]} list.
+     *
      * @param values {@code [latitude, longitude]}
      * @throws IllegalArgumentException if {@code values} is not exactly two finite doubles
      */

--- a/src/main/java/com/falkordb/graph_entities/Property.java
+++ b/src/main/java/com/falkordb/graph_entities/Property.java
@@ -3,7 +3,9 @@ package com.falkordb.graph_entities;
 import java.util.Objects;
 
 /**
- * A Graph entity property. Has a name, type, and value
+ * A Graph entity property. Has a name, type, and value.
+ *
+ * @param <T> the type of the property value
  */
 public class Property<T> {
 
@@ -28,6 +30,8 @@ public class Property<T> {
     }
 
     /**
+     * Returns the property name.
+     *
      * @return property name
      */
     public String getName() {
@@ -35,6 +39,8 @@ public class Property<T> {
     }
 
     /**
+     * Sets the property name.
+     *
      * @param name property name to be set
      */
     public void setName(String name) {
@@ -42,6 +48,8 @@ public class Property<T> {
     }
 
     /**
+     * Returns the property value.
+     *
      * @return property value
      */
     public T getValue() {
@@ -49,6 +57,8 @@ public class Property<T> {
     }
 
     /**
+     * Sets the property value.
+     *
      * @param value property value to be set
      */
     public void setValue(T value) {


### PR DESCRIPTION
## Wave 4 · PR 17 (part 1) — strict Javadoc gate (`doclint=all`)

Part of the approved Wave 4 plan (#329), tracked by #332. Adds a **Javadoc gate** and fixes the
public-API Javadoc so it passes.

### The gate
`maven-javadoc-plugin` in the off-by-default **`quality`** profile: `source 8`, `show=protected`,
**`doclint=all`**, **`failOnWarnings=true`**, scoped to the **public/protected API**
(`com.falkordb.impl` excluded, matching the `api-diff` boundary). Invoked via **`just javadoc`** and a
new CI **`javadoc`** job.

### Fixes (40 doclint gaps)
Turning the gate on surfaced **40** gaps — almost all *"no main description"* (a doc comment with block
tags but no summary sentence), plus a missing `@param <T>` on `Property`. Fixed with concise summaries
across `Property`, `Point`, `Node`, `Edge`, `GraphEntity`, `GraphException`, `ResultSet`, `Header`,
`Statistics`.

### Validation (via `just`, same as CI)
- `just javadoc` → **BUILD SUCCESS, 0 warnings**. The 41 → 18 → 0 progression as I fixed real gaps
  proves the gate is active and actually catches violations.
- `just fmt-check` + `just spellcheck` green. Recipe table documents `just javadoc` (and the
  previously-undocumented `just mutation`).

### Deferred to a follow-up (17b)
- **Pages publishing** — Javadoc into a `gh-pages` subdirectory with shared `concurrency`, coordinated
  with the benchmark publisher (do **not** switch the Pages source). This is the delicate part and
  deserves its own focused PR.
- Short **semver-policy doc**.

### Operator step
After merge, add the `javadoc` check to branch protection's required checks.
