### PR TITLE
build: bump api.diff.baseline to 0.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 		     breaks by default; a reviewed, intentional break is approved by overriding it to false (the
 		     CI `api-diff` job sets -Dapi.diff.fail=false when the PR carries the `breaking-change`
 		     label). -->
-		<api.diff.baseline>0.9.0</api.diff.baseline>
+		<api.diff.baseline>0.10.0</api.diff.baseline>
 		<api.diff.fail>true</api.diff.fail>
 	</properties>
 


### PR DESCRIPTION
## Post-release: bump `api.diff.baseline` to 0.10.0

`v0.10.0` was released to Maven Central (release PR #331). This is the documented **post-release step**: point the `api-diff` gate at the just-published release so it compares the public API against `0.10.0` going forward (was `0.9.0`).

- `pom.xml`: `api.diff.baseline` `0.9.0` → `0.10.0`.
- Verified: `0.10.0` is live on Maven Central (pom + jar HTTP 200) and `just api-diff` is **BUILD SUCCESS** against it.

One-line config change; no code or public-API change.
