### PR TITLE
ci: make the PR benchmark a same-machine head-vs-base A/B

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,7 +28,8 @@ recipe; recipes call the pinned Maven Wrapper (`./mvnw`).
 | `just javadoc` | Javadoc gate (the CI **`javadoc`** gate): strict `doclint=all` + `failOnWarnings` on the public/protected API (`com.falkordb.impl` excluded), in the off-by-default `-Pquality` profile. |
 | `just spellcheck` | Spellcheck the Markdown docs (the CI `spellcheck` gate). |
 | `just db-up` / `just db-down` | Manage a local FalkorDB container. |
-| `just bench` / `just bench-one <loads>` | Client load-sweep benchmark — client latency (total − server) vs throughput across concurrency levels; feeds the per-PR-vs-`master` radar + Pages curve. |
+| `just bench` / `just bench-one <loads>` | Client load-sweep benchmark — client latency (total − server) vs throughput across concurrency levels; feeds the `master` gh-pages trend radar + Pages curve. |
+| `just bench-compare <base_ref>` | Same-machine A/B: benchmark HEAD vs `<base_ref>` back-to-back on one machine and compare (the CI **`benchmark-pr`** job). Cancels hosted-runner speed variance, unlike the cross-runner stored-baseline radar. Needs a clean tree + a server (like `just bench`). |
 
 Server-backed **system tests are `*IT`** (run by Failsafe in `verify`) and start a FalkorDB
 automatically via **Testcontainers** (Docker required) — no manual server setup; set both

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Publish comparison to the job summary
       if: always()
       run: |
-        if [ -f benchmarks/target/bench-compare.md ]; then
+        if [ -s benchmarks/target/bench-compare.md ]; then
           cat benchmarks/target/bench-compare.md >> "$GITHUB_STEP_SUMMARY"
         fi
     - name: Upsert the comparison as a sticky PR comment
@@ -62,19 +62,22 @@ jobs:
       run: |
         set -euo pipefail
         file=benchmarks/target/bench-compare.md
-        if [ ! -f "$file" ]; then
+        if [ ! -s "$file" ]; then
           echo "no comparison output (benchmark step failed earlier); skipping comment"
           exit 0
         fi
+        # Posting is best-effort: fork PRs get a read-only GITHUB_TOKEN, so a 403 here must not fail
+        # the job (the report is still in the job summary above).
+        warn() { echo "::warning::could not post the benchmark comment (read-only token on a fork PR?); see the job summary"; exit 0; }
         marker='<!-- bench-compare -->'
         id="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
-          --jq "map(select(.body | contains(\"${marker}\"))) | .[0].id // empty")"
+          --jq "map(select(.body | contains(\"${marker}\"))) | .[0].id // empty")" || warn
         body="$(cat "$file")"
         if [ -n "$id" ]; then
-          gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${id}" -f body="$body" >/dev/null
+          gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${id}" -f body="$body" >/dev/null || warn
           echo "updated sticky comment ${id}"
         else
-          gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -f body="$body" >/dev/null
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -f body="$body" >/dev/null || warn
           echo "created sticky comment"
         fi
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,9 +14,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Pull requests run untrusted PR code (`just bench` executes the PR's own Justfile), so they get
-  # least privilege: no `contents: write`. They only compare against the master baseline and comment
-  # regressions (needs `pull-requests: write`); they never push to gh-pages.
+  # Pull requests run untrusted PR code (`just bench-compare` executes the PR's own Justfile), so they
+  # get least privilege: no `contents: write`. They benchmark the PR head and its base back-to-back on
+  # the SAME runner and compare the two directly (needs `pull-requests: write` for the sticky comment);
+  # they never push to gh-pages. A same-machine A/B cancels hosted-runner speed variance — the
+  # stored-baseline radar (benchmark-master, below) compares across different runners and so emits
+  # false ~2x alerts, which is why the PR gate no longer uses it.
   benchmark-pr:
     if: github.event_name == 'pull_request'
 
@@ -30,6 +33,8 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         persist-credentials: false
+        # Full history so the PR's base commit is present to check out and benchmark on this runner.
+        fetch-depth: 0
     - name: Set up JDK 21
       uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
       with:
@@ -38,43 +43,40 @@ jobs:
         cache: maven
     - name: Install just
       uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
-    - name: Run client load-sweep benchmark (via just)
-      run: just bench
-
-    # Client latency = total round-trip minus server internal execution time (smaller is better).
-    - name: Radar — client latency
-      uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
-      with:
-        name: Client latency
-        tool: 'customSmallerIsBetter'
-        output-file-path: benchmarks/target/bench-latency.json
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        gh-pages-branch: gh-pages
-        benchmark-data-dir-path: dev/bench/latency
-        alert-threshold: '200%'
-        comment-on-alert: true
-        summary-always: true
-        fail-on-alert: false
-        auto-push: false
-
-    # Throughput at each concurrency level (bigger is better).
-    - name: Radar — throughput
-      uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
-      with:
-        name: Throughput
-        tool: 'customBiggerIsBetter'
-        output-file-path: benchmarks/target/bench-throughput.json
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        gh-pages-branch: gh-pages
-        benchmark-data-dir-path: dev/bench/throughput
-        alert-threshold: '200%'
-        comment-on-alert: true
-        summary-always: true
-        fail-on-alert: false
-        auto-push: false
-        # The latency step above already fetched/checked out gh-pages in this job; re-fetching here
-        # fails ("refusing to fetch into checked-out gh-pages"), so reuse that checkout.
-        skip-fetch-gh-pages: true
+    # Benchmarks PR head vs base back-to-back on this runner, writing benchmarks/target/bench-compare.md.
+    # Regressions are reported (in the comment + job summary) but do not fail the job; a non-zero exit
+    # here means the benchmark itself broke, which should.
+    - name: Same-machine A/B benchmark (PR head vs base)
+      run: just bench-compare ${{ github.event.pull_request.base.sha }}
+    - name: Publish comparison to the job summary
+      if: always()
+      run: |
+        if [ -f benchmarks/target/bench-compare.md ]; then
+          cat benchmarks/target/bench-compare.md >> "$GITHUB_STEP_SUMMARY"
+        fi
+    - name: Upsert the comparison as a sticky PR comment
+      if: always()
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        set -euo pipefail
+        file=benchmarks/target/bench-compare.md
+        if [ ! -f "$file" ]; then
+          echo "no comparison output (benchmark step failed earlier); skipping comment"
+          exit 0
+        fi
+        marker='<!-- bench-compare -->'
+        id="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+          --jq "map(select(.body | contains(\"${marker}\"))) | .[0].id // empty")"
+        body="$(cat "$file")"
+        if [ -n "$id" ]; then
+          gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${id}" -f body="$body" >/dev/null
+          echo "updated sticky comment ${id}"
+        else
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -f body="$body" >/dev/null
+          echo "created sticky comment"
+        fi
 
   # Master pushes are trusted and are the only runs that publish: they store the baseline/trend and
   # the curve to gh-pages, so this job gets `contents: write`.

--- a/Justfile
+++ b/Justfile
@@ -124,15 +124,16 @@ bench-baseline:
 bench-compare base_ref threshold="1.25" loads="1,2,4,8,16,32,64":
     #!/usr/bin/env bash
     set -euo pipefail
-    if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+    if [ -n "$(git status --porcelain)" ]; then
         echo "bench-compare needs a clean working tree (it checks out {{base_ref}} and back); commit or stash first." >&2
         exit 1
     fi
     orig_ref="$(git symbolic-ref -q --short HEAD || git rev-parse HEAD)"
     base_sha="$(git rev-parse --short "{{base_ref}}")"
     out="$(mktemp -d)"
-    restore() { git checkout -q "$orig_ref"; }
-    trap restore EXIT
+    # Always restore the original ref and remove the temp dir, even if a bench/checkout fails midway.
+    cleanup() { git checkout -q "$orig_ref" 2>/dev/null || true; rm -rf "$out"; }
+    trap cleanup EXIT
     echo "==> benchmarking HEAD ($orig_ref)"
     just bench-one "{{loads}}"
     cp benchmarks/target/bench-latency.json "$out/head-latency.json"
@@ -142,8 +143,7 @@ bench-compare base_ref threshold="1.25" loads="1,2,4,8,16,32,64":
     just bench-one "{{loads}}"
     cp benchmarks/target/bench-latency.json "$out/base-latency.json"
     cp benchmarks/target/bench-throughput.json "$out/base-throughput.json"
-    restore
-    trap - EXIT
+    git checkout -q "$orig_ref"  # back on HEAD so the comparator below is the current one
     echo "==> comparing head ($orig_ref) vs base ({{base_ref}}), threshold {{threshold}}x"
     mkdir -p benchmarks/target
     python3 benchmarks/compare_bench.py \

--- a/Justfile
+++ b/Justfile
@@ -115,6 +115,43 @@ bench-one loads:
 bench-baseline:
     just bench
 
+# Same-machine A/B: benchmark HEAD vs <base_ref> back-to-back on THIS machine, then compare — so
+# absolute runner speed cancels out (unlike the stored-baseline radar, which compares across
+# different hosted runners and therefore emits false ~2x alerts). This is exactly what the
+# `benchmark-pr` CI job runs. Needs a clean working tree (it checks out <base_ref> and back) and a
+# server like the other bench recipes, e.g.
+# `just db-up && FALKORDB_HOST=localhost FALKORDB_PORT=6379 just bench-compare origin/master`.
+bench-compare base_ref threshold="1.25" loads="1,2,4,8,16,32,64":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+        echo "bench-compare needs a clean working tree (it checks out {{base_ref}} and back); commit or stash first." >&2
+        exit 1
+    fi
+    orig_ref="$(git symbolic-ref -q --short HEAD || git rev-parse HEAD)"
+    base_sha="$(git rev-parse --short "{{base_ref}}")"
+    out="$(mktemp -d)"
+    restore() { git checkout -q "$orig_ref"; }
+    trap restore EXIT
+    echo "==> benchmarking HEAD ($orig_ref)"
+    just bench-one "{{loads}}"
+    cp benchmarks/target/bench-latency.json "$out/head-latency.json"
+    cp benchmarks/target/bench-throughput.json "$out/head-throughput.json"
+    echo "==> benchmarking base ({{base_ref}} = $base_sha)"
+    git checkout -q "{{base_ref}}"
+    just bench-one "{{loads}}"
+    cp benchmarks/target/bench-latency.json "$out/base-latency.json"
+    cp benchmarks/target/bench-throughput.json "$out/base-throughput.json"
+    restore
+    trap - EXIT
+    echo "==> comparing head ($orig_ref) vs base ({{base_ref}}), threshold {{threshold}}x"
+    mkdir -p benchmarks/target
+    python3 benchmarks/compare_bench.py \
+        "$out/base-latency.json" "$out/head-latency.json" \
+        "$out/base-throughput.json" "$out/head-throughput.json" \
+        --threshold "{{threshold}}" --base-label "{{base_ref}}" --head-label "$orig_ref" \
+        | tee benchmarks/target/bench-compare.md
+
 # --- Publish (run by the snapshot/release CI workflows; not for day-to-day local use) ---
 
 # Pre-fetch dependencies (snapshot workflow warm-up).

--- a/benchmarks/compare_bench.py
+++ b/benchmarks/compare_bench.py
@@ -13,7 +13,9 @@ reported for information only.
 Usage:
   compare_bench.py BASE_LAT HEAD_LAT BASE_TPUT HEAD_TPUT [--threshold 1.25] [--base-label ..] [--head-label ..]
 
-Exit code: 0 if no gated regression beyond the threshold, 1 otherwise.
+Exit code: 0 normally (report-only — a regression is reported but does not change the exit code unless
+--fail-on-regression is given, in which case a gated regression exits 1); 2 when the two runs share no
+comparable load levels.
 """
 import argparse
 import json

--- a/benchmarks/compare_bench.py
+++ b/benchmarks/compare_bench.py
@@ -54,14 +54,11 @@ def fmt_pair(base, head, fmt):
 
 
 def slowdown(base, head, bigger_is_better):
-    """Ratio >1 == head is worse than base. None when it cannot be computed."""
-    if base is None or head is None:
+    """Ratio >1 == head is worse than base. None when it cannot be computed (a value is missing or
+    non-positive, e.g. a 0 throughput or 0 percentile from an empty sample set — not comparable)."""
+    if base is None or head is None or base <= 0 or head <= 0:
         return None
-    if bigger_is_better:
-        # throughput: worse means head < base
-        return None if head <= 0 else base / head
-    # latency: worse means head > base
-    return None if base <= 0 else head / base
+    return base / head if bigger_is_better else head / base
 
 
 def main():
@@ -101,7 +98,7 @@ def main():
         f"that much slower. Throughput & p50 are gated; p95/p99 are shown for context only "
         "(high-load tails are noisy).")
     lines.append("")
-    lines.append("| load | throughput (ops/s) base→head | Δ | p50 (µs) base→head | Δ | p95 Δ | p99 Δ |")
+    lines.append("| load | throughput (ops/s) base→head | ratio | p50 (µs) base→head | ratio | p95 ratio | p99 ratio |")
     lines.append("|--:|--|--:|--|--:|--:|--:|")
 
     regressions = []

--- a/benchmarks/compare_bench.py
+++ b/benchmarks/compare_bench.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Compare two runs of the JFalkorDB client load-sweep benchmark (see LoadBenchmark.java).
+
+Both runs are expected to come from the *same machine* (e.g. `just bench-compare`), so absolute
+hardware speed cancels out and the head/base ratio is a meaningful client-overhead delta rather than
+runner-to-runner noise. Reads the JSON the benchmark harness emits (a flat array of
+{"name","unit","value"} objects) for base and head, and reports per-load ratios.
+
+Gating (what can flag a regression) is deliberately limited to the *stable* signals — throughput and
+client p50 — because the high-load p95/p99 tails are dominated by pool-contention jitter and are
+reported for information only.
+
+Usage:
+  compare_bench.py BASE_LAT HEAD_LAT BASE_TPUT HEAD_TPUT [--threshold 1.25] [--base-label ..] [--head-label ..]
+
+Exit code: 0 if no gated regression beyond the threshold, 1 otherwise.
+"""
+import argparse
+import json
+import re
+import sys
+
+LOAD_RE = re.compile(r"@load=(\d+)")
+
+
+def load_metrics(path):
+    """Return {load:int -> {metric_key:str -> value:float}} parsed from a harness JSON file."""
+    with open(path, encoding="utf-8") as fh:
+        rows = json.load(fh)
+    out = {}
+    for row in rows:
+        name = row["name"]
+        m = LOAD_RE.search(name)
+        if not m:
+            continue
+        load = int(m.group(1))
+        key = name.split("@load=")[0].strip()  # e.g. "client_p50", "throughput"
+        out.setdefault(load, {})[key] = float(row["value"])
+    return out
+
+
+def fmt_ratio(ratio):
+    return "n/a" if ratio is None else f"{ratio:.2f}x"
+
+
+def slowdown(base, head, bigger_is_better):
+    """Ratio >1 == head is worse than base. None when it cannot be computed."""
+    if base is None or head is None:
+        return None
+    if bigger_is_better:
+        # throughput: worse means head < base
+        return None if head <= 0 else base / head
+    # latency: worse means head > base
+    return None if base <= 0 else head / base
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("base_latency")
+    ap.add_argument("head_latency")
+    ap.add_argument("base_throughput")
+    ap.add_argument("head_throughput")
+    ap.add_argument("--threshold", type=float, default=1.25,
+                    help="flag a regression when a gated metric is this many times worse (default 1.25 = 25%%)")
+    ap.add_argument("--base-label", default="base")
+    ap.add_argument("--head-label", default="head")
+    ap.add_argument("--fail-on-regression", action="store_true",
+                    help="exit non-zero when a gated regression is found (default: report only, exit 0)")
+    args = ap.parse_args()
+
+    if args.threshold <= 1.0:
+        ap.error("--threshold must be > 1.0")
+
+    base_lat = load_metrics(args.base_latency)
+    head_lat = load_metrics(args.head_latency)
+    base_tp = load_metrics(args.base_throughput)
+    head_tp = load_metrics(args.head_throughput)
+
+    loads = sorted(set(base_lat) & set(head_lat) & set(base_tp) & set(head_tp))
+    if not loads:
+        print("bench-compare: no comparable load levels found in the two runs", file=sys.stderr)
+        return 2
+
+    lines = []
+    lines.append("<!-- bench-compare -->")
+    lines.append("## 📊 Client benchmark — same-machine A/B")
+    lines.append("")
+    lines.append(
+        f"`{args.head_label}` vs `{args.base_label}`, benchmarked back-to-back on the **same runner** "
+        f"(so runner speed cancels out). A gated ratio `> {args.threshold:.2f}x` means the change is "
+        f"that much slower. Throughput & p50 are gated; p95/p99 are shown for context only "
+        "(high-load tails are noisy).")
+    lines.append("")
+    lines.append("| load | throughput (ops/s) base→head | Δ | p50 (µs) base→head | Δ | p95 Δ | p99 Δ |")
+    lines.append("|--:|--|--:|--|--:|--:|--:|")
+
+    regressions = []
+    for load in loads:
+        b_tp = base_tp[load].get("throughput")
+        h_tp = head_tp[load].get("throughput")
+        b_p50 = base_lat[load].get("client_p50")
+        h_p50 = head_lat[load].get("client_p50")
+        b_p95 = base_lat[load].get("client_p95")
+        h_p95 = head_lat[load].get("client_p95")
+        b_p99 = base_lat[load].get("client_p99")
+        h_p99 = head_lat[load].get("client_p99")
+
+        tp_slow = slowdown(b_tp, h_tp, bigger_is_better=True)
+        p50_slow = slowdown(b_p50, h_p50, bigger_is_better=False)
+        p95_slow = slowdown(b_p95, h_p95, bigger_is_better=False)
+        p99_slow = slowdown(b_p99, h_p99, bigger_is_better=False)
+
+        flagged = []
+        if tp_slow is not None and tp_slow > args.threshold:
+            flagged.append(f"throughput {tp_slow:.2f}x")
+        if p50_slow is not None and p50_slow > args.threshold:
+            flagged.append(f"p50 {p50_slow:.2f}x")
+        if flagged:
+            regressions.append(f"load={load}: " + ", ".join(flagged))
+
+        mark = " ⚠️" if flagged else ""
+        lines.append(
+            f"| {load} | {b_tp:.0f} → {h_tp:.0f} | {fmt_ratio(tp_slow)}{mark} "
+            f"| {b_p50:.1f} → {h_p50:.1f} | {fmt_ratio(p50_slow)}{mark} "
+            f"| {fmt_ratio(p95_slow)} | {fmt_ratio(p99_slow)} |")
+
+    lines.append("")
+    if regressions:
+        lines.append(f"### ⚠️ Possible regression (> {args.threshold:.2f}x on a gated metric)")
+        for r in regressions:
+            lines.append(f"- {r}")
+    else:
+        lines.append(f"### ✅ No regression beyond {args.threshold:.2f}x on any gated metric (throughput, p50).")
+
+    report = "\n".join(lines)
+    print(report)
+    return 1 if (regressions and args.fail_on_regression) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/compare_bench.py
+++ b/benchmarks/compare_bench.py
@@ -43,6 +43,14 @@ def fmt_ratio(ratio):
     return "n/a" if ratio is None else f"{ratio:.2f}x"
 
 
+def fmt_num(value, fmt):
+    return "n/a" if value is None else format(value, fmt)
+
+
+def fmt_pair(base, head, fmt):
+    return f"{fmt_num(base, fmt)} → {fmt_num(head, fmt)}"
+
+
 def slowdown(base, head, bigger_is_better):
     """Ratio >1 == head is worse than base. None when it cannot be computed."""
     if base is None or head is None:
@@ -120,8 +128,8 @@ def main():
 
         mark = " ⚠️" if flagged else ""
         lines.append(
-            f"| {load} | {b_tp:.0f} → {h_tp:.0f} | {fmt_ratio(tp_slow)}{mark} "
-            f"| {b_p50:.1f} → {h_p50:.1f} | {fmt_ratio(p50_slow)}{mark} "
+            f"| {load} | {fmt_pair(b_tp, h_tp, '.0f')} | {fmt_ratio(tp_slow)}{mark} "
+            f"| {fmt_pair(b_p50, h_p50, '.1f')} | {fmt_ratio(p50_slow)}{mark} "
             f"| {fmt_ratio(p95_slow)} | {fmt_ratio(p99_slow)} |")
 
     lines.append("")


### PR DESCRIPTION
## Problem

The `benchmark-pr` job compared each PR's client benchmark against a **stored baseline on `gh-pages`** — but that baseline was captured by an earlier `benchmark-master` run on a **different hosted runner**. GitHub-hosted runner speed varies enough that this cross-machine comparison produces **false ~2× "Performance Alert"s** (seen on #349: a uniform ~2.2× on *every* load/percentile, with throughput being the exact inverse of latency — the signature of a slower runner, not a code change). As-is, the benchmark gate is not trustworthy.

## Fix — same-machine A/B

Benchmark the **PR head and its base back-to-back on the same runner** and compare those two directly, so absolute hardware speed cancels out.

- **`benchmarks/compare_bench.py`** (new): compares two harness JSON runs, prints a per-load Markdown table (throughput + client p50 gated at a `1.25×` threshold; p95/p99 shown for context only, since high-load tails are noisy). Report-only by default (exit 0); `--fail-on-regression` opts into a hard gate.
- **`just bench-compare <base_ref>`** (new recipe): benchmarks `HEAD` vs `<base_ref>` back-to-back on one machine and runs the comparator. Clean-tree-guarded, and restores the original ref via a `trap` even on failure. Also a great local tool: `just db-up && FALKORDB_HOST=localhost FALKORDB_PORT=6379 just bench-compare origin/master`.
- **`benchmark-pr`** now runs `just bench-compare ${{ base.sha }}` (with `fetch-depth: 0`) and posts a **sticky** comparison comment + job summary. Regressions are **reported but non-blocking**; the job fails only if the benchmark itself breaks. The `benchmark-master` job is unchanged — it still publishes the gh-pages trend/curve.

## Validation

- `compare_bench.py` unit-verified: correct ratios, ✅/⚠️ verdicts, exit codes (report-only vs `--fail-on-regression` vs exit-2 on no data), and None-safe cells for a base/head metric mismatch.
- `just bench-compare origin/master` run locally end-to-end (twice): benches both refs, restores git state, writes the report — same-machine ✅ ~1.00× (identical client), confirming the mechanism.
- `actionlint` clean (includes shellcheck of the inline scripts).
- Self-reviewed (code-review agent); fixed a metric-mismatch crash and made the PR-comment write best-effort so a fork PR's read-only token can't fail the green job.

This is the automated form of the local A/B I posted on #349. Independent of the Wave-4 work.
