### PR TITLE
ci: rename Google Chat webhook secret to DRIVERS_GOOGLE_CHAT_WEBHOOK_URL

### DIFF
--- a/.github/workflows/version-canary.yml
+++ b/.github/workflows/version-canary.yml
@@ -61,13 +61,13 @@ jobs:
     permissions:
       issues: write
     env:
-      GOOGLE_CHAT_WEBHOOK_URL: ${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}
+      DRIVERS_GOOGLE_CHAT_WEBHOOK_URL: ${{ secrets.DRIVERS_GOOGLE_CHAT_WEBHOOK_URL }}
       REPO: ${{ github.repository }}
       WORKFLOW: ${{ github.workflow }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Notify Google Chat
-        if: ${{ env.GOOGLE_CHAT_WEBHOOK_URL != '' }}
+        if: ${{ env.DRIVERS_GOOGLE_CHAT_WEBHOOK_URL != '' }}
         run: |
           text=$(printf '%s\n' \
             "*$REPO* — the daily \`$WORKFLOW\` run against \`falkordb/falkordb:edge\` failed." \
@@ -76,12 +76,12 @@ jobs:
             "\`edge\` is an unreleased FalkorDB build, so released users are unaffected: this is an early warning that the next FalkorDB release breaks this client.")
           jq -n --arg text "$text" '{text: $text}' > payload.json
           curl -sS --fail-with-body -X POST -H 'Content-Type: application/json' \
-            -d @payload.json "$GOOGLE_CHAT_WEBHOOK_URL"
+            -d @payload.json "$DRIVERS_GOOGLE_CHAT_WEBHOOK_URL"
 
       # Fallback while the webhook secret is not configured, so the signal is
       # never lost. Opens one issue and comments on it on subsequent failures.
       - name: Open or update a tracking issue
-        if: ${{ env.GOOGLE_CHAT_WEBHOOK_URL == '' }}
+        if: ${{ env.DRIVERS_GOOGLE_CHAT_WEBHOOK_URL == '' }}
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -92,7 +92,7 @@ jobs:
             "" \
             "$RUN_URL" \
             "" \
-            "Set the \`GOOGLE_CHAT_WEBHOOK_URL\` secret to receive this in Google Chat instead.")
+            "Set the \`DRIVERS_GOOGLE_CHAT_WEBHOOK_URL\` secret to receive this in Google Chat instead.")
           number=$(gh issue list --state open --search "$TITLE in:title" --json number,title \
             --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")
           if [ -n "$number" ]; then


### PR DESCRIPTION
## Summary
Rename the Google Chat webhook secret used by the scheduled-failure notifier from `GOOGLE_CHAT_WEBHOOK_URL` to `DRIVERS_GOOGLE_CHAT_WEBHOOK_URL`, so the name states that it targets the client-drivers channel and does not collide with other Google Chat webhooks in the organization.

## Changes
- Workflow references updated: `secrets.*`, the job `env:` entry, the `if:` guards and the fallback issue text.

## Testing
- No repository-level `GOOGLE_CHAT_WEBHOOK_URL` secret exists yet, so nothing that currently works is affected.
- The notifier is guarded by `!= ''`, so until `DRIVERS_GOOGLE_CHAT_WEBHOOK_URL` is set the job falls back to opening a tracking issue — the failure signal is never lost.
- CI on this PR exercises the workflow parse.

## Memory / Performance Impact
N/A — CI configuration only.

## Related Issues
Follow-up to the CI image-matrix standardization work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated notification delivery to use the current Google Chat webhook configuration.
  * Improved fallback handling and issue messages when notifications cannot be delivered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->