### PR TITLE
ci: move release-please last-release-sha to top-level so the first changelog trims

### DIFF
--- a/docs/release-please-setup.md
+++ b/docs/release-please-setup.md
@@ -84,8 +84,9 @@ compute the real release directly: `0.9.1-SNAPSHOT` + the breaking `fix!` (with
 release the manifest tracks real versions normally (`0.10.0` → `0.10.1-SNAPSHOT` → …).
 
 Because there is no `v0.9.1-SNAPSHOT` tag for release-please to anchor the first run's history to, the
-package is also pinned with **`last-release-sha`** set to the `v0.9.0` commit
-(`23723b12ff353b57166aa2b0a3f01349d0eaacf9`). Without it, the first changelog walks the entire history
+run is also anchored with a **top-level `last-release-sha`** set to the `v0.9.0` commit
+(`23723b12ff353b57166aa2b0a3f01349d0eaacf9`) — it must be top-level (a package-level entry is ignored).
+Without it, the first changelog walks the entire history
 back to `v0.1.0` and lists every historical `fix:`/`feat:` (old dependency bumps and low-quality early
 commit messages) under `0.10.0`; with it, the first changelog spans only `v0.9.0..HEAD` (the real
 0.10.0 changes). It becomes a no-op once a real release tag exists (release-please then compares from

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/v17.6.0/schemas/config.json",
   "always-update": true,
+  "last-release-sha": "23723b12ff353b57166aa2b0a3f01349d0eaacf9",
   "packages": {
     ".": {
       "release-type": "java",
       "bump-minor-pre-major": true,
-      "last-release-sha": "23723b12ff353b57166aa2b0a3f01349d0eaacf9",
       "extra-files": [
         { "type": "pom", "path": "pom.xml" }
       ]


### PR DESCRIPTION
## Fix: move `last-release-sha` to top-level so the first release changelog actually trims

Follow-up to #359. That PR added `last-release-sha` **inside the package config**, where release-please **ignores it** — so release PR #331's 0.10.0 changelog *still* walked the entire history back to v0.1.0 (36 entries, incl. 2020-era dep bumps and typo'd commit messages like `repalce`/`READMe` that Copilot flagged on #331).

### Root cause
`last-release-sha` is a **top-level manifest-config** option, not a per-package one. Release PR #331's changelog is bloated because the bootstrap manifest (`0.9.1-SNAPSHOT`) matches no GitHub Release, so release-please can't anchor and considers all history; only a **top-level** `last-release-sha` caps that traversal.

### Fix (verified)
Move `last-release-sha` (the `v0.9.0` commit `23723b1…`) to the top level of `release-please-config.json`. Verified with `release-please release-pr --dry-run --target-branch=<this branch>`:
- **36 → 13 changelog entries** (12 real changes + the `fix!` listed under both BREAKING and Bug Fixes).
- The ancient entries (jedis 3.1→3.2 #64/v0.1.0, `repalce`, `content`, `READMe`, …) are **gone**.
- All 13 are genuine post-`v0.9.0` changes (async facade, builder, JSpecify, de-pin, injection-hardening, Point/Property fixes, Wave docs).

Setup-guide note updated to state it must be top-level.

### Rollout
1. Merge this → release-please re-runs on `master` and regenerates **#331** with the trimmed changelog.
2. Re-check #331 (should be ~13 entries) — this also resolves the Copilot typo review there (those entries disappear).
3. Then merge #331 to cut `v0.10.0`.

Config/docs only.
