### PR TITLE
build: bump api.diff.baseline to 0.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 		     breaks by default; a reviewed, intentional break is approved by overriding it to false (the
 		     CI `api-diff` job sets -Dapi.diff.fail=false when the PR carries the `breaking-change`
 		     label). -->
-		<api.diff.baseline>0.10.0</api.diff.baseline>
+		<api.diff.baseline>0.10.1</api.diff.baseline>
 		<api.diff.fail>true</api.diff.fail>
 	</properties>
 


### PR DESCRIPTION
The documented manual post-release step: now that **v0.10.1 is published on Maven
Central**, point the `api-diff` gate at it instead of 0.10.0.

The `pom.xml` comment states it directly — *"it must be bumped to the new version
as part of releasing"* — and #362 did the same for 0.10.0.

Without this, `api-diff` keeps diffing against 0.10.0, so any public-API change
introduced *in* 0.10.1 would stop being visible to the gate.

## Verification

`japicmp` resolves the new baseline from Central and finds no drift:

```
Comparing source compatibility of target/jfalkordb-0.10.2-SNAPSHOT.jar
  against ~/.m2/repository/com/falkordb/jfalkordb/0.10.1/jfalkordb-0.10.1.jar
No changes.
```

The `0.10.1` jar was downloaded fresh from Central during that run, which is what
confirms the baseline is actually resolvable — this PR had to wait for the
artifact to finish publishing.

## Note on the 0.10.1 release

`version-and-release.yml` went red for v0.10.1, but the release itself completed.
The failure was a transient Sonatype 502 on the *status-polling* step:

```
central-publishing-maven-plugin:0.11.0:publish failed:
Cannot get deployment status. Response status code: 502
```

Because the pom sets `autoPublish=true`, the deployment published server-side
anyway. All five artifacts (pom, jar, sources, javadoc, `.asc`) are live and
`maven-metadata.xml` reports `0.10.1` as `<latest>`/`<release>`. No re-deploy was
needed or performed.

Worth considering separately: `waitUntil=published` is what turns a transient
Sonatype hiccup into a failed release build. A retry around the status poll would
make releases robust against exactly this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)