### PR TITLE
perf: de-pin GraphCacheList cache refresh for virtual threads

### DIFF
--- a/src/main/java/com/falkordb/impl/graph_cache/GraphCacheList.java
+++ b/src/main/java/com/falkordb/impl/graph_cache/GraphCacheList.java
@@ -6,6 +6,7 @@ import com.falkordb.ResultSet;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Represents a local cache of list of strings. Holds data from a specific procedure, for a specific graph.
@@ -15,7 +16,15 @@ class GraphCacheList {
     private final String procedure;
     private final List<String> data = new CopyOnWriteArrayList<>();
     // Serializes cache refresh; don't synchronize on `data` itself (it's a concurrent collection).
-    private final Object refreshLock = new Object();
+    // This is a ReentrantLock rather than a `synchronized` block on purpose: refreshing the cache
+    // issues a blocking query (getProcedureInfo -> graph.callProcedure), and on JDK 21-23 a
+    // `synchronized` monitor held across a blocking call PINS the carrier thread, so many concurrent
+    // queries on virtual threads would not scale. A ReentrantLock held across the same blocking call
+    // does not pin. (It is still reentrant, matching `synchronized`, so a refresh that recursively
+    // touches this cache on the same thread is safe.) Note: cold connection creation inside
+    // commons-pool2's GenericObjectPool.create() is itself `synchronized` and can still capture a
+    // carrier under load — that is upstream; mitigate by warming the pool (see the Wave-5 docs).
+    private final ReentrantLock refreshLock = new ReentrantLock();
 
     /**
      * @param procedure - exact procedure command
@@ -31,10 +40,13 @@ class GraphCacheList {
      */
     public String getCachedData(int index, Graph graph) {
         if (index >= data.size()) {
-            synchronized (refreshLock) {
+            refreshLock.lock();
+            try {
                 if (index >= data.size()) {
                     getProcedureInfo(graph);
                 }
+            } finally {
+                refreshLock.unlock();
             }
         }
         return data.get(index);
@@ -57,6 +69,13 @@ class GraphCacheList {
     }
 
     public void clear() {
-        data.clear();
+        // Serialize with an in-flight refresh (both guard `data` via refreshLock) so a clear can't
+        // interleave with getProcedureInfo()'s append and leave a half-refreshed cache.
+        refreshLock.lock();
+        try {
+            data.clear();
+        } finally {
+            refreshLock.unlock();
+        }
     }
 }

--- a/src/test/java/com/falkordb/impl/graph_cache/GraphCacheListTest.java
+++ b/src/test/java/com/falkordb/impl/graph_cache/GraphCacheListTest.java
@@ -1,0 +1,223 @@
+package com.falkordb.impl.graph_cache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.falkordb.Graph;
+import com.falkordb.Header;
+import com.falkordb.Record;
+import com.falkordb.ResultSet;
+import com.falkordb.Statistics;
+import com.falkordb.impl.resultset.RecordImpl;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link GraphCacheList}'s cache-refresh behavior — in particular that the
+ * double-checked refresh runs the (blocking) procedure exactly once under concurrency after the
+ * de-pinning change from a {@code synchronized} block to a {@link java.util.concurrent.locks.ReentrantLock}.
+ */
+class GraphCacheListTest {
+
+    @Test
+    void returnsProcedureValuesAndRefreshesOnce() {
+        CountingGraph graph = new CountingGraph("a", "b", "c");
+        GraphCacheList cache = new GraphCacheList("db.labels");
+
+        assertEquals("a", cache.getCachedData(0, graph));
+        assertEquals("b", cache.getCachedData(1, graph));
+        assertEquals("c", cache.getCachedData(2, graph));
+        assertEquals(1, graph.calls.get(), "cached indices should not re-run the procedure");
+    }
+
+    @Test
+    void concurrentGetForAFreshIndexRefreshesExactlyOnce() throws InterruptedException {
+        CountingGraph graph = new CountingGraph("a", "b", "c");
+        GraphCacheList cache = new GraphCacheList("db.labels");
+
+        int threads = 16;
+        CountDownLatch ready = new CountDownLatch(threads);
+        CountDownLatch go = new CountDownLatch(1);
+        List<Thread> workers = new ArrayList<>();
+        List<String> results = Collections.synchronizedList(new ArrayList<>());
+        for (int i = 0; i < threads; i++) {
+            Thread t = new Thread(() -> {
+                ready.countDown();
+                try {
+                    go.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                results.add(cache.getCachedData(0, graph));
+            });
+            workers.add(t);
+            t.start();
+        }
+        ready.await();
+        go.countDown(); // release all workers at once to race the refresh
+        for (Thread t : workers) {
+            t.join();
+        }
+
+        assertEquals(1, graph.calls.get(), "the double-checked refresh must run the procedure once");
+        assertEquals(threads, results.size());
+        for (String r : results) {
+            assertEquals("a", r);
+        }
+    }
+
+    @Test
+    void clearForcesARefreshOnNextGet() {
+        CountingGraph graph = new CountingGraph("a", "b", "c");
+        GraphCacheList cache = new GraphCacheList("db.labels");
+
+        assertEquals("a", cache.getCachedData(0, graph));
+        assertEquals(1, graph.calls.get());
+
+        cache.clear();
+        assertEquals("a", cache.getCachedData(0, graph));
+        assertEquals(2, graph.calls.get(), "after clear the cache must re-fetch");
+    }
+
+    /** A {@link Graph} that only implements {@code callProcedure(String)}, counting invocations. */
+    private static final class CountingGraph implements Graph {
+        final AtomicInteger calls = new AtomicInteger();
+        private final List<String> values;
+
+        CountingGraph(String... values) {
+            this.values = new ArrayList<>();
+            Collections.addAll(this.values, values);
+        }
+
+        @Override
+        public ResultSet callProcedure(String procedure) {
+            calls.incrementAndGet();
+            List<Record> records = new ArrayList<>();
+            for (String v : values) {
+                records.add(new RecordImpl(Collections.singletonList("col"), Collections.singletonList(v)));
+            }
+            return new ListResultSet(records);
+        }
+
+        // --- unused Graph operations ---
+        @Override
+        public ResultSet query(String query) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResultSet readOnlyQuery(String query) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResultSet query(String query, long timeout) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResultSet readOnlyQuery(String query, long timeout) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResultSet query(String query, Map<String, Object> params) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResultSet readOnlyQuery(String query, Map<String, Object> params) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResultSet query(String query, Map<String, Object> params, long timeout) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResultSet readOnlyQuery(String query, Map<String, Object> params, long timeout) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResultSet profile(String query) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResultSet profile(String query, Map<String, Object> params) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResultSet callProcedure(String procedure, List<String> args) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ResultSet callProcedure(String procedure, List<String> args, Map<String, List<String>> kwargs) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String copyGraph(String destinationGraphId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String deleteGraph() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<String> explain(String query) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<String> explain(String query, Map<String, Object> params) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+    }
+
+    /** A minimal {@link ResultSet} backed by a list of records (only iteration is exercised). */
+    private static final class ListResultSet implements ResultSet {
+        private final List<Record> records;
+
+        ListResultSet(List<Record> records) {
+            this.records = records;
+        }
+
+        @Override
+        public Iterator<Record> iterator() {
+            return records.iterator();
+        }
+
+        @Override
+        public int size() {
+            return records.size();
+        }
+
+        @Override
+        public Statistics getStatistics() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Header getHeader() {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/src/test/java/com/falkordb/impl/graph_cache/GraphCacheListTest.java
+++ b/src/test/java/com/falkordb/impl/graph_cache/GraphCacheListTest.java
@@ -1,6 +1,8 @@
 package com.falkordb.impl.graph_cache;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.falkordb.Graph;
 import com.falkordb.Header;
@@ -14,6 +16,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
@@ -59,10 +62,11 @@ class GraphCacheListTest {
             workers.add(t);
             t.start();
         }
-        ready.await();
+        assertTrue(ready.await(10, TimeUnit.SECONDS), "workers did not reach the start line in time");
         go.countDown(); // release all workers at once to race the refresh
         for (Thread t : workers) {
-            t.join();
+            t.join(TimeUnit.SECONDS.toMillis(10));
+            assertFalse(t.isAlive(), "a worker did not finish in time — possible deadlock in the refresh path");
         }
 
         assertEquals(1, graph.calls.get(), "the double-checked refresh must run the procedure once");


### PR DESCRIPTION
Wave 5 (#333) · **Track 1 · PR A** — the de-pinning fix.

## What

`GraphCacheList.getCachedData` held a `synchronized (refreshLock)` **across a blocking**
`graph.callProcedure(...)`. On JDK 21–23 a `synchronized` monitor held across a blocking call **pins
the carrier thread**, so running many concurrent queries on virtual threads wouldn't scale. This swaps
it to a **`ReentrantLock`** (same double-checked refresh; still reentrant), which does **not** pin.
`clear()` now takes the same lock so it can't interleave with an in-flight refresh.

This is the **only** `synchronized` in `src/main/java/com/falkordb/**` (grep-verified). The remaining
pinning path — cold connection creation in **commons-pool2 2.12.1** `GenericObjectPool.create()` — is
**upstream**; it's documented here (mitigate by warming the pool / a finite `poolMaxWait`) and covered
by the follow-up pinning check (PR B) + docs (PR C).

## Tests / validation

- New `GraphCacheListTest`: the double-checked refresh runs the procedure **exactly once** under 16
  concurrent `getCachedData` callers; `clear()` forces a re-fetch.
- Behavior-preserving — the existing IT suite exercises the cache on every query.
- Green via `just`: **verify · lint · api-diff · javadoc** (impl-only, additive).

Part of #333. Track 2 (the `CompletableFuture` async facade) is an independent parallel PR.
