### PR TITLE
ci: publish Javadoc to gh-pages /dev/api + semver policy doc

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -39,3 +39,4 @@ xpath
 uncheck
 webhook
 Webhook
+semver

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -83,6 +83,12 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # Serialize with the Javadoc publisher via the shared gh-pages-publish group so gh-pages pushes
+    # never race (this job's `git push` below does not retry).
+    concurrency:
+      group: gh-pages-publish
+      cancel-in-progress: false
+
     permissions:
       contents: write
 

--- a/.github/workflows/javadoc-pages.yml
+++ b/.github/workflows/javadoc-pages.yml
@@ -1,0 +1,72 @@
+name: Javadoc → Pages
+
+# Publishes the public-API Javadoc to the gh-pages branch under /dev/api on master pushes (the
+# unreleased "dev" docs). The benchmark workflow publishes /dev/bench on the SAME branch, so to avoid
+# clobbering it or racing it this job (a) only ever touches /dev/api and (b) pushes with a rebase-retry
+# loop. It does NOT change the Pages source (still the gh-pages branch), so it cannot break the
+# benchmark site.
+
+on:
+  push:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: javadoc-pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
+    - name: Set up JDK 21
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+    - name: Install just
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+    - name: Generate the public-API Javadoc (via just)
+      run: just javadoc
+    - name: Publish Javadoc to gh-pages /dev/api
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        src="target/reports/apidocs"
+        test -f "$src/index.html"
+        work="$(mktemp -d)"
+        git clone --quiet --branch gh-pages \
+          "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$work"
+        # Replace only /dev/api; /dev/bench and the landing page are left untouched.
+        rm -rf "$work/dev/api"
+        mkdir -p "$work/dev/api"
+        cp -R "$src/." "$work/dev/api/"
+        cd "$work"
+        if [ -z "$(git status --porcelain)" ]; then
+          echo "Javadoc unchanged"; exit 0
+        fi
+        git add dev/api
+        git -c user.name='github-actions[bot]' \
+            -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+            commit -m "chore(docs): update dev Javadoc [skip ci]"
+        # A concurrent benchmark push (which only touches /dev/bench) can't conflict with /dev/api, so
+        # rebase-and-retry on a non-fast-forward push.
+        for _ in 1 2 3 4 5; do
+          if git push origin gh-pages; then exit 0; fi
+          git pull --rebase origin gh-pages
+        done
+        echo "failed to push Javadoc to gh-pages after retries" >&2
+        exit 1

--- a/.github/workflows/javadoc-pages.yml
+++ b/.github/workflows/javadoc-pages.yml
@@ -45,10 +45,13 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         set -euo pipefail
+        # javadoc:javadoc writes to <reportOutputDirectory>/apidocs — target/reports on Maven 3.9+ or
+        # the older target/site; accept whichever exists.
         src="target/reports/apidocs"
+        [ -f "$src/index.html" ] || src="target/site/apidocs"
         test -f "$src/index.html"
         work="$(mktemp -d)"
-        git clone --quiet --branch gh-pages \
+        git clone --quiet --depth 1 --single-branch --branch gh-pages \
           "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$work"
         # Replace only /dev/api; /dev/bench and the landing page are left untouched.
         rm -rf "$work/dev/api"

--- a/.github/workflows/javadoc-pages.yml
+++ b/.github/workflows/javadoc-pages.yml
@@ -14,14 +14,16 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: javadoc-pages-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   publish:
 
     runs-on: ubuntu-latest
+
+    # Serialize every gh-pages publisher (this + the benchmark master publish) via one shared group so
+    # their pushes never race — the benchmark publisher does a plain, non-retrying `git push`.
+    concurrency:
+      group: gh-pages-publish
+      cancel-in-progress: false
 
     permissions:
       contents: write

--- a/docs/semver-policy.md
+++ b/docs/semver-policy.md
@@ -1,7 +1,9 @@
 # Versioning &amp; API-compatibility policy
 
-JFalkorDB follows [Semantic Versioning](https://semver.org). The project has **not yet reached 1.0**,
-so a breaking change bumps the **minor** version (`0.x` &rarr; `0.(x+1)`), per semver clause 6.
+JFalkorDB follows [Semantic Versioning](https://semver.org). The project has **not yet reached 1.0**;
+while it is in `0.x`, a **breaking change bumps the minor version** (`0.x` &rarr; `0.(x+1)`) &mdash; the
+`bump-minor-pre-major` convention configured in release-please. (Semver itself leaves `0.y.z`
+unconstrained: during initial development anything may change.)
 
 ## The public API
 

--- a/docs/semver-policy.md
+++ b/docs/semver-policy.md
@@ -1,0 +1,25 @@
+# Versioning &amp; API-compatibility policy
+
+JFalkorDB follows [Semantic Versioning](https://semver.org). The project has **not yet reached 1.0**,
+so a breaking change bumps the **minor** version (`0.x` &rarr; `0.(x+1)`), per semver clause 6.
+
+## The public API
+
+The **public/protected API** is everything **outside** `com.falkordb.impl`. `com.falkordb.impl` is
+internal and may change at any time &mdash; do not depend on it.
+
+## How compatibility is enforced (automatically)
+
+- **`api-diff`** (japicmp, `just api-diff`) &mdash; a per-PR gate that diffs the built jar against the
+  last release on Maven Central and **fails on any binary- or source-incompatible** change to the
+  public/protected API. An intentional, reviewed break is approved with the **`breaking-change`** PR
+  label; the PR title must then carry a `!` (for example `fix!:` / `feat!:`), which the **PR-title**
+  gate enforces so the release is versioned correctly.
+- **`javadoc`** (`just javadoc`) &mdash; a strict `doclint` gate that keeps the public API documented.
+
+## Releases
+
+Releases are automated by **release-please**: conventional-commit merges to `master` accrue into a
+Release PR that bumps the version and `CHANGELOG.md`; merging that PR tags `vX.Y.Z` and publishes to
+Maven Central. A `feat:` / `fix!:` / breaking change therefore maps to the correct semver bump
+automatically.


### PR DESCRIPTION
## Wave 4 · PR 17b — publish Javadoc to gh-pages `/dev/api` + semver policy doc

Completes item 17 (follows the gate in #346). Two pieces:

### 1. Javadoc → Pages
A `javadoc-pages.yml` workflow that, **on master pushes** (and on demand), generates the public-API
Javadoc (`just javadoc`) and publishes it to the **gh-pages** branch under **`/dev/api`** (the
unreleased "dev" docs).

**Coordination with the benchmark publisher** (which writes `/dev/bench` on the same branch):
- This job **only ever touches `/dev/api`** — verified by a local dry-run that stages nothing under
  `/dev/bench` or the landing page.
- It pushes with a **rebase-retry loop**, so a concurrent benchmark push (disjoint subdir) can't race
  it.
- It does **not** switch the Pages source (still the `gh-pages` branch), so it **cannot break the
  benchmark site** — exactly as the plan requires.

### 2. `docs/semver-policy.md`
A short policy doc referencing `api-diff`, the `breaking-change` label + the PR-title `!` gate,
`javadoc`, and release-please.

### Validation
- `just javadoc` generates `target/reports/apidocs`; workflow YAML valid.
- **Dry-run** of the publish script against a real `gh-pages` clone: stages **only** `dev/api`.
- `just spellcheck` green (`semver` added to the wordlist).

> The gh-pages **push** itself only runs post-merge on master (it needs `contents: write` and the real
> branch), so that final step is validated by design/dry-run here and will run for real on merge.

### Operator note
The published docs will be at `…/JFalkorDB/dev/api/`. No Pages settings change is needed (source stays
the `gh-pages` branch).
