### PR TITLE
ci: anchor release-please's first changelog to the v0.9.0 commit

### DIFF
--- a/docs/release-please-setup.md
+++ b/docs/release-please-setup.md
@@ -81,7 +81,14 @@ a "snapshot bump" PR (downgrading `pom.xml` from `0.10.0-SNAPSHOT` to `0.9.1-SNA
 release. Seeding the manifest at the post-`0.9.0` snapshot it *would* have created lets the first run
 compute the real release directly: `0.9.1-SNAPSHOT` + the breaking `fix!` (with
 `bump-minor-pre-major`) → **`0.10.0`** — verified by `release-please --dry-run`. After the first
-release the manifest tracks real versions normally (`0.10.0` → `0.10.1-SNAPSHOT` → …). The only
-cosmetic effect is that the **first** changelog compare link reads `v0.9.1-SNAPSHOT...v0.10.0`;
-subsequent releases compare real tags.
+release the manifest tracks real versions normally (`0.10.0` → `0.10.1-SNAPSHOT` → …).
+
+Because there is no `v0.9.1-SNAPSHOT` tag for release-please to anchor the first run's history to, the
+package is also pinned with **`last-release-sha`** set to the `v0.9.0` commit
+(`23723b12ff353b57166aa2b0a3f01349d0eaacf9`). Without it, the first changelog walks the entire history
+back to `v0.1.0` and lists every historical `fix:`/`feat:` (old dependency bumps and low-quality early
+commit messages) under `0.10.0`; with it, the first changelog spans only `v0.9.0..HEAD` (the real
+0.10.0 changes). It becomes a no-op once a real release tag exists (release-please then compares from
+the newer tag). The one remaining cosmetic effect is that the **first** changelog compare link reads
+`v0.9.1-SNAPSHOT...v0.10.0`; subsequent releases compare real tags.
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
     ".": {
       "release-type": "java",
       "bump-minor-pre-major": true,
+      "last-release-sha": "23723b12ff353b57166aa2b0a3f01349d0eaacf9",
       "extra-files": [
         { "type": "pom", "path": "pom.xml" }
       ]


### PR DESCRIPTION
## Fix the first release-please changelog (release PR #331)

While reviewing the **release 0.10.0** PR (#331), I found its `CHANGELOG.md` lists **36 entries but only ~12 are actually new in 0.10.0** — the other **~24 already shipped in v0.1.0–v0.9.0** (e.g. `upgrade jedis 3.1.0 to 3.2.0` released in **v0.1.0, 2020**; `47 repalce getResponse`; `remove default 2000ms socket timeout` #282, which *is* the v0.9.0 commit).

### Root cause
This is the **first** release-please-generated changelog, and the bootstrap manifest is seeded at `0.9.1-SNAPSHOT` (intentional — see `docs/release-please-setup.md`). Since there's no `v0.9.1-SNAPSHOT` tag to anchor to, release-please's first run had no baseline and walked the entire history back to `v0.1.0`, dumping every historical `fix:`/`feat:` into the 0.10.0 section. The setup note anticipated only the cosmetic compare-link quirk, not this.

### Fix
Pin the package with **`last-release-sha`** = the `v0.9.0` commit (`23723b12ff353b57166aa2b0a3f01349d0eaacf9`), so the first changelog spans only `v0.9.0..HEAD` (the real 0.10.0 changes: async facade #355, builder #349, JSpecify #351, de-pin #354, injection-hardening #317, Point/Property fixes, the Wave docs). It's a no-op once a real release tag exists. The setup-guide bootstrap note is updated to explain it.

### How to verify / roll out
1. Merge **this** PR → the `release-please` workflow runs on `master` and **regenerates #331** with the trimmed 0.10.0 changelog.
2. Re-check #331's `CHANGELOG.md` (should now list ~12 entries, all post-`v0.9.0`).
3. Then merge #331 to cut `v0.10.0`.

Config/docs only — no code or public-API change.
