### PR TITLE
feat: add CompletableFuture async facade (AsyncGraph / AsyncFalkorDB)

### DIFF
--- a/src/main/java/com/falkordb/AsyncFalkorDB.java
+++ b/src/main/java/com/falkordb/AsyncFalkorDB.java
@@ -1,0 +1,40 @@
+package com.falkordb;
+
+import com.falkordb.impl.api.AsyncGraphImpl;
+import java.util.concurrent.Executor;
+
+/**
+ * Factory for {@link AsyncGraph}, an asynchronous view over a synchronous {@link Graph}.
+ *
+ * <p>The client stays a blocking, Java-8 client; asynchrony is provided entirely by the
+ * caller-supplied {@link Executor}. On JDK 21+ pass {@code Executors.newVirtualThreadPerTaskExecutor()}
+ * to fan a blocking graph out over many virtual threads:
+ *
+ * <pre>{@code
+ * Driver driver = FalkorDB.driver();
+ * ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor(); // JDK 21+
+ * AsyncGraph async = AsyncFalkorDB.wrap(driver.graph("social"), pool);
+ * CompletableFuture<ResultSet> f = async.query("MATCH (n) RETURN count(n)");
+ * // ... on shutdown: drain outstanding futures, then pool.shutdown() and driver.close()
+ * }</pre>
+ */
+public final class AsyncFalkorDB {
+
+    private AsyncFalkorDB() {}
+
+    /**
+     * Wraps a synchronous graph as an {@link AsyncGraph} whose operations run on {@code executor}.
+     *
+     * <p>Use a pool-per-call {@code driver.graph(id)} (a {@link GraphContextGenerator}), which is safe
+     * for concurrent calls; do not wrap a connection-bound {@link GraphContext}. The returned facade
+     * owns neither {@code graph} nor {@code executor}: the caller drains outstanding futures, shuts the
+     * executor down, then closes the graph and driver.
+     *
+     * @param graph    the synchronous graph to wrap (typically {@code driver.graph(id)})
+     * @param executor the executor each operation runs on (e.g. a virtual-thread executor on JDK 21+)
+     * @return an asynchronous view over {@code graph}
+     */
+    public static AsyncGraph wrap(GraphContextGenerator graph, Executor executor) {
+        return new AsyncGraphImpl(graph, executor);
+    }
+}

--- a/src/main/java/com/falkordb/AsyncGraph.java
+++ b/src/main/java/com/falkordb/AsyncGraph.java
@@ -1,0 +1,187 @@
+package com.falkordb;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * An asynchronous view over a {@link Graph}: every method mirrors the synchronous {@code Graph}
+ * operation of the same name but runs it on a caller-supplied {@link java.util.concurrent.Executor}
+ * and returns a {@link CompletableFuture}.
+ *
+ * <p>Obtain one with {@link AsyncFalkorDB#wrap(GraphContextGenerator, java.util.concurrent.Executor)},
+ * backing it with a pool-per-call {@code driver.graph(id)} (safe for concurrent calls). The facade owns
+ * nothing — neither the wrapped graph nor the executor — so it is not {@link java.io.Closeable}; the
+ * caller drains outstanding futures, shuts the executor down, then closes the graph and driver.
+ *
+ * <p>On JDK 21+ this pairs with {@code Executors.newVirtualThreadPerTaskExecutor()} to run many
+ * concurrent queries cheaply — the executor is supplied by the caller, so this type stays Java-8.
+ *
+ * <p><strong>Concurrency &amp; backpressure:</strong> real DB concurrency is bounded by the connection
+ * pool ({@code poolMaxTotal}), not the executor; there is no built-in admission bound, so pair a
+ * virtual-thread executor with a finite {@code poolMaxWait} (or your own semaphore) if you need one.
+ * <strong>Cancellation is best-effort:</strong> cancelling a returned future frees the caller and skips
+ * a not-yet-started query, but cannot interrupt a query already on the wire — bound in-flight work with
+ * a per-query/server timeout or a finite socket timeout (not {@code cancel()}). Failures surface as the
+ * future completing exceptionally ({@code join()} throws {@link java.util.concurrent.CompletionException};
+ * {@code get()} throws {@link java.util.concurrent.ExecutionException}). The map/list arguments are read
+ * later on the worker thread, so do not mutate them until the future completes.
+ */
+public interface AsyncGraph {
+
+    /**
+     * Asynchronously runs {@link Graph#query(String)}.
+     *
+     * @param query the Cypher query
+     * @return a future completing with the result set
+     */
+    CompletableFuture<ResultSet> query(String query);
+
+    /**
+     * Asynchronously runs {@link Graph#readOnlyQuery(String)}.
+     *
+     * @param query the Cypher query
+     * @return a future completing with the result set
+     */
+    CompletableFuture<ResultSet> readOnlyQuery(String query);
+
+    /**
+     * Asynchronously runs {@link Graph#query(String, long)}.
+     *
+     * @param query   the Cypher query
+     * @param timeout timeout in milliseconds
+     * @return a future completing with the result set
+     */
+    CompletableFuture<ResultSet> query(String query, long timeout);
+
+    /**
+     * Asynchronously runs {@link Graph#readOnlyQuery(String, long)}.
+     *
+     * @param query   the Cypher query
+     * @param timeout timeout in milliseconds
+     * @return a future completing with the result set
+     */
+    CompletableFuture<ResultSet> readOnlyQuery(String query, long timeout);
+
+    /**
+     * Asynchronously runs {@link Graph#query(String, Map)}.
+     *
+     * @param query  the Cypher query
+     * @param params the query parameters
+     * @return a future completing with the result set
+     */
+    CompletableFuture<ResultSet> query(String query, Map<String, Object> params);
+
+    /**
+     * Asynchronously runs {@link Graph#readOnlyQuery(String, Map)}.
+     *
+     * @param query  the Cypher query
+     * @param params the query parameters
+     * @return a future completing with the result set
+     */
+    CompletableFuture<ResultSet> readOnlyQuery(String query, Map<String, Object> params);
+
+    /**
+     * Asynchronously runs {@link Graph#query(String, Map, long)}.
+     *
+     * @param query   the Cypher query
+     * @param params  the query parameters
+     * @param timeout timeout in milliseconds
+     * @return a future completing with the result set
+     */
+    CompletableFuture<ResultSet> query(String query, Map<String, Object> params, long timeout);
+
+    /**
+     * Asynchronously runs {@link Graph#readOnlyQuery(String, Map, long)}.
+     *
+     * @param query   the Cypher query
+     * @param params  the query parameters
+     * @param timeout timeout in milliseconds
+     * @return a future completing with the result set
+     */
+    CompletableFuture<ResultSet> readOnlyQuery(String query, Map<String, Object> params, long timeout);
+
+    /**
+     * Asynchronously runs {@link Graph#callProcedure(String)}.
+     *
+     * @param procedure the procedure name
+     * @return a future completing with the result set
+     */
+    CompletableFuture<ResultSet> callProcedure(String procedure);
+
+    /**
+     * Asynchronously runs {@link Graph#profile(String)}.
+     *
+     * @param query the Cypher query
+     * @return a future completing with the result set (execution plan and metrics)
+     */
+    CompletableFuture<ResultSet> profile(String query);
+
+    /**
+     * Asynchronously runs {@link Graph#profile(String, Map)}.
+     *
+     * @param query  the Cypher query
+     * @param params the query parameters
+     * @return a future completing with the result set (execution plan and metrics)
+     */
+    CompletableFuture<ResultSet> profile(String query, Map<String, Object> params);
+
+    /**
+     * Asynchronously runs {@link Graph#callProcedure(String, List)}.
+     *
+     * @param procedure the procedure name
+     * @param args      the procedure arguments
+     * @return a future completing with the result set
+     */
+    CompletableFuture<ResultSet> callProcedure(String procedure, List<String> args);
+
+    /**
+     * Asynchronously runs {@link Graph#callProcedure(String, List, Map)}.
+     *
+     * @param procedure the procedure name
+     * @param args      the procedure arguments
+     * @param kwargs    the procedure output arguments
+     * @return a future completing with the result set
+     */
+    CompletableFuture<ResultSet> callProcedure(String procedure, List<String> args, Map<String, List<String>> kwargs);
+
+    /**
+     * Asynchronously runs {@link Graph#copyGraph(String)}.
+     *
+     * @param destinationGraphId the destination graph name
+     * @return a future completing with the copy running-time statistics
+     */
+    CompletableFuture<String> copyGraph(String destinationGraphId);
+
+    /**
+     * Asynchronously runs {@link Graph#deleteGraph()}.
+     *
+     * @return a future completing with the delete running-time statistics
+     */
+    CompletableFuture<String> deleteGraph();
+
+    /**
+     * Asynchronously runs {@link Graph#explain(String)}.
+     *
+     * @param query the Cypher query
+     * @return a future completing with the execution plan
+     */
+    CompletableFuture<List<String>> explain(String query);
+
+    /**
+     * Asynchronously runs {@link Graph#explain(String, Map)}.
+     *
+     * @param query  the Cypher query
+     * @param params the query parameters
+     * @return a future completing with the execution plan
+     */
+    CompletableFuture<List<String>> explain(String query, Map<String, Object> params);
+
+    /**
+     * The wrapped synchronous graph. The caller owns and closes it; use this to reach synchronous or
+     * connection-bound operations not exposed asynchronously.
+     *
+     * @return the wrapped graph
+     */
+    GraphContextGenerator graph();
+}

--- a/src/main/java/com/falkordb/impl/api/AsyncGraphImpl.java
+++ b/src/main/java/com/falkordb/impl/api/AsyncGraphImpl.java
@@ -1,0 +1,123 @@
+package com.falkordb.impl.api;
+
+import com.falkordb.AsyncGraph;
+import com.falkordb.GraphContextGenerator;
+import com.falkordb.ResultSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * Default {@link AsyncGraph} implementation: submits each synchronous {@link com.falkordb.Graph}
+ * operation to the caller-supplied {@link Executor} via {@link CompletableFuture#supplyAsync}.
+ *
+ * <p>Internal — construct through
+ * {@link com.falkordb.AsyncFalkorDB#wrap(GraphContextGenerator, Executor)}.
+ */
+public final class AsyncGraphImpl implements AsyncGraph {
+
+    private final GraphContextGenerator graph;
+    private final Executor executor;
+
+    /**
+     * @param graph    the synchronous graph to delegate to (must be safe for concurrent calls)
+     * @param executor the executor each operation runs on
+     */
+    public AsyncGraphImpl(GraphContextGenerator graph, Executor executor) {
+        this.graph = Objects.requireNonNull(graph, "graph must not be null");
+        this.executor = Objects.requireNonNull(executor, "executor must not be null");
+    }
+
+    @Override
+    public CompletableFuture<ResultSet> query(String query) {
+        return CompletableFuture.supplyAsync(() -> graph.query(query), executor);
+    }
+
+    @Override
+    public CompletableFuture<ResultSet> readOnlyQuery(String query) {
+        return CompletableFuture.supplyAsync(() -> graph.readOnlyQuery(query), executor);
+    }
+
+    @Override
+    public CompletableFuture<ResultSet> query(String query, long timeout) {
+        return CompletableFuture.supplyAsync(() -> graph.query(query, timeout), executor);
+    }
+
+    @Override
+    public CompletableFuture<ResultSet> readOnlyQuery(String query, long timeout) {
+        return CompletableFuture.supplyAsync(() -> graph.readOnlyQuery(query, timeout), executor);
+    }
+
+    @Override
+    public CompletableFuture<ResultSet> query(String query, Map<String, Object> params) {
+        return CompletableFuture.supplyAsync(() -> graph.query(query, params), executor);
+    }
+
+    @Override
+    public CompletableFuture<ResultSet> readOnlyQuery(String query, Map<String, Object> params) {
+        return CompletableFuture.supplyAsync(() -> graph.readOnlyQuery(query, params), executor);
+    }
+
+    @Override
+    public CompletableFuture<ResultSet> query(String query, Map<String, Object> params, long timeout) {
+        return CompletableFuture.supplyAsync(() -> graph.query(query, params, timeout), executor);
+    }
+
+    @Override
+    public CompletableFuture<ResultSet> readOnlyQuery(String query, Map<String, Object> params, long timeout) {
+        return CompletableFuture.supplyAsync(() -> graph.readOnlyQuery(query, params, timeout), executor);
+    }
+
+    @Override
+    public CompletableFuture<ResultSet> callProcedure(String procedure) {
+        return CompletableFuture.supplyAsync(() -> graph.callProcedure(procedure), executor);
+    }
+
+    @Override
+    public CompletableFuture<ResultSet> profile(String query) {
+        return CompletableFuture.supplyAsync(() -> graph.profile(query), executor);
+    }
+
+    @Override
+    public CompletableFuture<ResultSet> profile(String query, Map<String, Object> params) {
+        return CompletableFuture.supplyAsync(() -> graph.profile(query, params), executor);
+    }
+
+    @Override
+    public CompletableFuture<ResultSet> callProcedure(String procedure, List<String> args) {
+        return CompletableFuture.supplyAsync(() -> graph.callProcedure(procedure, args), executor);
+    }
+
+    @Override
+    public CompletableFuture<ResultSet> callProcedure(
+            String procedure, List<String> args, Map<String, List<String>> kwargs) {
+        return CompletableFuture.supplyAsync(() -> graph.callProcedure(procedure, args, kwargs), executor);
+    }
+
+    @Override
+    public CompletableFuture<String> copyGraph(String destinationGraphId) {
+        return CompletableFuture.supplyAsync(() -> graph.copyGraph(destinationGraphId), executor);
+    }
+
+    @Override
+    public CompletableFuture<String> deleteGraph() {
+        return CompletableFuture.supplyAsync(graph::deleteGraph, executor);
+    }
+
+    @Override
+    public CompletableFuture<List<String>> explain(String query) {
+        return CompletableFuture.supplyAsync(() -> graph.explain(query), executor);
+    }
+
+    @Override
+    public CompletableFuture<List<String>> explain(String query, Map<String, Object> params) {
+        return CompletableFuture.supplyAsync(() -> graph.explain(query, params), executor);
+    }
+
+    @Override
+    public GraphContextGenerator graph() {
+        return graph;
+    }
+}

--- a/src/main/java/com/falkordb/impl/api/AsyncGraphImpl.java
+++ b/src/main/java/com/falkordb/impl/api/AsyncGraphImpl.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.function.Supplier;
 
 /**
  * Default {@link AsyncGraph} implementation: submits each synchronous {@link com.falkordb.Graph}
@@ -30,90 +32,106 @@ public final class AsyncGraphImpl implements AsyncGraph {
         this.executor = Objects.requireNonNull(executor, "executor must not be null");
     }
 
+    /**
+     * Submits {@code op} on the executor, always returning a future. If the executor rejects the task
+     * (it is saturated or already shut down), the returned future completes exceptionally with the
+     * {@link RejectedExecutionException} instead of throwing synchronously, so every {@link AsyncGraph}
+     * method honors the "failures surface as exceptional completion" contract.
+     */
+    private <T> CompletableFuture<T> submit(Supplier<T> op) {
+        try {
+            return CompletableFuture.supplyAsync(op, executor);
+        } catch (RejectedExecutionException rejected) {
+            CompletableFuture<T> failed = new CompletableFuture<>();
+            failed.completeExceptionally(rejected);
+            return failed;
+        }
+    }
+
     @Override
     public CompletableFuture<ResultSet> query(String query) {
-        return CompletableFuture.supplyAsync(() -> graph.query(query), executor);
+        return submit(() -> graph.query(query));
     }
 
     @Override
     public CompletableFuture<ResultSet> readOnlyQuery(String query) {
-        return CompletableFuture.supplyAsync(() -> graph.readOnlyQuery(query), executor);
+        return submit(() -> graph.readOnlyQuery(query));
     }
 
     @Override
     public CompletableFuture<ResultSet> query(String query, long timeout) {
-        return CompletableFuture.supplyAsync(() -> graph.query(query, timeout), executor);
+        return submit(() -> graph.query(query, timeout));
     }
 
     @Override
     public CompletableFuture<ResultSet> readOnlyQuery(String query, long timeout) {
-        return CompletableFuture.supplyAsync(() -> graph.readOnlyQuery(query, timeout), executor);
+        return submit(() -> graph.readOnlyQuery(query, timeout));
     }
 
     @Override
     public CompletableFuture<ResultSet> query(String query, Map<String, Object> params) {
-        return CompletableFuture.supplyAsync(() -> graph.query(query, params), executor);
+        return submit(() -> graph.query(query, params));
     }
 
     @Override
     public CompletableFuture<ResultSet> readOnlyQuery(String query, Map<String, Object> params) {
-        return CompletableFuture.supplyAsync(() -> graph.readOnlyQuery(query, params), executor);
+        return submit(() -> graph.readOnlyQuery(query, params));
     }
 
     @Override
     public CompletableFuture<ResultSet> query(String query, Map<String, Object> params, long timeout) {
-        return CompletableFuture.supplyAsync(() -> graph.query(query, params, timeout), executor);
+        return submit(() -> graph.query(query, params, timeout));
     }
 
     @Override
     public CompletableFuture<ResultSet> readOnlyQuery(String query, Map<String, Object> params, long timeout) {
-        return CompletableFuture.supplyAsync(() -> graph.readOnlyQuery(query, params, timeout), executor);
+        return submit(() -> graph.readOnlyQuery(query, params, timeout));
     }
 
     @Override
     public CompletableFuture<ResultSet> callProcedure(String procedure) {
-        return CompletableFuture.supplyAsync(() -> graph.callProcedure(procedure), executor);
+        return submit(() -> graph.callProcedure(procedure));
     }
 
     @Override
     public CompletableFuture<ResultSet> profile(String query) {
-        return CompletableFuture.supplyAsync(() -> graph.profile(query), executor);
+        return submit(() -> graph.profile(query));
     }
 
     @Override
     public CompletableFuture<ResultSet> profile(String query, Map<String, Object> params) {
-        return CompletableFuture.supplyAsync(() -> graph.profile(query, params), executor);
+        return submit(() -> graph.profile(query, params));
     }
 
     @Override
     public CompletableFuture<ResultSet> callProcedure(String procedure, List<String> args) {
-        return CompletableFuture.supplyAsync(() -> graph.callProcedure(procedure, args), executor);
+        return submit(() -> graph.callProcedure(procedure, args));
     }
 
     @Override
     public CompletableFuture<ResultSet> callProcedure(
             String procedure, List<String> args, Map<String, List<String>> kwargs) {
-        return CompletableFuture.supplyAsync(() -> graph.callProcedure(procedure, args, kwargs), executor);
+        return submit(() -> graph.callProcedure(procedure, args, kwargs));
     }
 
     @Override
     public CompletableFuture<String> copyGraph(String destinationGraphId) {
-        return CompletableFuture.supplyAsync(() -> graph.copyGraph(destinationGraphId), executor);
+        return submit(() -> graph.copyGraph(destinationGraphId));
     }
 
     @Override
     public CompletableFuture<String> deleteGraph() {
-        return CompletableFuture.supplyAsync(graph::deleteGraph, executor);
+        return submit(graph::deleteGraph);
     }
 
     @Override
     public CompletableFuture<List<String>> explain(String query) {
-        return CompletableFuture.supplyAsync(() -> graph.explain(query), executor);
+        return submit(() -> graph.explain(query));
     }
 
     @Override
     public CompletableFuture<List<String>> explain(String query, Map<String, Object> params) {
-        return CompletableFuture.supplyAsync(() -> graph.explain(query, params), executor);
+        return submit(() -> graph.explain(query, params));
     }
 
     @Override

--- a/src/test/java/com/falkordb/AsyncFalkorDBIT.java
+++ b/src/test/java/com/falkordb/AsyncFalkorDBIT.java
@@ -93,6 +93,11 @@ public class AsyncFalkorDBIT {
             } finally {
                 if (executor != null) {
                     executor.shutdownNow();
+                    try {
+                        executor.awaitTermination(10, TimeUnit.SECONDS);
+                    } catch (InterruptedException interrupted) {
+                        Thread.currentThread().interrupt();
+                    }
                 }
                 if (driver != null) {
                     driver.close();

--- a/src/test/java/com/falkordb/AsyncFalkorDBIT.java
+++ b/src/test/java/com/falkordb/AsyncFalkorDBIT.java
@@ -1,0 +1,101 @@
+package com.falkordb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * System tests for {@link AsyncFalkorDB} against a real FalkorDB server (via {@link TestServer}).
+ *
+ * <p>Fans the blocking client out over a fixed <em>platform</em>-thread pool to validate the facade's
+ * delegation and concurrent fan-out independently of the thread model. It deliberately does
+ * <strong>not</strong> use a virtual-thread executor: on JDK 21–23 cold connection creation in
+ * commons-pool2 ({@code GenericObjectPool.create()} is {@code synchronized}) pins the carrier thread, and
+ * a creation storm from many virtual threads can starve the carrier pool. Virtual-thread pinning is
+ * characterized separately by the Wave-5 pinning check; the finite {@code poolMaxWait} below keeps a
+ * mis-sized pool from hanging the suite.
+ */
+public class AsyncFalkorDBIT {
+
+    private static final int FAN_OUT = 64;
+    private static final int POOL = 16;
+
+    private Driver driver;
+    private GraphContextGenerator client;
+    private ExecutorService executor;
+
+    private AsyncGraph asyncClient() {
+        driver = FalkorDB.builder()
+                .host(TestServer.host())
+                .port(TestServer.port())
+                .poolMaxTotal(POOL)
+                .poolMaxWait(Duration.ofSeconds(20))
+                .build();
+        client = driver.graph("async-it");
+        executor = newExecutor();
+        return AsyncFalkorDB.wrap(client, executor);
+    }
+
+    @Test
+    public void fansOutConcurrentQueries() throws Exception {
+        AsyncGraph async = asyncClient();
+
+        List<CompletableFuture<ResultSet>> futures = new ArrayList<>(FAN_OUT);
+        for (int i = 0; i < FAN_OUT; i++) {
+            Map<String, Object> params = Collections.singletonMap("i", i);
+            futures.add(async.query("CREATE (:Item {i:$i})", params));
+        }
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(60, TimeUnit.SECONDS);
+
+        for (CompletableFuture<ResultSet> future : futures) {
+            assertEquals(1, future.join().getStatistics().nodesCreated());
+        }
+        ResultSet count = async.readOnlyQuery("MATCH (n:Item) RETURN count(n)").get(30, TimeUnit.SECONDS);
+        Long total = count.iterator().next().getValue(0);
+        assertEquals(FAN_OUT, total.longValue());
+    }
+
+    @Test
+    public void serverErrorsCompleteTheFutureExceptionally() {
+        AsyncGraph async = asyncClient();
+
+        CompletableFuture<ResultSet> future = async.query("THIS IS NOT CYPHER");
+
+        ExecutionException failure = assertThrows(ExecutionException.class, () -> future.get(30, TimeUnit.SECONDS));
+        assertTrue(failure.getCause() instanceof RuntimeException, "server error should surface as the cause");
+    }
+
+    @AfterEach
+    public void cleanup() throws IOException {
+        try {
+            if (client != null) {
+                client.deleteGraph();
+            }
+        } finally {
+            if (executor != null) {
+                executor.shutdownNow();
+            }
+            if (driver != null) {
+                driver.close();
+            }
+        }
+    }
+
+    private static ExecutorService newExecutor() {
+        return Executors.newFixedThreadPool(POOL);
+    }
+}

--- a/src/test/java/com/falkordb/AsyncFalkorDBIT.java
+++ b/src/test/java/com/falkordb/AsyncFalkorDBIT.java
@@ -86,11 +86,17 @@ public class AsyncFalkorDBIT {
                 client.deleteGraph();
             }
         } finally {
-            if (executor != null) {
-                executor.shutdownNow();
-            }
-            if (driver != null) {
-                driver.close();
+            try {
+                if (client != null) {
+                    client.close();
+                }
+            } finally {
+                if (executor != null) {
+                    executor.shutdownNow();
+                }
+                if (driver != null) {
+                    driver.close();
+                }
             }
         }
     }

--- a/src/test/java/com/falkordb/AsyncFalkorDBTest.java
+++ b/src/test/java/com/falkordb/AsyncFalkorDBTest.java
@@ -16,6 +16,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
@@ -93,6 +94,20 @@ class AsyncFalkorDBTest {
 
         assertTrue(future.isCancelled());
         assertEquals(0, graph.calls.get(), "a cancelled-before-start query must never reach the graph");
+    }
+
+    @Test
+    void rejectedSubmissionCompletesExceptionallyRatherThanThrowing() {
+        Executor rejecting = command -> {
+            throw new RejectedExecutionException("saturated");
+        };
+        CompletableFuture<ResultSet> future =
+                AsyncFalkorDB.wrap(graph, rejecting).query("q");
+
+        assertTrue(future.isCompletedExceptionally(), "a rejected submission must yield a failed future");
+        CompletionException failure = assertThrows(CompletionException.class, future::join);
+        assertTrue(failure.getCause() instanceof RejectedExecutionException);
+        assertEquals(0, graph.calls.get(), "a rejected submission must never reach the graph");
     }
 
     /** Executor that queues tasks and only runs them on demand, to observe cancel-before-start. */

--- a/src/test/java/com/falkordb/AsyncFalkorDBTest.java
+++ b/src/test/java/com/falkordb/AsyncFalkorDBTest.java
@@ -246,12 +246,12 @@ class AsyncFalkorDBTest {
 
         @Override
         public Statistics getStatistics() {
-            return null;
+            throw new UnsupportedOperationException("not used by the async facade tests");
         }
 
         @Override
         public Header getHeader() {
-            return null;
+            throw new UnsupportedOperationException("not used by the async facade tests");
         }
     }
 }

--- a/src/test/java/com/falkordb/AsyncFalkorDBTest.java
+++ b/src/test/java/com/falkordb/AsyncFalkorDBTest.java
@@ -1,0 +1,257 @@
+package com.falkordb;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class AsyncFalkorDBTest {
+
+    private static final Executor DIRECT = Runnable::run;
+
+    private final FakeGraph graph = new FakeGraph();
+
+    private void assertDelegates(CompletableFuture<?> future, Object expected, String method, Object... args) {
+        assertSame(expected, future.join(), method + " result should propagate from the wrapped graph");
+        assertEquals(method, graph.lastMethod);
+        assertArrayEquals(args, graph.lastArgs);
+    }
+
+    @Test
+    void wrapRejectsNullArguments() {
+        assertThrows(NullPointerException.class, () -> AsyncFalkorDB.wrap(null, DIRECT));
+        assertThrows(NullPointerException.class, () -> AsyncFalkorDB.wrap(graph, null));
+    }
+
+    @Test
+    void graphReturnsTheWrappedInstance() {
+        assertSame(graph, AsyncFalkorDB.wrap(graph, DIRECT).graph());
+    }
+
+    @Test
+    void everyOperationDelegatesToTheWrappedGraph() {
+        AsyncGraph async = AsyncFalkorDB.wrap(graph, DIRECT);
+        Map<String, Object> params = Collections.singletonMap("k", "v");
+        List<String> args = Collections.singletonList("a");
+        Map<String, List<String>> kwargs = Collections.singletonMap("y", Collections.singletonList("z"));
+
+        assertDelegates(async.query("q"), FakeGraph.RS, "query", "q");
+        assertDelegates(async.readOnlyQuery("q"), FakeGraph.RS, "readOnlyQuery", "q");
+        assertDelegates(async.query("q", 5L), FakeGraph.RS, "query", "q", 5L);
+        assertDelegates(async.readOnlyQuery("q", 5L), FakeGraph.RS, "readOnlyQuery", "q", 5L);
+        assertDelegates(async.query("q", params), FakeGraph.RS, "query", "q", params);
+        assertDelegates(async.readOnlyQuery("q", params), FakeGraph.RS, "readOnlyQuery", "q", params);
+        assertDelegates(async.query("q", params, 5L), FakeGraph.RS, "query", "q", params, 5L);
+        assertDelegates(async.readOnlyQuery("q", params, 5L), FakeGraph.RS, "readOnlyQuery", "q", params, 5L);
+        assertDelegates(async.callProcedure("p"), FakeGraph.RS, "callProcedure", "p");
+        assertDelegates(async.profile("q"), FakeGraph.RS, "profile", "q");
+        assertDelegates(async.profile("q", params), FakeGraph.RS, "profile", "q", params);
+        assertDelegates(async.callProcedure("p", args), FakeGraph.RS, "callProcedure", "p", args);
+        assertDelegates(async.callProcedure("p", args, kwargs), FakeGraph.RS, "callProcedure", "p", args, kwargs);
+        assertDelegates(async.copyGraph("dst"), "OK", "copyGraph", "dst");
+        assertDelegates(async.deleteGraph(), "OK", "deleteGraph");
+        assertDelegates(async.explain("q"), FakeGraph.PLAN, "explain", "q");
+        assertDelegates(async.explain("q", params), FakeGraph.PLAN, "explain", "q", params);
+
+        assertEquals(17, graph.calls.get());
+    }
+
+    @Test
+    void failuresSurfaceAsExceptionalCompletion() {
+        graph.toThrow = new IllegalStateException("boom");
+        CompletableFuture<ResultSet> future = AsyncFalkorDB.wrap(graph, DIRECT).query("q");
+
+        CompletionException joined = assertThrows(CompletionException.class, future::join);
+        assertSame(graph.toThrow, joined.getCause());
+        ExecutionException got = assertThrows(ExecutionException.class, future::get);
+        assertSame(graph.toThrow, got.getCause());
+    }
+
+    @Test
+    void cancellingBeforeStartSkipsTheQuery() {
+        ManualExecutor executor = new ManualExecutor();
+        CompletableFuture<ResultSet> future =
+                AsyncFalkorDB.wrap(graph, executor).query("q");
+
+        assertEquals(1, executor.pending(), "task should be queued, not yet run");
+        assertTrue(future.cancel(true));
+        executor.runAll();
+
+        assertTrue(future.isCancelled());
+        assertEquals(0, graph.calls.get(), "a cancelled-before-start query must never reach the graph");
+    }
+
+    /** Executor that queues tasks and only runs them on demand, to observe cancel-before-start. */
+    private static final class ManualExecutor implements Executor {
+        private final Deque<Runnable> tasks = new ArrayDeque<>();
+
+        @Override
+        public void execute(Runnable command) {
+            tasks.add(command);
+        }
+
+        int pending() {
+            return tasks.size();
+        }
+
+        void runAll() {
+            Runnable task;
+            while ((task = tasks.poll()) != null) {
+                task.run();
+            }
+        }
+    }
+
+    /** Recording {@link GraphContextGenerator} fake; no Mockito on the classpath. */
+    private static final class FakeGraph implements GraphContextGenerator {
+        static final ResultSet RS = new FakeResultSet();
+        static final List<String> PLAN = Collections.singletonList("PLAN");
+
+        final AtomicInteger calls = new AtomicInteger();
+        volatile String lastMethod;
+        volatile Object[] lastArgs;
+        volatile RuntimeException toThrow;
+
+        private <T> T record(String method, T result, Object... args) {
+            calls.incrementAndGet();
+            lastMethod = method;
+            lastArgs = args;
+            if (toThrow != null) {
+                throw toThrow;
+            }
+            return result;
+        }
+
+        @Override
+        public ResultSet query(String query) {
+            return record("query", RS, query);
+        }
+
+        @Override
+        public ResultSet readOnlyQuery(String query) {
+            return record("readOnlyQuery", RS, query);
+        }
+
+        @Override
+        public ResultSet query(String query, long timeout) {
+            return record("query", RS, query, timeout);
+        }
+
+        @Override
+        public ResultSet readOnlyQuery(String query, long timeout) {
+            return record("readOnlyQuery", RS, query, timeout);
+        }
+
+        @Override
+        public ResultSet query(String query, Map<String, Object> params) {
+            return record("query", RS, query, params);
+        }
+
+        @Override
+        public ResultSet readOnlyQuery(String query, Map<String, Object> params) {
+            return record("readOnlyQuery", RS, query, params);
+        }
+
+        @Override
+        public ResultSet query(String query, Map<String, Object> params, long timeout) {
+            return record("query", RS, query, params, timeout);
+        }
+
+        @Override
+        public ResultSet readOnlyQuery(String query, Map<String, Object> params, long timeout) {
+            return record("readOnlyQuery", RS, query, params, timeout);
+        }
+
+        @Override
+        public ResultSet callProcedure(String procedure) {
+            return record("callProcedure", RS, procedure);
+        }
+
+        @Override
+        public ResultSet profile(String query) {
+            return record("profile", RS, query);
+        }
+
+        @Override
+        public ResultSet profile(String query, Map<String, Object> params) {
+            return record("profile", RS, query, params);
+        }
+
+        @Override
+        public ResultSet callProcedure(String procedure, List<String> args) {
+            return record("callProcedure", RS, procedure, args);
+        }
+
+        @Override
+        public ResultSet callProcedure(String procedure, List<String> args, Map<String, List<String>> kwargs) {
+            return record("callProcedure", RS, procedure, args, kwargs);
+        }
+
+        @Override
+        public String copyGraph(String destinationGraphId) {
+            return record("copyGraph", "OK", destinationGraphId);
+        }
+
+        @Override
+        public String deleteGraph() {
+            return record("deleteGraph", "OK");
+        }
+
+        @Override
+        public List<String> explain(String query) {
+            return record("explain", PLAN, query);
+        }
+
+        @Override
+        public List<String> explain(String query, Map<String, Object> params) {
+            return record("explain", PLAN, query, params);
+        }
+
+        @Override
+        public GraphContext getContext() {
+            throw new UnsupportedOperationException("not used by the async facade");
+        }
+
+        @Override
+        public void close() {
+            calls.incrementAndGet();
+            lastMethod = "close";
+        }
+    }
+
+    private static final class FakeResultSet implements ResultSet {
+        @Override
+        public Iterator<Record> iterator() {
+            return Collections.emptyIterator();
+        }
+
+        @Override
+        public int size() {
+            return 0;
+        }
+
+        @Override
+        public Statistics getStatistics() {
+            return null;
+        }
+
+        @Override
+        public Header getHeader() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Wave 5 (Project Loom, #333) — `CompletableFuture` async facade

An **optional** asynchronous view over the synchronous blocking `Graph` API, so callers on **JDK 21+** can fan the blocking client out over a virtual-thread (or any) executor while the client itself stays **pure Java 8**.

### What's added
- **`com.falkordb.AsyncGraph`** (public) — mirrors `Graph`'s 17 query ops, each returning `CompletableFuture<T>`, plus a `graph()` escape hatch that returns the wrapped **concurrency-safe `GraphContextGenerator`** (never a connection-bound raw `Graph`).
- **`com.falkordb.AsyncFalkorDB.wrap(GraphContextGenerator, Executor)`** (public factory) — the facade **owns nothing** (not `Closeable`); the caller owns the graph and the executor.
- **`com.falkordb.impl.api.AsyncGraphImpl`** (internal, api-diff-excluded) — `CompletableFuture.supplyAsync(() -> graph.query(...), executor)`.

```java
Driver driver = FalkorDB.driver();
ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor(); // JDK 21+, caller-owned
AsyncGraph async = AsyncFalkorDB.wrap(driver.graph("social"), pool);
CompletableFuture<ResultSet> f = async.query("MATCH (n) RETURN count(n)");
```

### Design (matches the approved Wave-5 plan, #353)
- **Pure Java 8 & additive** — the caller supplies the JDK-21 executor, so no library type references Loom; `api-diff` stays green.
- **Concurrency is pool-limited**, not executor-limited (`poolMaxTotal`); no built-in admission bound.
- **Cancellation is best-effort but honors cancel-before-start** — cancelling before the task starts skips the query; an in-flight blocking read can't be interrupted (rely on timeouts, #282).
- Failures surface as the future completing exceptionally (`join()`→`CompletionException`, `get()`→`ExecutionException`).

### Tests
- **`AsyncFalkorDBTest`** (unit, no server) — delegation of all 17 ops (name + args), exception unwrapping, cancel-before-start (query never issued), null-arg rejection, and the `graph()` escape hatch, using hand-rolled fakes (no Mockito).
- **`AsyncFalkorDBIT`** (server) — fan-out over a **fixed platform-thread pool** with a finite `poolMaxWait`. Deliberately **not** a virtual-thread executor: cold commons-pool2 connection creation (`GenericObjectPool.create()` is `synchronized`) pins carriers on JDK 21–23, so a vthread creation storm can deadlock a cold pool — that pinning is characterized separately by the Wave-5 **pinning check** (PR-B). Facade correctness is thread-model-agnostic.

### Validation (all green locally, via `just` = CI)
`just verify` (116 ITs + unit; animal-sniffer Java-8) · `just lint` · `just fmt-check` · `just api-diff` (additive) · `just javadoc`.

Part of #333.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an asynchronous graph API for queries, read-only queries, procedures, profiling, graph management, and explain plans.
  - Added support for running asynchronous operations on a caller-provided executor.
  - Added `CompletableFuture`-based results with support for concurrent operations, timeouts, cancellation, and error propagation.

- **Tests**
  - Added unit and integration coverage for async execution, concurrency, failures, delegation, cancellation, and resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->