### PR TITLE
feat: add FalkorDB.builder() fluent configuration API

### DIFF
--- a/src/main/java/com/falkordb/FalkorDB.java
+++ b/src/main/java/com/falkordb/FalkorDB.java
@@ -2,6 +2,7 @@ package com.falkordb;
 
 import com.falkordb.impl.api.DriverImpl;
 import java.net.URI;
+import java.time.Duration;
 
 /**
  * FalkorDB driver factory
@@ -51,5 +52,236 @@ public final class FalkorDB {
      */
     public static Driver driver(URI uri) {
         return new DriverImpl(uri);
+    }
+
+    /**
+     * Starts building a driver with a fluent, discoverable configuration API — a superset of the
+     * {@code driver(...)} factories that also exposes TLS, connection-pool sizing, and timeouts.
+     *
+     * <p>With no options set, {@link Builder#build()} produces a driver identical to {@link #driver()}
+     * (host {@code localhost}, port {@code 6379}, no credentials, no TLS, Jedis' default 2000&nbsp;ms
+     * connect timeout, no socket read deadline, and the default connection pool). For example:
+     *
+     * <pre>{@code
+     * Driver driver = FalkorDB.builder()
+     *     .host("db.example.com")
+     *     .port(6380)
+     *     .credentials("user", "password")
+     *     .ssl(true)
+     *     .poolMaxTotal(64)
+     *     .connectionTimeout(Duration.ofSeconds(2))
+     *     .build();
+     * }</pre>
+     *
+     * <p>To connect from a URI, keep using {@link #driver(URI)}.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A fluent builder for a {@link Driver}, created via {@link FalkorDB#builder()}.
+     *
+     * <p>All options are optional; unset options fall back to the same defaults as {@link
+     * FalkorDB#driver()}. Instances are not thread-safe and are intended to be configured and
+     * {@linkplain #build() built} on a single thread. Validation happens in {@link #build()}.
+     */
+    public static final class Builder {
+
+        private String host = "localhost";
+        private int port = 6379;
+        private String user;
+        private String password;
+        private boolean ssl;
+        private Duration connectionTimeout;
+        private Duration socketTimeout;
+        private Integer poolMaxTotal;
+        private Integer poolMaxIdle;
+        private Duration poolMaxWait;
+
+        private Builder() {}
+
+        /**
+         * Sets the server host (default {@code "localhost"}).
+         *
+         * @param host server host; must not be {@code null} or blank
+         * @return this builder
+         */
+        public Builder host(String host) {
+            this.host = host;
+            return this;
+        }
+
+        /**
+         * Sets the server port (default {@code 6379}).
+         *
+         * @param port server port; must be in {@code [1, 65535]}
+         * @return this builder
+         */
+        public Builder port(int port) {
+            this.port = port;
+            return this;
+        }
+
+        /**
+         * Sets the username and password used to authenticate.
+         *
+         * @param user     username
+         * @param password password
+         * @return this builder
+         */
+        public Builder credentials(String user, String password) {
+            this.user = user;
+            this.password = password;
+            return this;
+        }
+
+        /**
+         * Sets a password for password-only ({@code default} user) authentication, clearing any
+         * previously set username.
+         *
+         * @param password password
+         * @return this builder
+         */
+        public Builder credentials(String password) {
+            this.user = null;
+            this.password = password;
+            return this;
+        }
+
+        /**
+         * Enables or disables TLS (default {@code false}).
+         *
+         * @param ssl whether to connect over TLS
+         * @return this builder
+         */
+        public Builder ssl(boolean ssl) {
+            this.ssl = ssl;
+            return this;
+        }
+
+        /**
+         * Sets the maximum connection-pool size (default {@code 8}).
+         *
+         * @param poolMaxTotal maximum number of connections; must be at least {@code 1}
+         * @return this builder
+         */
+        public Builder poolMaxTotal(int poolMaxTotal) {
+            this.poolMaxTotal = poolMaxTotal;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of idle connections kept in the pool (default {@code 8}).
+         *
+         * @param poolMaxIdle maximum idle connections; must be non-negative and no greater than the
+         *                    pool's {@code maxTotal}
+         * @return this builder
+         */
+        public Builder poolMaxIdle(int poolMaxIdle) {
+            this.poolMaxIdle = poolMaxIdle;
+            return this;
+        }
+
+        /**
+         * Sets the maximum time to wait for a connection when the pool is exhausted (default: wait
+         * indefinitely). A negative duration waits indefinitely; {@link Duration#ZERO} fails fast.
+         *
+         * @param poolMaxWait maximum borrow wait
+         * @return this builder
+         */
+        public Builder poolMaxWait(Duration poolMaxWait) {
+            this.poolMaxWait = poolMaxWait;
+            return this;
+        }
+
+        /**
+         * Sets the connection (connect) timeout (default 2000&nbsp;ms). {@link Duration#ZERO} means an
+         * infinite connect wait, which is allowed but not recommended.
+         *
+         * @param connectionTimeout connect timeout; must not be negative
+         * @return this builder
+         */
+        public Builder connectionTimeout(Duration connectionTimeout) {
+            this.connectionTimeout = connectionTimeout;
+            return this;
+        }
+
+        /**
+         * Sets the socket (read) timeout (default {@link Duration#ZERO} = no read deadline, so a
+         * long-running server query is never cut off client-side).
+         *
+         * @param socketTimeout read timeout; must not be negative
+         * @return this builder
+         */
+        public Builder socketTimeout(Duration socketTimeout) {
+            this.socketTimeout = socketTimeout;
+            return this;
+        }
+
+        /**
+         * Validates the configuration and builds a driver. Unset options use the same defaults as
+         * {@link FalkorDB#driver()}.
+         *
+         * @return a new driver
+         * @throws IllegalArgumentException if any option is out of range (see the individual setters)
+         */
+        public Driver build() {
+            if (host == null || host.trim().isEmpty()) {
+                throw new IllegalArgumentException("host must not be null or blank");
+            }
+            if (port < 1 || port > 65535) {
+                throw new IllegalArgumentException("port must be in [1, 65535], but was " + port);
+            }
+            int maxTotal = poolMaxTotal == null ? DriverImpl.DEFAULT_POOL_MAX_TOTAL : poolMaxTotal;
+            if (maxTotal < 1) {
+                throw new IllegalArgumentException("poolMaxTotal must be at least 1, but was " + maxTotal);
+            }
+            int maxIdle = poolMaxIdle == null ? DriverImpl.DEFAULT_POOL_MAX_IDLE : poolMaxIdle;
+            if (maxIdle < 0) {
+                throw new IllegalArgumentException("poolMaxIdle must not be negative, but was " + maxIdle);
+            }
+            if (maxIdle > maxTotal) {
+                throw new IllegalArgumentException(
+                        "poolMaxIdle (" + maxIdle + ") must not exceed poolMaxTotal (" + maxTotal + ")");
+            }
+            Duration maxWait = poolMaxWait == null ? DriverImpl.DEFAULT_POOL_MAX_WAIT : poolMaxWait;
+            int connectMillis = connectionTimeout == null
+                    ? DriverImpl.DEFAULT_CONNECTION_TIMEOUT_MILLIS
+                    : toTimeoutMillis(connectionTimeout, "connectionTimeout");
+            int socketMillis = socketTimeout == null
+                    ? DriverImpl.DEFAULT_SOCKET_TIMEOUT_MILLIS
+                    : toTimeoutMillis(socketTimeout, "socketTimeout");
+            return DriverImpl.create(
+                    host, port, user, password, ssl, connectMillis, socketMillis, maxTotal, maxIdle, maxWait);
+        }
+
+        /**
+         * Converts a Jedis timeout {@link Duration} to non-negative {@code int} milliseconds: rejects
+         * {@code null}/negative and values above {@link Integer#MAX_VALUE} ms, and rounds a positive
+         * sub-millisecond duration up to {@code 1} ms so it never collapses to {@code 0} ("infinite").
+         */
+        private static int toTimeoutMillis(Duration duration, String name) {
+            if (duration.isNegative()) {
+                throw new IllegalArgumentException(name + " must not be negative, but was " + duration);
+            }
+            // Guard the seconds component before Duration.toMillis(), which itself throws
+            // ArithmeticException (not IllegalArgumentException) once the value overflows a long.
+            if (duration.getSeconds() > Integer.MAX_VALUE / 1000L) {
+                throw new IllegalArgumentException(
+                        name + " must not exceed " + Integer.MAX_VALUE + " ms, but was " + duration);
+            }
+            long millis = duration.toMillis();
+            if (millis > Integer.MAX_VALUE) {
+                throw new IllegalArgumentException(
+                        name + " must not exceed " + Integer.MAX_VALUE + " ms, but was " + millis + " ms");
+            }
+            if (millis == 0 && !duration.isZero()) {
+                return 1;
+            }
+            return (int) millis;
+        }
     }
 }

--- a/src/main/java/com/falkordb/FalkorDB.java
+++ b/src/main/java/com/falkordb/FalkorDB.java
@@ -223,30 +223,14 @@ public final class FalkorDB {
 
         /**
          * Validates the configuration and builds a driver. Unset options use the same defaults as
-         * {@link FalkorDB#driver()}.
+         * {@link FalkorDB#driver()}. Range validation happens in {@link DriverImpl#create}.
          *
          * @return a new driver
          * @throws IllegalArgumentException if any option is out of range (see the individual setters)
          */
         public Driver build() {
-            if (host == null || host.trim().isEmpty()) {
-                throw new IllegalArgumentException("host must not be null or blank");
-            }
-            if (port < 1 || port > 65535) {
-                throw new IllegalArgumentException("port must be in [1, 65535], but was " + port);
-            }
             int maxTotal = poolMaxTotal == null ? DriverImpl.DEFAULT_POOL_MAX_TOTAL : poolMaxTotal;
-            if (maxTotal < 1) {
-                throw new IllegalArgumentException("poolMaxTotal must be at least 1, but was " + maxTotal);
-            }
             int maxIdle = poolMaxIdle == null ? DriverImpl.DEFAULT_POOL_MAX_IDLE : poolMaxIdle;
-            if (maxIdle < 0) {
-                throw new IllegalArgumentException("poolMaxIdle must not be negative, but was " + maxIdle);
-            }
-            if (maxIdle > maxTotal) {
-                throw new IllegalArgumentException(
-                        "poolMaxIdle (" + maxIdle + ") must not exceed poolMaxTotal (" + maxTotal + ")");
-            }
             Duration maxWait = poolMaxWait == null ? DriverImpl.DEFAULT_POOL_MAX_WAIT : poolMaxWait;
             int connectMillis = connectionTimeout == null
                     ? DriverImpl.DEFAULT_CONNECTION_TIMEOUT_MILLIS
@@ -260,8 +244,9 @@ public final class FalkorDB {
 
         /**
          * Converts a Jedis timeout {@link Duration} to non-negative {@code int} milliseconds: rejects
-         * {@code null}/negative and values above {@link Integer#MAX_VALUE} ms, and rounds a positive
+         * negative values and values above {@link Integer#MAX_VALUE} ms, and rounds a positive
          * sub-millisecond duration up to {@code 1} ms so it never collapses to {@code 0} ("infinite").
+         * A {@code null} duration never reaches here — {@link #build()} maps it to the default instead.
          */
         private static int toTimeoutMillis(Duration duration, String name) {
             if (duration.isNegative()) {

--- a/src/main/java/com/falkordb/impl/api/DriverImpl.java
+++ b/src/main/java/com/falkordb/impl/api/DriverImpl.java
@@ -100,10 +100,10 @@ public class DriverImpl implements Driver {
     /**
      * Creates a driver from already-resolved connection settings (used by {@code FalkorDB.builder()}).
      *
-     * <p>Assembles a Jedis client config (credentials, optional TLS, and the two timeouts) and a
-     * commons-pool2 pool config (sizing plus borrow-wait), then wraps a {@link JedisPool} built from
-     * them. This is internal wiring — prefer {@code com.falkordb.FalkorDB.builder()} over calling it
-     * directly.
+     * <p>Validates its arguments, then assembles a Jedis client config (credentials, optional TLS, and
+     * the two timeouts) and a commons-pool2 pool config (sizing plus borrow-wait), and wraps a {@link
+     * JedisPool} built from them. This is internal wiring — prefer {@code com.falkordb.FalkorDB.builder()}
+     * over calling it directly.
      *
      * @param host                     server host
      * @param port                     server port
@@ -117,6 +117,9 @@ public class DriverImpl implements Driver {
      * @param poolMaxWait              maximum time to wait for a connection when the pool is exhausted
      *                                 (negative = wait indefinitely, {@link Duration#ZERO} = fail fast)
      * @return a new driver backed by the assembled pool
+     * @throws IllegalArgumentException if {@code host} is null/blank, {@code port} is outside
+     *                                  {@code [1, 65535]}, the pool sizing is invalid, a timeout is
+     *                                  negative, or {@code poolMaxWait} is null
      */
     public static Driver create(
             String host,
@@ -129,6 +132,33 @@ public class DriverImpl implements Driver {
             int poolMaxTotal,
             int poolMaxIdle,
             Duration poolMaxWait) {
+        if (host == null || host.trim().isEmpty()) {
+            throw new IllegalArgumentException("host must not be null or blank");
+        }
+        if (port < 1 || port > 65535) {
+            throw new IllegalArgumentException("port must be in [1, 65535], but was " + port);
+        }
+        if (poolMaxTotal < 1) {
+            throw new IllegalArgumentException("poolMaxTotal must be at least 1, but was " + poolMaxTotal);
+        }
+        if (poolMaxIdle < 0) {
+            throw new IllegalArgumentException("poolMaxIdle must not be negative, but was " + poolMaxIdle);
+        }
+        if (poolMaxIdle > poolMaxTotal) {
+            throw new IllegalArgumentException(
+                    "poolMaxIdle (" + poolMaxIdle + ") must not exceed poolMaxTotal (" + poolMaxTotal + ")");
+        }
+        if (connectionTimeoutMillis < 0) {
+            throw new IllegalArgumentException(
+                    "connectionTimeoutMillis must not be negative, but was " + connectionTimeoutMillis);
+        }
+        if (socketTimeoutMillis < 0) {
+            throw new IllegalArgumentException(
+                    "socketTimeoutMillis must not be negative, but was " + socketTimeoutMillis);
+        }
+        if (poolMaxWait == null) {
+            throw new IllegalArgumentException("poolMaxWait must not be null");
+        }
         return new DriverImpl(new JedisPool(
                 buildPoolConfig(poolMaxTotal, poolMaxIdle, poolMaxWait),
                 new HostAndPort(host, port),

--- a/src/main/java/com/falkordb/impl/api/DriverImpl.java
+++ b/src/main/java/com/falkordb/impl/api/DriverImpl.java
@@ -2,6 +2,7 @@ package com.falkordb.impl.api;
 
 import com.falkordb.Driver;
 import java.net.URI;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
@@ -10,6 +11,7 @@ import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.Protocol;
+import redis.clients.jedis.SslOptions;
 import redis.clients.jedis.util.Pool;
 import redis.clients.jedis.util.SafeEncoder;
 
@@ -26,9 +28,28 @@ public class DriverImpl implements Driver {
      * duplicate writes. Query duration is governed by the server's TIMEOUT /
      * TIMEOUT_DEFAULT configuration (or a per-query timeout) instead, matching the other
      * FalkorDB clients. To use a different socket timeout, build your own pool and pass
-     * it to {@link #DriverImpl(Pool)}.
+     * it to {@link #DriverImpl(Pool)}. Also the default socket timeout applied by {@link #create}
+     * when the caller does not specify one.
      */
-    private static final int DEFAULT_SOCKET_TIMEOUT_MILLIS = 0;
+    public static final int DEFAULT_SOCKET_TIMEOUT_MILLIS = 0;
+
+    /**
+     * Default connection (connect) timeout in milliseconds applied by {@link #create} when the
+     * caller does not specify one: Jedis' {@link Protocol#DEFAULT_TIMEOUT} (2000&nbsp;ms).
+     */
+    public static final int DEFAULT_CONNECTION_TIMEOUT_MILLIS = Protocol.DEFAULT_TIMEOUT;
+
+    /** Default maximum pool size ({@code maxTotal}) applied by {@link #create}: commons-pool2's {@code 8}. */
+    public static final int DEFAULT_POOL_MAX_TOTAL = GenericObjectPoolConfig.DEFAULT_MAX_TOTAL;
+
+    /** Default maximum idle connections ({@code maxIdle}) applied by {@link #create}: commons-pool2's {@code 8}. */
+    public static final int DEFAULT_POOL_MAX_IDLE = GenericObjectPoolConfig.DEFAULT_MAX_IDLE;
+
+    /**
+     * Default pool borrow wait ({@code maxWait}) applied by {@link #create}: commons-pool2's
+     * {@code -1ms}, i.e. wait indefinitely for a connection when the pool is exhausted.
+     */
+    public static final Duration DEFAULT_POOL_MAX_WAIT = GenericObjectPoolConfig.DEFAULT_MAX_WAIT;
 
     private final Pool<Jedis> pool;
 
@@ -65,21 +86,87 @@ public class DriverImpl implements Driver {
     }
 
     /**
-     * Builds the client configuration used by this driver: Jedis' default connection
-     * timeout, no socket (read) timeout (see {@link #DEFAULT_SOCKET_TIMEOUT_MILLIS}),
-     * and the given credentials when provided.
+     * Builds the client configuration used by the legacy host/port factories: Jedis' default
+     * connection timeout, no socket (read) timeout (see {@link #DEFAULT_SOCKET_TIMEOUT_MILLIS}),
+     * and the given credentials when provided. Delegates to {@link #buildClientConfig} so the
+     * {@code driver(host, port[, user, password])} factories and the {@code FalkorDB.builder()}
+     * defaults resolve to an identical configuration.
      */
-    private static DefaultJedisClientConfig clientConfig(String user, final String password) {
+    static DefaultJedisClientConfig clientConfig(String user, final String password) {
+        return buildClientConfig(
+                user, password, false, DEFAULT_CONNECTION_TIMEOUT_MILLIS, DEFAULT_SOCKET_TIMEOUT_MILLIS);
+    }
+
+    /**
+     * Creates a driver from already-resolved connection settings (used by {@code FalkorDB.builder()}).
+     *
+     * <p>Assembles a Jedis client config (credentials, optional TLS, and the two timeouts) and a
+     * commons-pool2 pool config (sizing plus borrow-wait), then wraps a {@link JedisPool} built from
+     * them. This is internal wiring — prefer {@code com.falkordb.FalkorDB.builder()} over calling it
+     * directly.
+     *
+     * @param host                     server host
+     * @param port                     server port
+     * @param user                     username, or {@code null} for none
+     * @param password                 password, or {@code null} for none
+     * @param ssl                      whether to connect over TLS
+     * @param connectionTimeoutMillis  connection (connect) timeout in milliseconds
+     * @param socketTimeoutMillis      socket (read) timeout in milliseconds ({@code 0} = no deadline)
+     * @param poolMaxTotal             maximum pool size
+     * @param poolMaxIdle              maximum idle connections in the pool
+     * @param poolMaxWait              maximum time to wait for a connection when the pool is exhausted
+     *                                 (negative = wait indefinitely, {@link Duration#ZERO} = fail fast)
+     * @return a new driver backed by the assembled pool
+     */
+    public static Driver create(
+            String host,
+            int port,
+            String user,
+            String password,
+            boolean ssl,
+            int connectionTimeoutMillis,
+            int socketTimeoutMillis,
+            int poolMaxTotal,
+            int poolMaxIdle,
+            Duration poolMaxWait) {
+        return new DriverImpl(new JedisPool(
+                buildPoolConfig(poolMaxTotal, poolMaxIdle, poolMaxWait),
+                new HostAndPort(host, port),
+                buildClientConfig(user, password, ssl, connectionTimeoutMillis, socketTimeoutMillis)));
+    }
+
+    /**
+     * Builds a Jedis client config from resolved settings. TLS is enabled through the non-deprecated
+     * {@link SslOptions#defaults()} path rather than the deprecated {@code ssl(boolean)} setter.
+     */
+    static DefaultJedisClientConfig buildClientConfig(
+            String user, String password, boolean ssl, int connectionTimeoutMillis, int socketTimeoutMillis) {
         DefaultJedisClientConfig.Builder builder = DefaultJedisClientConfig.builder()
-                .connectionTimeoutMillis(Protocol.DEFAULT_TIMEOUT)
-                .socketTimeoutMillis(DEFAULT_SOCKET_TIMEOUT_MILLIS);
+                .connectionTimeoutMillis(connectionTimeoutMillis)
+                .socketTimeoutMillis(socketTimeoutMillis);
         if (user != null) {
             builder.user(user);
         }
         if (password != null) {
             builder.password(password);
         }
+        if (ssl) {
+            builder.sslOptions(SslOptions.defaults());
+        }
         return builder.build();
+    }
+
+    /**
+     * Builds a commons-pool2 config from resolved sizing settings. {@code maxWait} is passed through
+     * as a {@link Duration} with commons-pool2's native semantics (negative = wait indefinitely,
+     * {@link Duration#ZERO} = fail fast when exhausted).
+     */
+    static GenericObjectPoolConfig<Jedis> buildPoolConfig(int maxTotal, int maxIdle, Duration maxWait) {
+        GenericObjectPoolConfig<Jedis> poolConfig = new GenericObjectPoolConfig<>();
+        poolConfig.setMaxTotal(maxTotal);
+        poolConfig.setMaxIdle(maxIdle);
+        poolConfig.setMaxWait(maxWait);
+        return poolConfig;
     }
 
     /**

--- a/src/main/java/com/falkordb/impl/api/DriverImpl.java
+++ b/src/main/java/com/falkordb/impl/api/DriverImpl.java
@@ -135,6 +135,7 @@ public class DriverImpl implements Driver {
         if (host == null || host.trim().isEmpty()) {
             throw new IllegalArgumentException("host must not be null or blank");
         }
+        String normalizedHost = host.trim();
         if (port < 1 || port > 65535) {
             throw new IllegalArgumentException("port must be in [1, 65535], but was " + port);
         }
@@ -161,7 +162,7 @@ public class DriverImpl implements Driver {
         }
         return new DriverImpl(new JedisPool(
                 buildPoolConfig(poolMaxTotal, poolMaxIdle, poolMaxWait),
-                new HostAndPort(host, port),
+                new HostAndPort(normalizedHost, port),
                 buildClientConfig(user, password, ssl, connectionTimeoutMillis, socketTimeoutMillis)));
     }
 

--- a/src/test/java/com/falkordb/ConfigBuilderIT.java
+++ b/src/test/java/com/falkordb/ConfigBuilderIT.java
@@ -40,11 +40,14 @@ public class ConfigBuilderIT {
 
     @AfterEach
     public void closeClient() throws IOException {
-        if (client != null) {
-            client.deleteGraph();
-        }
-        if (driver != null) {
-            driver.close();
+        try {
+            if (client != null) {
+                client.deleteGraph();
+            }
+        } finally {
+            if (driver != null) {
+                driver.close();
+            }
         }
     }
 }

--- a/src/test/java/com/falkordb/ConfigBuilderIT.java
+++ b/src/test/java/com/falkordb/ConfigBuilderIT.java
@@ -1,0 +1,50 @@
+package com.falkordb;
+
+import java.io.IOException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * System tests for {@link FalkorDB#builder()} against a real FalkorDB server (via {@link TestServer}).
+ */
+public class ConfigBuilderIT {
+
+    private Driver driver;
+    private GraphContextGenerator client;
+
+    @Test
+    public void buildAndQuery() {
+        driver = FalkorDB.builder()
+                .host(TestServer.host())
+                .port(TestServer.port())
+                .build();
+        client = driver.graph("g");
+        ResultSet resultSet = client.query("CREATE ({name:'bsb'})");
+        Assertions.assertEquals(1, resultSet.getStatistics().nodesCreated());
+    }
+
+    @Test
+    public void buildWithCustomPoolAndTimeouts() {
+        driver = FalkorDB.builder()
+                .host(TestServer.host())
+                .port(TestServer.port())
+                .poolMaxTotal(4)
+                .poolMaxIdle(2)
+                .connectionTimeout(java.time.Duration.ofSeconds(2))
+                .build();
+        client = driver.graph("g");
+        ResultSet resultSet = client.query("CREATE ({name:'bsb'})");
+        Assertions.assertEquals(1, resultSet.getStatistics().nodesCreated());
+    }
+
+    @AfterEach
+    public void closeClient() throws IOException {
+        if (client != null) {
+            client.deleteGraph();
+        }
+        if (driver != null) {
+            driver.close();
+        }
+    }
+}

--- a/src/test/java/com/falkordb/ConfigBuilderTest.java
+++ b/src/test/java/com/falkordb/ConfigBuilderTest.java
@@ -68,6 +68,12 @@ class ConfigBuilderTest {
     }
 
     @Test
+    void acceptsWhitespacePaddedHost() {
+        // A padded host is trimmed rather than rejected (and is not passed padded on to DNS lookup).
+        assertDoesNotThrow(() -> FalkorDB.builder().host(" localhost ").build().close());
+    }
+
+    @Test
     void rejectsPortOutOfRange() {
         assertThrows(
                 IllegalArgumentException.class, () -> FalkorDB.builder().port(0).build());

--- a/src/test/java/com/falkordb/ConfigBuilderTest.java
+++ b/src/test/java/com/falkordb/ConfigBuilderTest.java
@@ -1,0 +1,156 @@
+package com.falkordb;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link FalkorDB#builder()} validation and wiring. These do not connect to a server:
+ * {@code build()} assembles a lazy {@link redis.clients.jedis.JedisPool}, so no I/O happens until a
+ * connection is actually borrowed.
+ */
+class ConfigBuilderTest {
+
+    @Test
+    void buildWithDefaultsReturnsDriver() throws IOException {
+        try (Driver driver = FalkorDB.builder().build()) {
+            assertNotNull(driver);
+        }
+    }
+
+    @Test
+    void buildWithFullConfigurationSucceeds() {
+        assertDoesNotThrow(() -> {
+            try (Driver driver = FalkorDB.builder()
+                    .host("db.example.com")
+                    .port(6380)
+                    .credentials("user", "password")
+                    .ssl(true)
+                    .poolMaxTotal(64)
+                    .poolMaxIdle(16)
+                    .poolMaxWait(Duration.ofSeconds(30))
+                    .connectionTimeout(Duration.ofSeconds(2))
+                    .socketTimeout(Duration.ofSeconds(5))
+                    .build()) {
+                assertNotNull(driver);
+            }
+        });
+    }
+
+    @Test
+    void settersReturnSameBuilder() {
+        FalkorDB.Builder builder = FalkorDB.builder();
+        assertSame(builder, builder.host("h"));
+        assertSame(builder, builder.port(6379));
+        assertSame(builder, builder.credentials("u", "p"));
+        assertSame(builder, builder.credentials("p"));
+        assertSame(builder, builder.ssl(true));
+        assertSame(builder, builder.poolMaxTotal(8));
+        assertSame(builder, builder.poolMaxIdle(8));
+        assertSame(builder, builder.poolMaxWait(Duration.ZERO));
+        assertSame(builder, builder.connectionTimeout(Duration.ZERO));
+        assertSame(builder, builder.socketTimeout(Duration.ZERO));
+    }
+
+    @Test
+    void rejectsNullOrBlankHost() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FalkorDB.builder().host(null).build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FalkorDB.builder().host("   ").build());
+    }
+
+    @Test
+    void rejectsPortOutOfRange() {
+        assertThrows(
+                IllegalArgumentException.class, () -> FalkorDB.builder().port(0).build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FalkorDB.builder().port(-1).build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FalkorDB.builder().port(65536).build());
+    }
+
+    @Test
+    void acceptsPortBoundaries() {
+        assertDoesNotThrow(() -> FalkorDB.builder().port(1).build().close());
+        assertDoesNotThrow(() -> FalkorDB.builder().port(65535).build().close());
+    }
+
+    @Test
+    void rejectsInvalidPoolSizing() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FalkorDB.builder().poolMaxTotal(0).build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FalkorDB.builder().poolMaxTotal(-1).build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FalkorDB.builder().poolMaxIdle(-1).build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FalkorDB.builder().poolMaxTotal(4).poolMaxIdle(8).build());
+    }
+
+    @Test
+    void acceptsMaxIdleEqualToMaxTotal() {
+        assertDoesNotThrow(
+                () -> FalkorDB.builder().poolMaxTotal(8).poolMaxIdle(8).build().close());
+    }
+
+    @Test
+    void rejectsNegativeTimeouts() {
+        assertThrows(IllegalArgumentException.class, () -> FalkorDB.builder()
+                .connectionTimeout(Duration.ofMillis(-1))
+                .build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FalkorDB.builder().socketTimeout(Duration.ofMillis(-1)).build());
+    }
+
+    @Test
+    void rejectsTimeoutAboveIntMax() {
+        assertThrows(IllegalArgumentException.class, () -> FalkorDB.builder()
+                .connectionTimeout(Duration.ofMillis((long) Integer.MAX_VALUE + 1))
+                .build());
+    }
+
+    @Test
+    void rejectsExtremeTimeoutWithIllegalArgumentException() {
+        // A Duration so large that Duration.toMillis() would itself overflow must still surface the
+        // documented IllegalArgumentException, not an ArithmeticException.
+        assertThrows(IllegalArgumentException.class, () -> FalkorDB.builder()
+                .connectionTimeout(Duration.ofSeconds(Long.MAX_VALUE))
+                .build());
+    }
+
+    @Test
+    void acceptsZeroTimeoutsAndNegativePoolWait() {
+        // Zero connect/socket timeouts (socket ZERO = no read deadline, #282) and a negative
+        // poolMaxWait (wait indefinitely) are all valid.
+        assertDoesNotThrow(() -> FalkorDB.builder()
+                .connectionTimeout(Duration.ZERO)
+                .socketTimeout(Duration.ZERO)
+                .poolMaxWait(Duration.ofMillis(-1))
+                .build()
+                .close());
+    }
+
+    @Test
+    void acceptsSubMillisecondTimeout() {
+        // A positive sub-millisecond timeout must round up to 1ms (not collapse to 0 = infinite).
+        assertDoesNotThrow(() -> FalkorDB.builder()
+                .connectionTimeout(Duration.ofNanos(500_000))
+                .build()
+                .close());
+    }
+}

--- a/src/test/java/com/falkordb/impl/api/DriverConfigTest.java
+++ b/src/test/java/com/falkordb/impl/api/DriverConfigTest.java
@@ -3,6 +3,7 @@ package com.falkordb.impl.api;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Duration;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
@@ -93,5 +94,23 @@ class DriverConfigTest {
         assertEquals(64, config.getMaxTotal());
         assertEquals(16, config.getMaxIdle());
         assertEquals(Duration.ofSeconds(30), config.getMaxWaitDuration());
+    }
+
+    @Test
+    void createValidatesItsArguments() {
+        // create() is a public boundary (used by FalkorDB.builder()); it must reject invalid input
+        // with IllegalArgumentException rather than surfacing a downstream NPE/other exception.
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DriverImpl.create(null, 6379, null, null, false, 2000, 0, 8, 8, Duration.ofMillis(-1)));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DriverImpl.create("localhost", 0, null, null, false, 2000, 0, 8, 8, Duration.ofMillis(-1)));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DriverImpl.create("localhost", 6379, null, null, false, 2000, 0, 0, 8, Duration.ofMillis(-1)));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DriverImpl.create("localhost", 6379, null, null, false, 2000, 0, 8, 8, null));
     }
 }

--- a/src/test/java/com/falkordb/impl/api/DriverConfigTest.java
+++ b/src/test/java/com/falkordb/impl/api/DriverConfigTest.java
@@ -1,0 +1,97 @@
+package com.falkordb.impl.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.Duration;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.Jedis;
+
+/**
+ * Unit tests for the {@code FalkorDB.builder()} wiring in {@link DriverImpl}: how resolved settings
+ * map onto the Jedis client config and the commons-pool2 pool config, and that the builder defaults
+ * reproduce the {@code driver()} configuration exactly. No server is required.
+ */
+class DriverConfigTest {
+
+    @Test
+    void clientConfigDefaultsMatchDriverFactory() {
+        DefaultJedisClientConfig config = DriverImpl.buildClientConfig(
+                null,
+                null,
+                false,
+                DriverImpl.DEFAULT_CONNECTION_TIMEOUT_MILLIS,
+                DriverImpl.DEFAULT_SOCKET_TIMEOUT_MILLIS);
+
+        assertEquals(2000, config.getConnectionTimeoutMillis(), "default connect timeout");
+        assertEquals(0, config.getSocketTimeoutMillis(), "default socket timeout (#282: no read deadline)");
+        assertNull(config.getUser(), "no user by default");
+        assertNull(config.getPassword(), "no password by default");
+        assertNull(config.getSslOptions(), "no TLS by default");
+    }
+
+    @Test
+    void legacyClientConfigEqualsBuilderDefaults() {
+        // driver(host, port) resolves through clientConfig(null, null); assert it is field-for-field
+        // identical to the builder's all-defaults client config, so builder().build() == driver().
+        DefaultJedisClientConfig legacy = DriverImpl.clientConfig(null, null);
+        DefaultJedisClientConfig builderDefaults = DriverImpl.buildClientConfig(
+                null,
+                null,
+                false,
+                DriverImpl.DEFAULT_CONNECTION_TIMEOUT_MILLIS,
+                DriverImpl.DEFAULT_SOCKET_TIMEOUT_MILLIS);
+
+        assertEquals(legacy.getConnectionTimeoutMillis(), builderDefaults.getConnectionTimeoutMillis());
+        assertEquals(legacy.getSocketTimeoutMillis(), builderDefaults.getSocketTimeoutMillis());
+        assertEquals(legacy.getUser(), builderDefaults.getUser());
+        assertEquals(legacy.getPassword(), builderDefaults.getPassword());
+        assertEquals(legacy.getSslOptions(), builderDefaults.getSslOptions());
+    }
+
+    @Test
+    void clientConfigMapsCredentialsSslAndTimeouts() {
+        DefaultJedisClientConfig config = DriverImpl.buildClientConfig("alice", "s3cret", true, 1500, 4000);
+
+        assertEquals("alice", config.getUser());
+        assertEquals("s3cret", config.getPassword());
+        assertEquals(1500, config.getConnectionTimeoutMillis());
+        assertEquals(4000, config.getSocketTimeoutMillis());
+        assertNotNull(config.getSslOptions(), "ssl=true should map to non-null SslOptions (modern TLS path)");
+    }
+
+    @Test
+    void clientConfigSupportsPasswordOnly() {
+        DefaultJedisClientConfig config = DriverImpl.buildClientConfig(null, "s3cret", false, 2000, 0);
+
+        assertNull(config.getUser(), "password-only auth has no username");
+        assertEquals("s3cret", config.getPassword());
+    }
+
+    @Test
+    void poolConfigDefaultsMatchDriverFactory() {
+        GenericObjectPoolConfig<Jedis> builderDefaults = DriverImpl.buildPoolConfig(
+                DriverImpl.DEFAULT_POOL_MAX_TOTAL, DriverImpl.DEFAULT_POOL_MAX_IDLE, DriverImpl.DEFAULT_POOL_MAX_WAIT);
+        // The host/port factories rely on the JedisPool's own default GenericObjectPoolConfig.
+        GenericObjectPoolConfig<Jedis> factoryDefaults = new GenericObjectPoolConfig<>();
+
+        assertEquals(factoryDefaults.getMaxTotal(), builderDefaults.getMaxTotal(), "default maxTotal");
+        assertEquals(factoryDefaults.getMaxIdle(), builderDefaults.getMaxIdle(), "default maxIdle");
+        assertEquals(factoryDefaults.getMaxWaitDuration(), builderDefaults.getMaxWaitDuration(), "default maxWait");
+        assertEquals(8, builderDefaults.getMaxTotal());
+        assertEquals(8, builderDefaults.getMaxIdle());
+        assertEquals(Duration.ofMillis(-1), builderDefaults.getMaxWaitDuration());
+    }
+
+    @Test
+    void poolConfigMapsSizingAndWait() {
+        GenericObjectPoolConfig<Jedis> config = DriverImpl.buildPoolConfig(64, 16, Duration.ofSeconds(30));
+
+        assertEquals(64, config.getMaxTotal());
+        assertEquals(16, config.getMaxIdle());
+        assertEquals(Duration.ofSeconds(30), config.getMaxWaitDuration());
+    }
+}


### PR DESCRIPTION
## What

Adds a discoverable, fluent **`FalkorDB.builder()`** — a superset of the `driver(...)` factories that
also exposes **TLS**, **connection-pool sizing**, and **timeouts**:

```java
Driver driver = FalkorDB.builder()
    .host("db.example.com")
    .port(6380)
    .credentials("user", "password")   // or .credentials("password") for password-only
    .ssl(true)
    .poolMaxTotal(64)
    .poolMaxIdle(16)
    .poolMaxWait(Duration.ofSeconds(30))
    .connectionTimeout(Duration.ofSeconds(2))
    .socketTimeout(Duration.ZERO)      // no read deadline (#282)
    .build();
```

This is **Wave 4 · PR 15a** (per the merged plan in #348). JSpecify nullability follows as **15b**.

## Design

- **Additive only → `api-diff` green.** New `FalkorDB.builder()` + nested `public static final class
  FalkorDB.Builder` (private ctor). The `Driver` interface and every existing `driver(...)` factory are
  untouched. `build()` returns the existing `Driver` via a new **public `DriverImpl.create(...)`**
  factory (a method on the already-public `DriverImpl`, in `com.falkordb.impl`, excluded from api-diff —
  no new public type ships, per the #348 review).
- **Defaults ≡ `driver()`** exactly (`localhost:6379`, no creds, no TLS, 2000&nbsp;ms connect, socket
  timeout `0` per #282, default 8-connection pool), locked by a regression test that compares the
  builder's default client/pool config field-by-field against the factory path.
- **Two timeout paths.** connect/socket → Jedis int-millis (`ZERO`=no deadline; overflow &
  sub-millisecond-rounding guards, and extreme `Duration`s still throw `IllegalArgumentException`, not
  `ArithmeticException`); **`poolMaxWait`** → commons-pool2 `setMaxWait(Duration)` with native
  semantics (negative = wait forever, `ZERO` = fail fast).
- **TLS** maps through the non-deprecated `SslOptions.defaults()` (Jedis' `ssl(boolean)` is
  `@Deprecated` in 7.5.3).
- **Validation** in `build()`: non-blank host, port `[1,65535]`, `poolMaxTotal≥1`, `0≤poolMaxIdle≤maxTotal`,
  non-negative timeouts.
- `.uri()` is intentionally **deferred** (URI users keep `FalkorDB.driver(URI)`) — see #348.

## Tests & validation

- Unit: `ConfigBuilderTest` (validation + build), `DriverConfigTest` (config/pool mapping + defaults ≡
  `driver()`), all server-free (lazy `JedisPool`).
- IT: `ConfigBuilderIT` (connect → query → close via Testcontainers).
- Green locally via `just`: **verify · lint · fmt-check · api-diff · javadoc** (+ Enforcer bytecode-8,
  Animal Sniffer). Self-reviewed (code-review agent) before pushing.

Part of #332 (Wave 4). Unblocks PR 16 (examples).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fluent builder for configuring FalkorDB connections.
  * Supports custom host, port, credentials, TLS, connection pooling, and timeout settings.
  * Added validation for connection and pool configuration values.
  * Added support for password-only authentication and precise timeout handling.

* **Tests**
  * Added coverage for default, custom, boundary, and invalid configurations.
  * Added integration tests confirming configured clients can connect and execute queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->