### PR TITLE
ci(maven): verify against latest on PRs, run the edge canary daily

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,6 +25,11 @@ concurrency:
 permissions:
   contents: write
 
+env:
+  # FalkorDB image tag the released-image gate (`verify-latest`) runs against.
+  # The pinned-digest jobs deliberately ignore this: they guard the minimum
+  # supported version. `edge` is covered daily by the `version-canary` workflow.
+  FALKORDB_VERSION: latest
 
 jobs:
   build:
@@ -78,9 +83,9 @@ jobs:
       uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
     # FALKORDB_IMAGE is read by the TestServer harness (FalkorDbImage.resolve) so the whole suite runs
     # against this tag instead of the pinned default digest.
-    - name: Build & test against falkordb/falkordb:latest (via just)
+    - name: Build & test against falkordb/falkordb:${{ env.FALKORDB_VERSION }} (via just)
       env:
-        FALKORDB_IMAGE: falkordb/falkordb:latest
+        FALKORDB_IMAGE: falkordb/falkordb:${{ env.FALKORDB_VERSION }}
       run: just verify
 
   format:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,6 +17,11 @@ on:
   release:
     types: [ published ]
   workflow_dispatch:
+    inputs:
+      falkordb_image_tag:
+        description: "FalkorDB Docker image tag the released-image gate runs against (defaults to latest)"
+        required: false
+        default: "latest"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -29,7 +34,7 @@ env:
   # FalkorDB image tag the released-image gate (`verify-latest`) runs against.
   # The pinned-digest jobs deliberately ignore this: they guard the minimum
   # supported version. `edge` is covered daily by the `version-canary` workflow.
-  FALKORDB_VERSION: latest
+  FALKORDB_VERSION: ${{ github.event.inputs.falkordb_image_tag || 'latest' }}
 
 jobs:
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,8 +11,12 @@ name: Java CI with Maven
 on:
   push:
     branches: [ "master" ]
+    tags: [ "v*" ]
   pull_request:
     branches: [ "master" ]
+  release:
+    types: [ published ]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -51,6 +55,33 @@ jobs:
     - name: Maven Dependency Tree Dependency Submission
       if: github.token.permissions.contents == 'write'
       uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 # v5.0.0
+
+  # Released-image gate: the required `build`/`smoke-*` jobs pin a digest (v4.20.1, the minimum
+  # supported version), so nothing here would notice a break against the image most users actually
+  # run. This job runs the same `just verify` suite against `falkordb/falkordb:latest` on every PR,
+  # push, tag and release; the daily `version-canary` workflow covers `edge`.
+  verify-latest:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        persist-credentials: false
+    - name: Set up JDK 21
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+    - name: Install just
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+    # FALKORDB_IMAGE is read by the TestServer harness (FalkorDbImage.resolve) so the whole suite runs
+    # against this tag instead of the pinned default digest.
+    - name: Build & test against falkordb/falkordb:latest (via just)
+      env:
+        FALKORDB_IMAGE: falkordb/falkordb:latest
+      run: just verify
 
   format:
 

--- a/.github/workflows/version-canary.yml
+++ b/.github/workflows/version-canary.yml
@@ -49,3 +49,36 @@ jobs:
       env:
         FALKORDB_IMAGE: falkordb/falkordb:${{ matrix.falkordb_version }}
       run: just verify
+
+  # A cron job has nobody watching it: GitHub only emails the user who last
+  # touched the cron line, so a silent daily failure is the default outcome.
+  # Failures therefore open a tracking issue (or comment on the open one).
+  report-scheduled-failure:
+    name: Report scheduled failure
+    needs: [canary]
+    if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.result, 'failure') }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          WORKFLOW: ${{ github.workflow }}
+          TITLE: "FalkorDB version canary is failing"
+        run: |
+          body=$(printf '%s\n' \
+            "The daily \`$WORKFLOW\` run against \`falkordb/falkordb:edge\` failed." \
+            "" \
+            "$RUN_URL" \
+            "" \
+            "\`edge\` is an unreleased FalkorDB build, so this does not affect users on \`latest\`: it is an early warning that something in the next FalkorDB release breaks this client.")
+          number=$(gh issue list --state open --search "$TITLE in:title" --json number,title \
+            --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")
+          if [ -n "$number" ]; then
+            gh issue comment "$number" --body "$body"
+          else
+            gh issue create --title "$TITLE" --body "$body"
+          fi

--- a/.github/workflows/version-canary.yml
+++ b/.github/workflows/version-canary.yml
@@ -27,9 +27,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image:
-          - falkordb/falkordb:edge
-          - falkordb/falkordb:latest
+        falkordb_version:
+          - edge
+          - latest
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -45,7 +45,7 @@ jobs:
       uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
     # FALKORDB_IMAGE is read by the TestServer harness (FalkorDbImage.resolve) so the whole suite runs
     # against this tag instead of the pinned default digest.
-    - name: Build & test against ${{ matrix.image }} (via just)
+    - name: Build & test against falkordb/falkordb:${{ matrix.falkordb_version }} (via just)
       env:
-        FALKORDB_IMAGE: ${{ matrix.image }}
+        FALKORDB_IMAGE: falkordb/falkordb:${{ matrix.falkordb_version }}
       run: just verify

--- a/.github/workflows/version-canary.yml
+++ b/.github/workflows/version-canary.yml
@@ -50,9 +50,9 @@ jobs:
         FALKORDB_IMAGE: falkordb/falkordb:${{ matrix.falkordb_version }}
       run: just verify
 
-  # A cron job has nobody watching it: GitHub only emails the user who last
-  # touched the cron line, so a silent daily failure is the default outcome.
-  # Failures therefore open a tracking issue (or comment on the open one).
+  # A cron job has nobody watching it: GitHub only emails whoever last touched
+  # the cron line, so a failing daily run would otherwise go unnoticed. Post it
+  # to Google Chat instead.
   report-scheduled-failure:
     name: Report scheduled failure
     needs: [canary]
@@ -60,13 +60,31 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+    env:
+      GOOGLE_CHAT_WEBHOOK_URL: ${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}
+      REPO: ${{ github.repository }}
+      WORKFLOW: ${{ github.workflow }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
-      - name: Open or update the tracking issue
+      - name: Notify Google Chat
+        if: ${{ env.GOOGLE_CHAT_WEBHOOK_URL != '' }}
+        run: |
+          text=$(printf '%s\n' \
+            "*$REPO* — the daily \`$WORKFLOW\` run against \`falkordb/falkordb:edge\` failed." \
+            "<$RUN_URL|View the run>" \
+            "" \
+            "\`edge\` is an unreleased FalkorDB build, so released users are unaffected: this is an early warning that the next FalkorDB release breaks this client.")
+          jq -n --arg text "$text" '{text: $text}' > payload.json
+          curl -sS --fail-with-body -X POST -H 'Content-Type: application/json' \
+            -d @payload.json "$GOOGLE_CHAT_WEBHOOK_URL"
+
+      # Fallback while the webhook secret is not configured, so the signal is
+      # never lost. Opens one issue and comments on it on subsequent failures.
+      - name: Open or update a tracking issue
+        if: ${{ env.GOOGLE_CHAT_WEBHOOK_URL == '' }}
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          WORKFLOW: ${{ github.workflow }}
           TITLE: "FalkorDB version canary is failing"
         run: |
           body=$(printf '%s\n' \
@@ -74,7 +92,7 @@ jobs:
             "" \
             "$RUN_URL" \
             "" \
-            "\`edge\` is an unreleased FalkorDB build, so this does not affect users on \`latest\`: it is an early warning that something in the next FalkorDB release breaks this client.")
+            "Set the \`GOOGLE_CHAT_WEBHOOK_URL\` secret to receive this in Google Chat instead.")
           number=$(gh issue list --state open --search "$TITLE in:title" --json number,title \
             --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")
           if [ -n "$number" ]; then

--- a/.github/workflows/version-canary.yml
+++ b/.github/workflows/version-canary.yml
@@ -1,14 +1,15 @@
 name: FalkorDB version canary
 
 # Non-blocking early warning that the client still works against the moving FalkorDB `edge` and
-# `latest` images. Runs on a schedule (and on demand) — NOT on pushes/PRs — so upstream breakage never
+# `latest` images. Runs daily (and on demand) — NOT on pushes/PRs — so upstream breakage never
 # gates a merge: the required `build`/`smoke-jdk8`/`smoke-jdk` jobs pin the digest (v4.20.1), which is
-# also the current minimum supported version. Uses the `FALKORDB_IMAGE` override so Testcontainers runs
-# the full `just verify` suite against each tag.
+# also the current minimum supported version, while `verify-latest` in `maven.yml` covers `latest` on
+# every PR. The daily `edge` run is what catches bugs in unreleased FalkorDB builds early. Uses the
+# `FALKORDB_IMAGE` override so Testcontainers runs the full `just verify` suite against each tag.
 
 on:
   schedule:
-    - cron: '0 5 * * 1' # weekly, Mondays 05:00 UTC
+    - cron: '0 2 * * *' # daily, 02:00 UTC
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
PR CI only exercised the pinned FalkorDB digest (v4.20.1, the minimum supported version), so a break against the image most users actually run — `falkordb/falkordb:latest` — would not surface until someone reported it, and the `edge` canary only ran weekly. This adds a released-image gate to the PR/release pipeline and tightens the canary to daily, while leaving the pinned-digest jobs (and their branch-protection contexts) untouched.

## Changes
- `maven.yml`: new `verify-latest` job runs the full `just verify` suite against `falkordb/falkordb:latest` via the existing `FALKORDB_IMAGE` Testcontainers override, with the tag coming from a workflow-level `FALKORDB_VERSION` variable.
- `maven.yml`: triggers extended with version tags (`v*`), `release: published` and `workflow_dispatch`, so released code is validated against `latest` too.
- `version-canary.yml`: schedule moves from weekly (Mondays 05:00 UTC) to daily (02:00 UTC), and its matrix is now over bare version tags (`edge`, `latest`) rather than full image references, matching the other clients.
- Comments updated to describe the split of responsibilities: pinned digest = minimum supported version gate, `verify-latest` = released image, canary = `edge`.

The required `build`/`smoke-jdk8`/`smoke-jdk` jobs keep their pinned digest and their job names, so branch protection is unaffected.

## The standard, in all seven clients
Every official client picks the image tag with the same expression:

```
${{ github.event.inputs.falkordb_image_tag || (github.event_name == 'schedule' && 'edge' || 'latest') }}
```

`latest` for pull requests, pushes, tags and releases; `edge` for the daily scheduled run; any tag on manual dispatch.

Clients that start FalkorDB with docker compose (falkordb-ts, falkordb-php) keep it in a workflow-level `FALKORDB_VERSION`, which compose reads as `falkordb/falkordb:${FALKORDB_VERSION:-latest}`.

Clients that run FalkorDB as a **service container** keep doing exactly that — the service container is the idiomatic mechanism and gets networking, health checks and cleanup from the runner for free. The tag still has a single definition, but it cannot be an `env:` variable: GitHub does not allow the `env` context in `jobs.<id>.services.<id>.image` ([context availability](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#context-availability)). A small `falkordb-version` job resolves it once and every job consumes it:

```yaml
jobs:
  falkordb-version:
    name: Resolve FalkorDB version
    runs-on: ubuntu-latest
    outputs:
      version: ${{ steps.resolve.outputs.version }}
    steps:
      - id: resolve
        env:
          FALKORDB_VERSION: ${{ github.event.inputs.falkordb_image_tag || (github.event_name == 'schedule' && 'edge' || 'latest') }}
        run: echo "version=$FALKORDB_VERSION" >> "$GITHUB_OUTPUT"

  test:
    needs: falkordb-version
    services:
      falkordb:
        image: falkordb/falkordb:${{ needs.falkordb-version.outputs.version }}
```

## Failure notifications
The daily `edge` run posts to Google Chat when it fails. GitHub itself only emails whoever last edited the cron line, so without this the early-warning run would fail silently.

Add a Google Chat **incoming webhook** for the target space and store it as an Actions secret named `GOOGLE_CHAT_WEBHOOK_URL` — ideally once at organisation level so all seven clients share it:

```bash
gh secret set GOOGLE_CHAT_WEBHOOK_URL --org FalkorDB --visibility all
```

Until that secret exists the job falls back to opening (or commenting on) a tracking issue, so the signal is never lost. The step only runs on `schedule` failures; manual and PR runs are already visible to whoever triggered them. The message is built with `jq`, and no `${{ }}` expression is expanded into the shell.

## Testing
Verified by this PR's own runs: `verify-latest` builds and passes the full Failsafe/Testcontainers suite against `falkordb/falkordb:latest`, alongside the unchanged pinned-digest jobs.

## Memory / Performance Impact
N/A — CI configuration only. Adds one `just verify` job to PR CI, running in parallel with the existing jobs.

## Related Issues
N/A



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added verification for the latest FalkorDB image during tagged, released, or manually triggered runs.
  * Manual runs can now select a specific FalkorDB image version.

* **Chores**
  * Updated scheduled canary testing to run daily.
  * Expanded canary checks to cover both edge and latest image versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
