### PR TITLE
fix: four correctness bugs in reply parsing and procedure encoding

### DIFF
--- a/src/main/java/com/falkordb/AsyncGraph.java
+++ b/src/main/java/com/falkordb/AsyncGraph.java
@@ -140,7 +140,8 @@ public interface AsyncGraph {
      *
      * @param procedure the procedure name
      * @param args      the procedure arguments
-     * @param kwargs    the procedure output arguments
+     * @param kwargs    the procedure output arguments: the {@code "y"} entry lists the output
+     *                  columns to bind with Cypher's {@code YIELD} clause
      * @return a future completing with the result set
      */
     CompletableFuture<ResultSet> callProcedure(String procedure, List<String> args, Map<String, List<String>> kwargs);

--- a/src/main/java/com/falkordb/Graph.java
+++ b/src/main/java/com/falkordb/Graph.java
@@ -120,7 +120,8 @@ public interface Graph extends Closeable {
      * Invoke a stored procedure
      * @param procedure - procedure to execute
      * @param args - procedure arguments
-     * @param kwargs - procedure output arguments
+     * @param kwargs - procedure output arguments: the {@code "y"} entry lists the output
+     *     columns to bind with Cypher's {@code YIELD} clause
      * @return result set with the procedure data
      */
     ResultSet callProcedure(String procedure, List<String> args, Map<String, List<String>> kwargs);

--- a/src/main/java/com/falkordb/GraphPipeline.java
+++ b/src/main/java/com/falkordb/GraphPipeline.java
@@ -106,7 +106,8 @@ public interface GraphPipeline
      * Invoke a stored procedure
      * @param procedure - procedure to execute
      * @param args - procedure arguments
-     * @param kwargs - procedure output arguments
+     * @param kwargs - procedure output arguments: the {@code "y"} entry lists the output
+     *     columns to bind with Cypher's {@code YIELD} clause
      * @return a response which builds result set with the procedure data
      */
     Response<ResultSet> callProcedure(String procedure, List<String> args, Map<String, List<String>> kwargs);

--- a/src/main/java/com/falkordb/GraphTransaction.java
+++ b/src/main/java/com/falkordb/GraphTransaction.java
@@ -107,7 +107,8 @@ public interface GraphTransaction
      * Invoke a stored procedure
      * @param procedure - procedure to execute
      * @param args - procedure arguments
-     * @param kwargs - procedure output arguments
+     * @param kwargs - procedure output arguments: the {@code "y"} entry lists the output
+     *     columns to bind with Cypher's {@code YIELD} clause
      * @return a response which builds result set with the procedure data
      */
     Response<ResultSet> callProcedure(String procedure, List<String> args, Map<String, List<String>> kwargs);

--- a/src/main/java/com/falkordb/impl/Utils.java
+++ b/src/main/java/com/falkordb/impl/Utils.java
@@ -363,6 +363,9 @@ public class Utils {
         queryStringBuilder.append(')');
         List<String> kwargsList = kwargs.getOrDefault("y", null);
         if (kwargsList != null && !kwargsList.isEmpty()) {
+            // The output columns are bound with Cypher's YIELD clause; without the keyword the
+            // emitted query is a syntax error.
+            queryStringBuilder.append(" YIELD ");
             i = 0;
             for (; i < kwargsList.size() - 1; i++) {
                 queryStringBuilder.append(kwargsList.get(i)).append(',');

--- a/src/main/java/com/falkordb/impl/api/GraphTransactionImpl.java
+++ b/src/main/java/com/falkordb/impl/api/GraphTransactionImpl.java
@@ -317,12 +317,9 @@ public class GraphTransactionImpl extends Transaction implements com.falkordb.Gr
     @Override
     public Response<String> deleteGraph() {
         try {
-            return appendWithResponse(GraphCommand.DELETE, Arrays.asList(graphId), new Builder<String>() {
-                @Override
-                public String build(Object o) {
-                    return (String) o;
-                }
-            });
+            // GRAPH.DELETE replies with a bulk string, which Jedis hands to the builder as a byte[] —
+            // casting it to String throws. BuilderFactory.STRING decodes it, as the pipeline does.
+            return appendWithResponse(GraphCommand.DELETE, Arrays.asList(graphId), BuilderFactory.STRING);
         } finally {
             cache.clear();
         }

--- a/src/main/java/com/falkordb/impl/resultset/ResultSetImpl.java
+++ b/src/main/java/com/falkordb/impl/resultset/ResultSetImpl.java
@@ -38,10 +38,13 @@ public final class ResultSetImpl implements ResultSet {
         this.cache = cache;
 
         // If a run-time error occurred, the last member of the rawResponse will be a
-        // JedisDataException.
-        if (rawResponse.get(rawResponse.size() - 1) instanceof JedisDataException) {
-
-            throw new GraphException((Throwable) rawResponse.get(rawResponse.size() - 1));
+        // JedisDataException. An empty reply has no such member, and must fall through to the
+        // empty-result-set branch below rather than index past the start of the list.
+        if (!rawResponse.isEmpty()) {
+            Object last = rawResponse.get(rawResponse.size() - 1);
+            if (last instanceof JedisDataException) {
+                throw new GraphException((Throwable) last);
+            }
         }
 
         // Check if this is a profile response (all elements are byte arrays)

--- a/src/main/java/com/falkordb/impl/resultset/StatisticsImpl.java
+++ b/src/main/java/com/falkordb/impl/resultset/StatisticsImpl.java
@@ -1,6 +1,7 @@
 package com.falkordb.impl.resultset;
 
 import com.falkordb.Statistics;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -12,7 +13,6 @@ import redis.clients.jedis.util.SafeEncoder;
  */
 public class StatisticsImpl implements Statistics {
     // members
-    private final List<byte[]> raw;
     private final Map<Statistics.Label, String> statistics;
 
     /**
@@ -22,8 +22,26 @@ public class StatisticsImpl implements Statistics {
      * @param raw a raw representation of the query execution statistics
      */
     public StatisticsImpl(List<byte[]> raw) {
-        this.raw = raw;
-        this.statistics = new EnumMap<>(Statistics.Label.class); // lazy loaded
+        // Parsed once, up front: the raw reply is a handful of short strings, and an immutable map
+        // keeps this result type safe to hand across threads (see AsyncGraph) and gives equals and
+        // hashCode stable value semantics, which a List<byte[]> cannot provide.
+        this.statistics = Collections.unmodifiableMap(parse(raw));
+    }
+
+    private static Map<Statistics.Label, String> parse(List<byte[]> raw) {
+        Map<Statistics.Label, String> parsed = new EnumMap<>(Statistics.Label.class);
+        for (byte[] tuple : raw) {
+            String text = SafeEncoder.encode(tuple);
+            // Only the FIRST colon delimits label from value; the value itself may contain colons.
+            String[] rowTuple = text.split(":", 2);
+            if (rowTuple.length == 2) {
+                Statistics.Label label = Statistics.Label.getEnum(rowTuple[0]);
+                if (label != null) {
+                    parsed.put(label, rowTuple[1].trim());
+                }
+            }
+        }
+        return parsed;
     }
 
     /**
@@ -33,23 +51,7 @@ public class StatisticsImpl implements Statistics {
      */
     @Override
     public String getStringValue(Statistics.Label label) {
-        return getStatistics().get(label);
-    }
-
-    private Map<Statistics.Label, String> getStatistics() {
-        if (statistics.size() == 0) {
-            for (byte[] tuple : this.raw) {
-                String text = SafeEncoder.encode(tuple);
-                String[] rowTuple = text.split(":");
-                if (rowTuple.length == 2) {
-                    Statistics.Label label = Statistics.Label.getEnum(rowTuple[0]);
-                    if (label != null) {
-                        this.statistics.put(label, rowTuple[1].trim());
-                    }
-                }
-            }
-        }
-        return statistics;
+        return statistics.get(label);
     }
 
     /**
@@ -144,18 +146,18 @@ public class StatisticsImpl implements Statistics {
         if (this == o) return true;
         if (!(o instanceof StatisticsImpl)) return false;
         StatisticsImpl that = (StatisticsImpl) o;
-        return Objects.equals(raw, that.raw) && Objects.equals(getStatistics(), that.getStatistics());
+        return Objects.equals(statistics, that.statistics);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(raw, getStatistics());
+        return Objects.hash(statistics);
     }
 
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("StatisticsImpl{");
-        sb.append("statistics=").append(getStatistics());
+        sb.append("statistics=").append(statistics);
         sb.append('}');
         return sb.toString();
     }

--- a/src/test/java/com/falkordb/GraphAPIIT.java
+++ b/src/test/java/com/falkordb/GraphAPIIT.java
@@ -1214,6 +1214,23 @@ public class GraphAPIIT {
     }
 
     @Test
+    public void testCallProcedureWithYieldedOutputs() {
+        client.query("CREATE (:Person {name:'a'})");
+
+        // The "y" kwargs entry names the procedure's output columns. The emitted query previously
+        // omitted the YIELD keyword entirely, so the server rejected every kwargs call as a syntax
+        // error.
+        Map<String, List<String>> kwargs = new HashMap<>();
+        kwargs.put("y", Collections.singletonList("label"));
+        ResultSet resultSet = client.callProcedure("db.labels", Collections.<String>emptyList(), kwargs);
+
+        Assertions.assertEquals(
+                Collections.singletonList("label"), resultSet.getHeader().getSchemaNames());
+        Assertions.assertEquals(1, resultSet.size());
+        Assertions.assertEquals("Person", resultSet.iterator().next().getValue("label"));
+    }
+
+    @Test
     public void testExplainContextedAPI() {
         try (GraphContext context = client.getContext()) {
             // Create some test data first

--- a/src/test/java/com/falkordb/TransactionIT.java
+++ b/src/test/java/com/falkordb/TransactionIT.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import redis.clients.jedis.Response;
 
 public class TransactionIT {
 
@@ -231,6 +232,25 @@ public class TransactionIT {
             Assertions.assertEquals(Arrays.asList("label"), record.keys());
             Assertions.assertEquals("Person", record.getValue("label"));
         }
+    }
+
+    @Test
+    public void testDeleteGraphInTransaction() {
+        api.query("CREATE (:Person {name:'a'})");
+
+        try (GraphContext c = api.getContext()) {
+            GraphTransaction transaction = c.multi();
+
+            Response<String> deleted = transaction.deleteGraph();
+            transaction.exec();
+
+            // GRAPH.DELETE replies with a bulk string; the builder used to cast that byte[] straight
+            // to String, so reading the response threw ClassCastException.
+            Assertions.assertNotNull(deleted.get());
+        }
+
+        // Recreate the graph so the @AfterEach cleanup has something to delete.
+        api.query("CREATE (:Person {name:'b'})");
     }
 
     @Test

--- a/src/test/java/com/falkordb/impl/UtilsTest.java
+++ b/src/test/java/com/falkordb/impl/UtilsTest.java
@@ -36,13 +36,15 @@ public class UtilsTest {
                 "CALL prc(\"a\",\"b\")",
                 Utils.prepareProcedure("prc", Arrays.asList(new String[] {"a", "b"}), new HashMap<>()));
 
+        // The "y" kwargs entry names the procedure's output columns, which Cypher binds with YIELD.
+        // Without the keyword (and the separating space) the emitted query is a syntax error.
         Map<String, List<String>> kwargs = new HashMap<>();
         kwargs.put("y", Arrays.asList(new String[] {"ka", "kb"}));
         assertEquals(
-                "CALL prc(\"a\",\"b\")ka,kb",
+                "CALL prc(\"a\",\"b\") YIELD ka,kb",
                 Utils.prepareProcedure("prc", Arrays.asList(new String[] {"a", "b"}), kwargs));
 
-        assertEquals("CALL prc()ka,kb", Utils.prepareProcedure("prc", Arrays.asList(new String[] {}), kwargs));
+        assertEquals("CALL prc() YIELD ka,kb", Utils.prepareProcedure("prc", Arrays.asList(new String[] {}), kwargs));
     }
 
     @Test

--- a/src/test/java/com/falkordb/impl/resultset/ResultSetImplTest.java
+++ b/src/test/java/com/falkordb/impl/resultset/ResultSetImplTest.java
@@ -1,0 +1,25 @@
+package com.falkordb.impl.resultset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.falkordb.ResultSet;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+
+public class ResultSetImplTest {
+
+    @Test
+    public void emptyResponseYieldsEmptyResultSet() {
+        // An empty array reply must produce the empty ResultSet the size()!=3 branch was written to
+        // build. The run-time-error probe used to read get(size()-1) before any empty check, so an
+        // empty reply threw IndexOutOfBoundsException and left that branch unreachable.
+        ResultSet resultSet = new ResultSetImpl(new ArrayList<>(), null, null);
+
+        assertEquals(0, resultSet.size());
+        assertTrue(resultSet.getHeader().getSchemaNames().isEmpty());
+        assertFalse(resultSet.iterator().hasNext());
+        assertEquals(0, resultSet.getStatistics().nodesCreated());
+    }
+}

--- a/src/test/java/com/falkordb/impl/resultset/StatisticsImplTest.java
+++ b/src/test/java/com/falkordb/impl/resultset/StatisticsImplTest.java
@@ -1,18 +1,61 @@
 package com.falkordb.impl.resultset;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.falkordb.Statistics;
+import java.util.ArrayList;
+import java.util.List;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.Test;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class StatisticsImplTest {
 
+    private static StatisticsImpl statisticsOf(String... lines) {
+        List<byte[]> raw = new ArrayList<>(lines.length);
+        for (String line : lines) {
+            raw.add(SafeEncoder.encode(line));
+        }
+        return new StatisticsImpl(raw);
+    }
+
     @Test
     public void equalsHashCodeContract() {
-        // StatisticsImpl is an internal, mutable, non-final result type compared with instanceof. Its
-        // lazily-built statistics map is always constructor-initialized (never null in practice), so
-        // NULL_FIELDS is safe.
+        // StatisticsImpl is an internal, non-final result type compared with instanceof. Its statistics
+        // map is always constructor-initialized (never null in practice), so NULL_FIELDS is safe.
         EqualsVerifier.forClass(StatisticsImpl.class)
                 .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE, Warning.NULL_FIELDS)
                 .verify();
+    }
+
+    @Test
+    public void equalStatisticsFromDistinctByteArraysAreEqual() {
+        // Two responses carrying identical statistics must compare equal and hash alike. The raw
+        // reply is a List<byte[]>, and byte[] inherits identity equals/hashCode, so including it in
+        // equals/hashCode made value-equal statistics unequal and hashCode vary between instances.
+        StatisticsImpl first = statisticsOf("Nodes created: 2", "Properties set: 4");
+        StatisticsImpl second = statisticsOf("Nodes created: 2", "Properties set: 4");
+
+        assertEquals(first, second);
+        assertEquals(first.hashCode(), second.hashCode());
+    }
+
+    @Test
+    public void keepsStatisticValueContainingColon() {
+        // Each raw entry is "K:V" with the FIRST colon as the delimiter; the value may itself contain
+        // colons. Splitting on every colon yielded 3 parts, failed the length==2 guard, and dropped
+        // the statistic entirely.
+        StatisticsImpl statistics = statisticsOf("Query internal execution time: 0:00.4");
+
+        assertEquals("0:00.4", statistics.getStringValue(Statistics.Label.QUERY_INTERNAL_EXECUTION_TIME));
+    }
+
+    @Test
+    public void unrecognizedAndMalformedEntriesAreIgnored() {
+        // An entry with no colon, and one whose label is unknown, must not abort parsing of the rest.
+        StatisticsImpl statistics = statisticsOf("no delimiter here", "Totally unknown label: 7", "Nodes created: 3");
+
+        assertEquals(3, statistics.nodesCreated());
     }
 }


### PR DESCRIPTION
Four confirmed correctness bugs found while reviewing the client's reply-handling
and command-encoding layer. Each is fixed in its own commit, and each fix has a
test that was **watched failing against the unfixed code first**.

All changes are inside `com.falkordb.impl` (excluded from the `api-diff` gate)
plus javadoc-only additions to four public interfaces. No public or protected
signature changes — `japicmp` reports no break.

## 1. Transactional `deleteGraph()` always threw `ClassCastException`

`GraphTransactionImpl.deleteGraph()` built its response with `return (String) o`,
but Jedis hands builders a `byte[]` for a bulk-string reply:

```
ClassCast class [B cannot be cast to class java.lang.String
```

`GraphPipelineImpl` already used `BuilderFactory.STRING` for the same command.
Nothing covered this path — `TransactionIT.deleteGraph()` is the `@AfterEach`
calling `api.deleteGraph()`, not the transactional overload — so
`testDeleteGraphInTransaction` now reads the response inside `MULTI`/`EXEC`.

## 2. `callProcedure(procedure, args, kwargs)` sent invalid Cypher

`Utils.prepareProcedure` appended the kwargs entries directly after the closing
paren with no keyword and no separator. FalkorDB rejects the result outright:

```
errMsg: Invalid input 'a': expected LOAD CSV
errCtx: CALL db.labels()label
```

So the three-argument `callProcedure` overload could never succeed on any of
`Graph`, `GraphPipeline`, `GraphTransaction`, or `AsyncGraph`.

`UtilsTest.testPrepareProcedure` asserted the broken output verbatim
(`"CALL prc(\"a\",\"b\")ka,kb"`), so the suite was protecting the bug. Its
expectations are corrected, and `GraphAPIIT.testCallProcedureWithYieldedOutputs`
now proves a kwargs call round-trips against a real server.

The `"y"` kwargs key that selects the YIELD columns was also undocumented — it
is now described on all four public interfaces.

## 3. `Statistics` / `ResultSet` had reference equality, not value equality

`StatisticsImpl` kept the raw `List<byte[]>` and included it in
`equals`/`hashCode`. `byte[]` inherits identity semantics, so two result sets
carrying identical statistics compared **unequal**, and `hashCode()` varied
between instances — which leaked into `ResultSetImpl.equals`/`hashCode` and made
`ResultSet` unusable as a map key. `HeaderImpl` already excludes its `raw` field
for this exact reason; `EqualsVerifier` missed it because it shallow-copies the
same array instances.

The same parse also split on *every* colon, so a statistic whose value contains
one (`Query internal execution time: 0:00.4`) produced three parts, failed the
`length == 2` guard, and was dropped silently.

Both are fixed by parsing once in the constructor into an unmodifiable map
instead of lazily mutating a non-volatile `EnumMap` on first read. That also
removes the unsynchronized lazy init — relevant now that `AsyncGraph` hands
`ResultSet`s across threads — and the re-parse on every call when nothing
matched.

## 4. An empty reply threw `IndexOutOfBoundsException`

`ResultSetImpl`'s run-time-error probe read `get(rawResponse.size() - 1)` before
any empty check, so an empty array reply threw instead of producing a result set,
and left the deliberate `rawResponse.isEmpty()` handling below it unreachable as
dead code.

## Validation

| Gate | Result |
| --- | --- |
| `verify` (build + 211 unit + 118 IT + coverage + Animal Sniffer) | pass |
| `fmt-check` (palantir-java-format) | pass |
| `javadoc` (strict doclint) | pass |
| `api-diff` (japicmp vs 0.10.0) | pass, no break |
| `examples` (`--release 8` against the built jar) | pass |
| `lint` (SpotBugs + Error Prone) | **not run locally** — Error Prone 2.50.0 fails to load on the JDK 17 available here; it fails identically on unmodified `master`, so this needs CI's JDK 21 |
| `spellcheck` | n/a, no Markdown touched |

## Follow-ups not in this PR

Found in the same review, deliberately left out to keep this reviewable:

- `HeaderImpl.buildSchema()` has the same unsynchronized lazy-init race, and
  indexes `ResultSetColumnTypes.values()[...]` with an unvalidated server ordinal
  (`ResultSetScalarTypes` does this safely — the two should match).
- `GraphContextImpl.deleteGraph()` closes the pooled connection in its `catch`
  and rethrows, so try-with-resources closes it a second time.
- Pipeline/transaction `deleteGraph()` clear the shared `GraphCache` at
  command-*append* time rather than after the DELETE executes, so the cache can
  be refilled from the still-live graph and then serve stale label ids.
- `VALUE_DOUBLE` decoding uses `Double.parseDouble`, which rejects Redis'
  `inf`/`-inf`/`nan` spellings.
- Temporal decoding truncates sub-second components on all four temporal types.
- 16 byte-identical anonymous `Builder<ResultSet>` blocks across
  `GraphPipelineImpl` and `GraphTransactionImpl` (note: Jedis `Builder<T>` is an
  abstract class, not a functional interface, so the dedup is a shared field —
  not a lambda).
- The published jar declares no `Automatic-Module-Name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Procedure calls now support output columns through Cypher’s `YIELD` clause.

* **Bug Fixes**
  * Improved graph deletion in transactions.
  * Empty query responses are handled safely.
  * Statistics parsing now supports values containing colons and ignores invalid entries.
  * Statistics comparisons and formatting are more consistent.

* **Documentation**
  * Clarified procedure output argument documentation.

* **Tests**
  * Added coverage for yielded procedure outputs, transactional graph deletion, empty results, and statistics parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->