### PR TITLE
build: combine Dependabot updates (setup-java, codeql action)

### DIFF
--- a/.github/workflows/api-diff.yml
+++ b/.github/workflows/api-diff.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up JDK 21
-      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up JDK 21
-      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -36,7 +36,7 @@ jobs:
         # Full history so the PR's base commit is present to check out and benchmark on this runner.
         fetch-depth: 0
     - name: Set up JDK 21
-      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -102,7 +102,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up JDK 21
-      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up JDK 21
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -39,7 +39,7 @@ jobs:
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
@@ -48,6 +48,6 @@ jobs:
         run: just build
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/javadoc-pages.yml
+++ b/.github/workflows/javadoc-pages.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up JDK 21
-      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up JDK 21
-      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -61,7 +61,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up JDK 21
-      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -80,7 +80,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up JDK 21
-      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -99,7 +99,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up JDK 21
-      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -120,7 +120,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up JDK 21
-      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -147,7 +147,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up JDK 21 (build) and JDK 8 (runtime)
-      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: |
           8
@@ -184,7 +184,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up JDK ${{ matrix.jdk }} (runtime) and JDK 21 (build)
-      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: |
           ${{ matrix.jdk }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up JDK 21
-      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/.github/workflows/pin-check.yml
+++ b/.github/workflows/pin-check.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up JDK 21
-      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up JDK 21
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -56,7 +56,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up publishing to maven central
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -68,7 +68,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up JDK 21 for publishing to Maven Central
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/version-canary.yml
+++ b/.github/workflows/version-canary.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up JDK 21
-      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: '21'
         distribution: 'temurin'


### PR DESCRIPTION
Combines the following Dependabot updates into one PR:

- Bump `actions/setup-java` from 5.6.0 to 5.7.0, across all workflows (#371)
- Bump `github/codeql-action` `init` from 4.37.3 to 4.37.4 (#372)
- Bump `github/codeql-action` `analyze` from 4.37.3 to 4.37.4 (#370)

Closes #370, #371, #372.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned Java setup action used across build, testing, auditing, benchmarking, release, and documentation workflows.
  * Refreshed pinned security-analysis action references.
  * Workflow behavior and existing configurations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->