### PR TITLE
feat: add JSpecify nullability to the public API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,11 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.jspecify</groupId>
+			<artifactId>jspecify</artifactId>
+			<version>1.0.0</version>
+		</dependency>
+		<dependency>
 			<groupId>redis.clients</groupId>
 			<artifactId>jedis</artifactId>
 			<version>7.5.3</version>
@@ -121,6 +126,16 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.15.0</version>
+				<configuration>
+					<!-- Silence the spurious "unknown enum constant ElementType.MODULE" [classfile]
+					     warning: JSpecify's @NullMarked @Target lists the Java-9 ElementType.MODULE,
+					     which the release-8 symbol table can't resolve. It is harmless (the annotation
+					     still applies); Java-8 compatibility is guaranteed by release 8 + Enforcer +
+					     Animal Sniffer + the JDK-8 smoke, not by this lint category. -->
+					<compilerArgs>
+						<arg>-Xlint:-classfile</arg>
+					</compilerArgs>
+				</configuration>
 			</plugin>
 
 			<plugin>
@@ -472,7 +487,13 @@
 						<artifactId>maven-javadoc-plugin</artifactId>
 						<version>3.12.0</version>
 						<configuration>
-							<source>8</source>
+							<!-- Doc-generation only: pin javadoc to release 11 so JSpecify's @NullMarked
+							     @Target (which lists the Java-9 ElementType.MODULE) resolves — under
+							     release 8 javadoc emits a spurious "unknown enum constant ElementType.MODULE"
+							     warning that failOnWarnings turns fatal. This does NOT affect the shipped
+							     artifact: the compiler still targets release 8 (Enforcer + Animal Sniffer +
+							     the JDK-8 smoke guarantee Java-8 compatibility). -->
+							<release>11</release>
 							<show>protected</show>
 							<doclint>all</doclint>
 							<failOnWarnings>true</failOnWarnings>

--- a/smoke-test/src/test/java/com/falkordb/smoke/SmokeTest.java
+++ b/smoke-test/src/test/java/com/falkordb/smoke/SmokeTest.java
@@ -2,12 +2,17 @@ package com.falkordb.smoke;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.falkordb.Driver;
 import com.falkordb.FalkorDB;
 import com.falkordb.GraphContextGenerator;
 import com.falkordb.Record;
 import com.falkordb.ResultSet;
+import com.falkordb.graph_entities.GraphEntity;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.Method;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
@@ -41,5 +46,29 @@ class SmokeTest {
                 graph.deleteGraph();
             }
         }
+    }
+
+    /**
+     * Proves the shipped JSpecify nullability annotations load and are reflectively visible on a
+     * JDK-8 runtime: {@code GraphEntity.getProperty(String)} carries a runtime-retained, TYPE_USE
+     * {@code @Nullable} on its return. (We deliberately reflect on a member annotation, not on the
+     * package {@code @NullMarked}, to avoid JSpecify's documented Java-8 {@code ElementType.MODULE}
+     * reflection caveat.)
+     */
+    @Test
+    void jspecifyNullableIsVisibleAtRuntimeOnJava8() throws Exception {
+        Method getProperty = GraphEntity.class.getMethod("getProperty", String.class);
+        AnnotatedType returnType = getProperty.getAnnotatedReturnType();
+        boolean nullablePresent = false;
+        for (Annotation annotation : returnType.getAnnotations()) {
+            if ("org.jspecify.annotations.Nullable".equals(
+                    annotation.annotationType().getName())) {
+                nullablePresent = true;
+                break;
+            }
+        }
+        assertTrue(
+                nullablePresent,
+                "GraphEntity.getProperty(String) should carry a runtime-visible @Nullable on JDK 8");
     }
 }

--- a/src/main/java/com/falkordb/Driver.java
+++ b/src/main/java/com/falkordb/Driver.java
@@ -2,6 +2,7 @@ package com.falkordb;
 
 import java.io.Closeable;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 import redis.clients.jedis.Jedis;
 
 /**
@@ -55,7 +56,7 @@ public interface Driver extends Closeable {
      * @param withCode Whether to include the code in the response
      * @return a list of UDF library information
      */
-    List<Object> udfList(String libraryName, boolean withCode);
+    List<Object> udfList(@Nullable String libraryName, boolean withCode);
 
     /**
      * Flushes all loaded UDF libraries.

--- a/src/main/java/com/falkordb/FalkorDB.java
+++ b/src/main/java/com/falkordb/FalkorDB.java
@@ -3,6 +3,7 @@ package com.falkordb;
 import com.falkordb.impl.api.DriverImpl;
 import java.net.URI;
 import java.time.Duration;
+import org.jspecify.annotations.Nullable;
 
 /**
  * FalkorDB driver factory
@@ -92,14 +93,14 @@ public final class FalkorDB {
 
         private String host = "localhost";
         private int port = 6379;
-        private String user;
-        private String password;
+        private @Nullable String user;
+        private @Nullable String password;
         private boolean ssl;
-        private Duration connectionTimeout;
-        private Duration socketTimeout;
-        private Integer poolMaxTotal;
-        private Integer poolMaxIdle;
-        private Duration poolMaxWait;
+        private @Nullable Duration connectionTimeout;
+        private @Nullable Duration socketTimeout;
+        private @Nullable Integer poolMaxTotal;
+        private @Nullable Integer poolMaxIdle;
+        private @Nullable Duration poolMaxWait;
 
         private Builder() {}
 

--- a/src/main/java/com/falkordb/GraphTransaction.java
+++ b/src/main/java/com/falkordb/GraphTransaction.java
@@ -3,6 +3,7 @@ package com.falkordb;
 import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 import redis.clients.jedis.Response;
 import redis.clients.jedis.commands.PipelineBinaryCommands;
 import redis.clients.jedis.commands.PipelineCommands;
@@ -160,6 +161,7 @@ public interface GraphTransaction
      * executes the transaction
      * @return a list of the executed transaction commands answers, in case of successful transaction, null otherwise
      */
+    @Nullable
     List<Object> exec();
 
     /**

--- a/src/main/java/com/falkordb/Record.java
+++ b/src/main/java/com/falkordb/Record.java
@@ -16,7 +16,7 @@ public interface Record {
      * @param index field index
      * @param <T> return value type
      *
-     * @return the value
+     * @return the value at the field, or {@code null} if the stored value is null
      */
     <T> @Nullable T getValue(int index);
 
@@ -26,7 +26,7 @@ public interface Record {
      * @param key header key
      * @param <T> return value type
      *
-     * @return the value
+     * @return the value at the field, or {@code null} if the stored value is null
      */
     <T> @Nullable T getValue(String key);
 

--- a/src/main/java/com/falkordb/Record.java
+++ b/src/main/java/com/falkordb/Record.java
@@ -1,6 +1,7 @@
 package com.falkordb;
 
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Container for Graph result values.
@@ -17,7 +18,7 @@ public interface Record {
      *
      * @return the value
      */
-    <T> T getValue(int index);
+    <T> @Nullable T getValue(int index);
 
     /**
      * The value at the given field
@@ -27,7 +28,7 @@ public interface Record {
      *
      * @return the value
      */
-    <T> T getValue(String key);
+    <T> @Nullable T getValue(String key);
 
     /**
      * The value at the given field index (represented as String)

--- a/src/main/java/com/falkordb/Statistics.java
+++ b/src/main/java/com/falkordb/Statistics.java
@@ -1,5 +1,7 @@
 package com.falkordb;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * An interface for the statistics of a result set.
  */
@@ -67,7 +69,7 @@ public interface Statistics {
          * @param value label text
          * @return the matching Label
          */
-        public static Label getEnum(String value) {
+        public static @Nullable Label getEnum(String value) {
             for (Label v : values()) {
                 if (v.toString().equalsIgnoreCase(value)) return v;
             }
@@ -81,6 +83,7 @@ public interface Statistics {
      * @param label the requested statistic label
      * @return a String representation of the specific statistic or null
      */
+    @Nullable
     String getStringValue(Statistics.Label label);
 
     /**

--- a/src/main/java/com/falkordb/Statistics.java
+++ b/src/main/java/com/falkordb/Statistics.java
@@ -67,7 +67,7 @@ public interface Statistics {
          * Get a Label by label text
          *
          * @param value label text
-         * @return the matching Label
+         * @return the matching Label, or {@code null} if no label matches the given text
          */
         public static @Nullable Label getEnum(String value) {
             for (Label v : values()) {

--- a/src/main/java/com/falkordb/exceptions/GraphException.java
+++ b/src/main/java/com/falkordb/exceptions/GraphException.java
@@ -1,5 +1,6 @@
 package com.falkordb.exceptions;
 
+import org.jspecify.annotations.Nullable;
 import redis.clients.jedis.exceptions.JedisDataException;
 
 /**
@@ -14,7 +15,7 @@ public class GraphException extends JedisDataException {
      *
      * @param message the error message
      */
-    public GraphException(String message) {
+    public GraphException(@Nullable String message) {
         super(message);
     }
 
@@ -23,7 +24,7 @@ public class GraphException extends JedisDataException {
      *
      * @param cause the cause of the exception
      */
-    public GraphException(Throwable cause) {
+    public GraphException(@Nullable Throwable cause) {
         super(cause);
     }
 
@@ -33,7 +34,7 @@ public class GraphException extends JedisDataException {
      * @param message the error message
      * @param cause the cause of the exception
      */
-    public GraphException(String message, Throwable cause) {
+    public GraphException(@Nullable String message, @Nullable Throwable cause) {
         super(message, cause);
     }
 }

--- a/src/main/java/com/falkordb/exceptions/package-info.java
+++ b/src/main/java/com/falkordb/exceptions/package-info.java
@@ -2,8 +2,8 @@
  * Exceptions thrown by the FalkorDB client, principally {@link
  * com.falkordb.exceptions.GraphException}.
  *
- * <p>This package is {@link org.jspecify.annotations.NullMarked}: every type usage is non-null unless
- * it is explicitly annotated {@link org.jspecify.annotations.Nullable}.
+ * <p>This package is {@link org.jspecify.annotations.NullMarked}: an unannotated type usage is
+ * non-null, and the nullable ones are explicitly annotated {@link org.jspecify.annotations.Nullable}.
  */
 @NullMarked
 package com.falkordb.exceptions;

--- a/src/main/java/com/falkordb/exceptions/package-info.java
+++ b/src/main/java/com/falkordb/exceptions/package-info.java
@@ -1,0 +1,11 @@
+/**
+ * Exceptions thrown by the FalkorDB client, principally {@link
+ * com.falkordb.exceptions.GraphException}.
+ *
+ * <p>This package is {@link org.jspecify.annotations.NullMarked}: every type usage is non-null unless
+ * it is explicitly annotated {@link org.jspecify.annotations.Nullable}.
+ */
+@NullMarked
+package com.falkordb.exceptions;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/com/falkordb/graph_entities/Edge.java
+++ b/src/main/java/com/falkordb/graph_entities/Edge.java
@@ -34,7 +34,7 @@ public class Edge extends GraphEntity {
     /**
      * Returns the edge relationship type.
      *
-     * @return the edge relationship type
+     * @return the edge relationship type, or {@code null} if it has not been set
      */
     public @Nullable String getRelationshipType() {
         return relationshipType;

--- a/src/main/java/com/falkordb/graph_entities/Edge.java
+++ b/src/main/java/com/falkordb/graph_entities/Edge.java
@@ -1,6 +1,7 @@
 package com.falkordb.graph_entities;
 
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A class represent an edge (graph entity). In addition to the base class id and properties, an edge shows its source,
@@ -9,7 +10,7 @@ import java.util.Objects;
 public class Edge extends GraphEntity {
 
     // members
-    private String relationshipType;
+    private @Nullable String relationshipType;
     private long source;
     private long destination;
 
@@ -35,7 +36,7 @@ public class Edge extends GraphEntity {
      *
      * @return the edge relationship type
      */
-    public String getRelationshipType() {
+    public @Nullable String getRelationshipType() {
         return relationshipType;
     }
 
@@ -44,7 +45,7 @@ public class Edge extends GraphEntity {
      *
      * @param relationshipType - the relationship type to be set.
      */
-    public void setRelationshipType(String relationshipType) {
+    public void setRelationshipType(@Nullable String relationshipType) {
         this.relationshipType = relationshipType;
     }
 

--- a/src/main/java/com/falkordb/graph_entities/GraphEntity.java
+++ b/src/main/java/com/falkordb/graph_entities/GraphEntity.java
@@ -1,6 +1,7 @@
 package com.falkordb.graph_entities;
 
 import java.util.*;
+import org.jspecify.annotations.Nullable;
 
 /**
  * This is an abstract class for representing a graph entity.
@@ -59,7 +60,7 @@ public abstract class GraphEntity {
      * @param name property name
      * @param value property value
      */
-    public void addProperty(String name, Object value) {
+    public void addProperty(String name, @Nullable Object value) {
         addProperty(new Property(name, value));
     }
 
@@ -96,7 +97,7 @@ public abstract class GraphEntity {
      * @param propertyName - property name as lookup key (String)
      * @return property object, or null if key is not found
      */
-    public Property getProperty(String propertyName) {
+    public @Nullable Property getProperty(String propertyName) {
         return propertyMap.get(propertyName);
     }
 

--- a/src/main/java/com/falkordb/graph_entities/GraphEntity.java
+++ b/src/main/java/com/falkordb/graph_entities/GraphEntity.java
@@ -74,12 +74,18 @@ public abstract class GraphEntity {
     }
 
     /**
-     * Add a property to the entity
+     * Add a property to the entity. The property's {@link Property#getName() name} is the lookup key
+     * and must not be null (so {@link #getEntityPropertyNames()} never contains null).
      *
-     * @param property property object
+     * @param property property object; its name must not be null
+     * @throws IllegalArgumentException if the property's name is null
      */
     public void addProperty(Property property) {
-        propertyMap.put(property.getName(), property);
+        String name = property.getName();
+        if (name == null) {
+            throw new IllegalArgumentException("property name must not be null");
+        }
+        propertyMap.put(name, property);
     }
 
     /**

--- a/src/main/java/com/falkordb/graph_entities/Property.java
+++ b/src/main/java/com/falkordb/graph_entities/Property.java
@@ -33,7 +33,7 @@ public class Property<T> {
     /**
      * Returns the property name.
      *
-     * @return property name
+     * @return the property name, or {@code null} if it has not been set
      */
     public @Nullable String getName() {
         return name;
@@ -51,7 +51,7 @@ public class Property<T> {
     /**
      * Returns the property value.
      *
-     * @return property value
+     * @return the property value, or {@code null} if it has not been set
      */
     public @Nullable T getValue() {
         return value;

--- a/src/main/java/com/falkordb/graph_entities/Property.java
+++ b/src/main/java/com/falkordb/graph_entities/Property.java
@@ -1,6 +1,7 @@
 package com.falkordb.graph_entities;
 
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A Graph entity property. Has a name, type, and value.
@@ -10,8 +11,8 @@ import java.util.Objects;
 public class Property<T> {
 
     // members
-    private String name;
-    private T value;
+    private @Nullable String name;
+    private @Nullable T value;
 
     /**
      * Default constructor
@@ -24,7 +25,7 @@ public class Property<T> {
      * @param name property name
      * @param value property value
      */
-    public Property(String name, T value) {
+    public Property(@Nullable String name, @Nullable T value) {
         this.name = name;
         this.value = value;
     }
@@ -34,7 +35,7 @@ public class Property<T> {
      *
      * @return property name
      */
-    public String getName() {
+    public @Nullable String getName() {
         return name;
     }
 
@@ -43,7 +44,7 @@ public class Property<T> {
      *
      * @param name property name to be set
      */
-    public void setName(String name) {
+    public void setName(@Nullable String name) {
         this.name = name;
     }
 
@@ -52,7 +53,7 @@ public class Property<T> {
      *
      * @return property value
      */
-    public T getValue() {
+    public @Nullable T getValue() {
         return value;
     }
 
@@ -61,21 +62,21 @@ public class Property<T> {
      *
      * @param value property value to be set
      */
-    public void setValue(T value) {
+    public void setValue(@Nullable T value) {
         this.value = value;
     }
 
     // equals() treats an Integer value as equal to the numerically-equal Long (the server can return
     // either width for the same value). hashCode() must apply the SAME normalization, otherwise equal
     // properties can hash differently - e.g. Integer(-1).hashCode() == -1 but Long(-1L).hashCode() == 0.
-    private static Object normalizeValue(Object value) {
+    private static @Nullable Object normalizeValue(@Nullable Object value) {
         if (value instanceof Integer) {
             return Long.valueOf(((Integer) value).longValue());
         }
         return value;
     }
 
-    private boolean valueEquals(Object value1, Object value2) {
+    private boolean valueEquals(@Nullable Object value1, @Nullable Object value2) {
         return Objects.equals(normalizeValue(value1), normalizeValue(value2));
     }
 

--- a/src/main/java/com/falkordb/graph_entities/package-info.java
+++ b/src/main/java/com/falkordb/graph_entities/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * Graph entity value types returned by query results: {@link com.falkordb.graph_entities.Node},
+ * {@link com.falkordb.graph_entities.Edge}, {@link com.falkordb.graph_entities.Path}, {@link
+ * com.falkordb.graph_entities.Point}, and their {@link com.falkordb.graph_entities.Property Properties}.
+ *
+ * <p>This package is {@link org.jspecify.annotations.NullMarked}: every type usage is non-null unless
+ * it is explicitly annotated {@link org.jspecify.annotations.Nullable}.
+ */
+@NullMarked
+package com.falkordb.graph_entities;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/com/falkordb/graph_entities/package-info.java
+++ b/src/main/java/com/falkordb/graph_entities/package-info.java
@@ -3,8 +3,8 @@
  * {@link com.falkordb.graph_entities.Edge}, {@link com.falkordb.graph_entities.Path}, {@link
  * com.falkordb.graph_entities.Point}, and their {@link com.falkordb.graph_entities.Property Properties}.
  *
- * <p>This package is {@link org.jspecify.annotations.NullMarked}: every type usage is non-null unless
- * it is explicitly annotated {@link org.jspecify.annotations.Nullable}.
+ * <p>This package is {@link org.jspecify.annotations.NullMarked}: an unannotated type usage is
+ * non-null, and the nullable ones are explicitly annotated {@link org.jspecify.annotations.Nullable}.
  */
 @NullMarked
 package com.falkordb.graph_entities;

--- a/src/main/java/com/falkordb/package-info.java
+++ b/src/main/java/com/falkordb/package-info.java
@@ -4,8 +4,8 @@
  * com.falkordb.ResultSet}, {@link com.falkordb.Record}, {@link com.falkordb.Header}, {@link
  * com.falkordb.Statistics}) used to run queries and read their results.
  *
- * <p>This package is {@link org.jspecify.annotations.NullMarked}: every type usage is non-null unless
- * it is explicitly annotated {@link org.jspecify.annotations.Nullable}.
+ * <p>This package is {@link org.jspecify.annotations.NullMarked}: an unannotated type usage is
+ * non-null, and the nullable ones are explicitly annotated {@link org.jspecify.annotations.Nullable}.
  */
 @NullMarked
 package com.falkordb;

--- a/src/main/java/com/falkordb/package-info.java
+++ b/src/main/java/com/falkordb/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * Core FalkorDB client API: the {@link com.falkordb.FalkorDB} driver factory plus the {@link
+ * com.falkordb.Driver}, {@link com.falkordb.Graph}, and result-reading interfaces ({@link
+ * com.falkordb.ResultSet}, {@link com.falkordb.Record}, {@link com.falkordb.Header}, {@link
+ * com.falkordb.Statistics}) used to run queries and read their results.
+ *
+ * <p>This package is {@link org.jspecify.annotations.NullMarked}: every type usage is non-null unless
+ * it is explicitly annotated {@link org.jspecify.annotations.Nullable}.
+ */
+@NullMarked
+package com.falkordb;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
## What

Adds **JSpecify nullability** to the JFalkorDB public API — **Wave 4 · PR 15b** (completes item #332·15 alongside 15a #349).

- Ships `org.jspecify:jspecify` 1.0.0 (compile scope; verified **class-file 52 / Java 8**, `@Nullable` is `TYPE_USE` + `RUNTIME`).
- Marks the three **public** packages `@NullMarked` via `package-info.java` (`com.falkordb`, `com.falkordb.graph_entities`, `com.falkordb.exceptions`) → everything is **non-null by default**; `com.falkordb.impl` stays unmarked (internal, api-diff-excluded).
- Annotates the genuinely-nullable members `@Nullable` (per-member audit + a `code-review` pass): `GraphEntity.getProperty`, `addProperty` value; `Property` name/value; `Edge.relationshipType`; `Record.getValue(int|String)`; `Statistics.getStringValue` + `Label.getEnum`; **`GraphTransaction.exec`** (null on a WATCH-aborted `MULTI/EXEC`); `Driver.udfList` `libraryName`; `GraphException` message/cause.

## Java-8 safety (unchanged artifact)

- Compiler still targets **release 8**; Enforcer (bytecode ≤ 1.8), Animal Sniffer (`java18`), and the JDK-8 smoke are untouched. `jspecify` has **no transitive deps**.
- The strict **javadoc** gate pins **`<release>11</release>`** (doc-generation only) so `@NullMarked`'s Java-9 `ElementType.MODULE` `@Target` resolves — otherwise it emits a spurious "unknown enum constant" that `failOnWarnings` turned fatal. The default compiler silences the same cosmetic `[classfile]` warning.
- **New JDK-8 smoke** reflects on `GraphEntity.getProperty()` and asserts its return carries a runtime-visible `@Nullable` — proving the annotations load on Java 8.

## Validation (via `just` = CI)

Green locally: **verify · lint · fmt-check · api-diff** (annotations are additive/compatible) **· javadoc · verify-jdk8** (JSpecify loads + reflects on JDK 8). Self-reviewed with the `code-review` agent — it caught the `GraphTransaction.exec()` nullable return and a missed `GraphException` edit, both fixed here.

Closes item **15** of #332 (15a + 15b). Unblocks PR 16 (examples).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added explicit nullability information across the public client API, clarifying which values, parameters, and results may be absent.
  * Documented core and graph entity packages with non-null-by-default behavior.

* **Bug Fixes**
  * Improved Java 8 compatibility for runtime-visible nullability annotations.
  * Updated documentation generation to avoid Java module-related warnings.

* **Tests**
  * Added coverage verifying nullable annotations are visible at runtime on Java 8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->