### PR TITLE
fix!: non-finite doubles, header thread-safety, and Record null/unknown-column handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,6 +257,24 @@
 				</executions>
 			</plugin>
 
+			<!-- Stable JPMS module name for modular consumers (`requires com.falkordb;`). A manifest
+			     entry only, not a module-info, so it is safe at release 8 and costs nothing at runtime.
+			     Without it a modular consumer binds to a name derived from the jar FILENAME, which
+			     shading or renaming silently breaks, and which could not be stabilised later without
+			     breaking every consumer already relying on the derived name. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.4.2</version>
+				<configuration>
+					<archive>
+						<manifestEntries>
+							<Automatic-Module-Name>com.falkordb</Automatic-Module-Name>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -257,11 +257,13 @@
 				</executions>
 			</plugin>
 
-			<!-- Stable JPMS module name for modular consumers (`requires com.falkordb;`). A manifest
-			     entry only, not a module-info, so it is safe at release 8 and costs nothing at runtime.
-			     Without it a modular consumer binds to a name derived from the jar FILENAME, which
-			     shading or renaming silently breaks, and which could not be stabilised later without
-			     breaking every consumer already relying on the derived name. -->
+			<!-- Stable JPMS module name. MUST stay `jfalkordb`: that is the name Java already derives from
+				     the jar FILENAME, so it is what existing modular consumers already write in
+				     `requires jfalkordb;`. Pinning it here is what makes the name survive a rename or
+				     shading; changing the VALUE would break module resolution for those consumers and is a
+				     breaking change, not a patch. (Reverse-DNS `com.falkordb` would match the package, but
+				     adopting it means a minor bump plus a `requires` migration note.) Manifest entry only,
+				     not a module-info, so it is safe at release 8 and free at runtime. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
@@ -269,7 +271,7 @@
 				<configuration>
 					<archive>
 						<manifestEntries>
-							<Automatic-Module-Name>com.falkordb</Automatic-Module-Name>
+							<Automatic-Module-Name>jfalkordb</Automatic-Module-Name>
 						</manifestEntries>
 					</archive>
 				</configuration>

--- a/src/main/java/com/falkordb/Header.java
+++ b/src/main/java/com/falkordb/Header.java
@@ -32,14 +32,22 @@ public interface Header {
     /**
      * Returns the schema names.
      *
-     * @return the schema names
+     * <p>The returned list is unmodifiable; mutating it throws
+     * {@link UnsupportedOperationException}. Copy it if you need a mutable list. (Before 0.11.0 this
+     * exposed the header's internal list, so callers could corrupt the schema in place.)
+     *
+     * @return the schema names, unmodifiable
      */
     List<String> getSchemaNames();
 
     /**
      * Returns the schema types.
      *
-     * @return the schema types
+     * <p>The returned list is unmodifiable; mutating it throws
+     * {@link UnsupportedOperationException}. Copy it if you need a mutable list. (Before 0.11.0 this
+     * exposed the header's internal list, so callers could corrupt the schema in place.)
+     *
+     * @return the schema types, unmodifiable
      */
     List<ResultSetColumnTypes> getSchemaTypes();
 }

--- a/src/main/java/com/falkordb/Record.java
+++ b/src/main/java/com/falkordb/Record.java
@@ -27,6 +27,7 @@ public interface Record {
      * @param <T> return value type
      *
      * @return the value at the field, or {@code null} if the stored value is null
+     * @throws IllegalArgumentException if the record has no column with that key
      */
     <T> @Nullable T getValue(String key);
 
@@ -34,8 +35,9 @@ public interface Record {
      * The value at the given field index (represented as String)
      *
      * @param index field index
-     * @return string representation of the value
+     * @return string representation of the value, or {@code null} if the stored value is null
      */
+    @Nullable
     String getString(int index);
 
     /**
@@ -43,8 +45,10 @@ public interface Record {
      *
      * @param key header key
      *
-     * @return string representation of the value
+     * @return string representation of the value, or {@code null} if the stored value is null
+     * @throws IllegalArgumentException if the record has no column with that key
      */
+    @Nullable
     String getString(String key);
 
     /**

--- a/src/main/java/com/falkordb/Record.java
+++ b/src/main/java/com/falkordb/Record.java
@@ -13,8 +13,14 @@ public interface Record {
     /**
      * The value at the given field index
      *
+     * <p>{@code T} is inferred from the assignment, never checked: the cast is unchecked and erased,
+     * so the compiler inserts it at <em>your</em> call site. Asking for the wrong type therefore
+     * throws {@link ClassCastException} there rather than here, and throws nothing at all while the
+     * value stays untyped (assigned to {@code Object}, or passed straight on). Check the column's
+     * {@link Header#getSchemaTypes() schema type} if you cannot rely on the query shape.
+     *
      * @param index field index
-     * @param <T> return value type
+     * @param <T> return value type, unchecked
      *
      * @return the value at the field, or {@code null} if the stored value is null
      */
@@ -23,8 +29,11 @@ public interface Record {
     /**
      * The value at the given field
      *
+     * <p>{@code T} is unchecked, exactly as in {@link #getValue(int)}: a wrong type surfaces as a
+     * {@link ClassCastException} at the caller, not here.
+     *
      * @param key header key
-     * @param <T> return value type
+     * @param <T> return value type, unchecked
      *
      * @return the value at the field, or {@code null} if the stored value is null
      * @throws IllegalArgumentException if the record has no column with that key

--- a/src/main/java/com/falkordb/Record.java
+++ b/src/main/java/com/falkordb/Record.java
@@ -54,7 +54,12 @@ public interface Record {
     /**
      * The keys of the record
      *
-     * @return list of the record key
+     * <p>Records share the result set's schema, so the returned list is unmodifiable; mutating it
+     * throws {@link UnsupportedOperationException}. Copy it if you need a mutable list. (Before
+     * 0.11.0 this exposed the shared header list, so mutating it corrupted every record in the
+     * result set.)
+     *
+     * @return list of the record key, unmodifiable
      */
     List<String> keys();
 

--- a/src/main/java/com/falkordb/Record.java
+++ b/src/main/java/com/falkordb/Record.java
@@ -66,9 +66,13 @@ public interface Record {
     /**
      * The values of the record
      *
-     * @return list of the record values
+     * <p>A NULL column deserializes to {@code null}, so the returned list may contain null elements
+     * — hence {@code List<@Nullable Object>} rather than {@code List<Object>}. Null-check an element
+     * before dereferencing it, as you would the {@link #getValue(int)} of that column.
+     *
+     * @return list of the record values, whose elements may be {@code null}
      */
-    List<Object> values();
+    List<@Nullable Object> values();
 
     /**
      * Check if the record header contains the given key

--- a/src/main/java/com/falkordb/impl/api/GraphPipelineImpl.java
+++ b/src/main/java/com/falkordb/impl/api/GraphPipelineImpl.java
@@ -24,6 +24,20 @@ public class GraphPipelineImpl extends Pipeline implements com.falkordb.GraphPip
     private final String graphId;
 
     /**
+     * Builds a {@link ResultSet} from a raw graph reply. One shared instance replaces the eight
+     * byte-identical anonymous builders this class used to declare, so a fix to the response shape
+     * lands in one place. Jedis {@code Builder} is an abstract class, not a functional interface, so
+     * this cannot be a lambda. {@code graph}/{@code cache} are read at build time, not captured.
+     */
+    private final Builder<ResultSet> resultSetBuilder = new Builder<ResultSet>() {
+        @SuppressWarnings("unchecked")
+        @Override
+        public ResultSet build(Object o) {
+            return new ResultSetImpl((List<Object>) o, graph, cache);
+        }
+    };
+
+    /**
      * Creates a new pipeline for a given graph.
      * @param connection the connection to use
      * @param graph the graph to use
@@ -60,13 +74,7 @@ public class GraphPipelineImpl extends Pipeline implements com.falkordb.GraphPip
     @Override
     public Response<ResultSet> query(String query) {
         return appendWithResponse(
-                GraphCommand.QUERY, Arrays.asList(graphId, query, Utils.COMPACT_STRING), new Builder<ResultSet>() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    public ResultSet build(Object o) {
-                        return new ResultSetImpl((List<Object>) o, graph, cache);
-                    }
-                });
+                GraphCommand.QUERY, Arrays.asList(graphId, query, Utils.COMPACT_STRING), resultSetBuilder);
     }
 
     /**
@@ -77,13 +85,7 @@ public class GraphPipelineImpl extends Pipeline implements com.falkordb.GraphPip
     @Override
     public Response<ResultSet> readOnlyQuery(String query) {
         return appendWithResponse(
-                GraphCommand.RO_QUERY, Arrays.asList(graphId, query, Utils.COMPACT_STRING), new Builder<ResultSet>() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    public ResultSet build(Object o) {
-                        return new ResultSetImpl((List<Object>) o, graph, cache);
-                    }
-                });
+                GraphCommand.RO_QUERY, Arrays.asList(graphId, query, Utils.COMPACT_STRING), resultSetBuilder);
     }
 
     /**
@@ -99,13 +101,7 @@ public class GraphPipelineImpl extends Pipeline implements com.falkordb.GraphPip
         return appendWithResponse(
                 GraphCommand.QUERY,
                 Arrays.asList(graphId, query, Utils.COMPACT_STRING, Utils.TIMEOUT_STRING, Long.toString(timeout)),
-                new Builder<ResultSet>() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    public ResultSet build(Object o) {
-                        return new ResultSetImpl((List<Object>) o, graph, cache);
-                    }
-                });
+                resultSetBuilder);
     }
 
     /**
@@ -121,13 +117,7 @@ public class GraphPipelineImpl extends Pipeline implements com.falkordb.GraphPip
         return appendWithResponse(
                 GraphCommand.RO_QUERY,
                 Arrays.asList(graphId, query, Utils.COMPACT_STRING, Utils.TIMEOUT_STRING, Long.toString(timeout)),
-                new Builder<ResultSet>() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    public ResultSet build(Object o) {
-                        return new ResultSetImpl((List<Object>) o, graph, cache);
-                    }
-                });
+                resultSetBuilder);
     }
 
     /**
@@ -141,13 +131,7 @@ public class GraphPipelineImpl extends Pipeline implements com.falkordb.GraphPip
         return appendWithResponse(
                 GraphCommand.QUERY,
                 Arrays.asList(graphId, Utils.prepareQuery(query, params), Utils.COMPACT_STRING),
-                new Builder<ResultSet>() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    public ResultSet build(Object o) {
-                        return new ResultSetImpl((List<Object>) o, graph, cache);
-                    }
-                });
+                resultSetBuilder);
     }
 
     /**
@@ -161,13 +145,7 @@ public class GraphPipelineImpl extends Pipeline implements com.falkordb.GraphPip
         return appendWithResponse(
                 GraphCommand.RO_QUERY,
                 Arrays.asList(graphId, Utils.prepareQuery(query, params), Utils.COMPACT_STRING),
-                new Builder<ResultSet>() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    public ResultSet build(Object o) {
-                        return new ResultSetImpl((List<Object>) o, graph, cache);
-                    }
-                });
+                resultSetBuilder);
     }
 
     /**
@@ -190,13 +168,7 @@ public class GraphPipelineImpl extends Pipeline implements com.falkordb.GraphPip
                         Utils.COMPACT_STRING,
                         Utils.TIMEOUT_STRING,
                         Long.toString(timeout)),
-                new Builder<ResultSet>() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    public ResultSet build(Object o) {
-                        return new ResultSetImpl((List<Object>) o, graph, cache);
-                    }
-                });
+                resultSetBuilder);
     }
 
     /**
@@ -219,13 +191,7 @@ public class GraphPipelineImpl extends Pipeline implements com.falkordb.GraphPip
                         Utils.COMPACT_STRING,
                         Utils.TIMEOUT_STRING,
                         Long.toString(timeout)),
-                new Builder<ResultSet>() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    public ResultSet build(Object o) {
-                        return new ResultSetImpl((List<Object>) o, graph, cache);
-                    }
-                });
+                resultSetBuilder);
     }
 
     /**

--- a/src/main/java/com/falkordb/impl/api/GraphTransactionImpl.java
+++ b/src/main/java/com/falkordb/impl/api/GraphTransactionImpl.java
@@ -24,6 +24,20 @@ public class GraphTransactionImpl extends Transaction implements com.falkordb.Gr
     private GraphCache cache;
 
     /**
+     * Builds a {@link ResultSet} from a raw graph reply. One shared instance replaces the eight
+     * byte-identical anonymous builders this class used to declare, so a fix to the response shape
+     * lands in one place. Jedis {@code Builder} is an abstract class, not a functional interface, so
+     * this cannot be a lambda. {@code graph}/{@code cache} are read at build time, not captured.
+     */
+    private final Builder<ResultSet> resultSetBuilder = new Builder<ResultSet>() {
+        @SuppressWarnings("unchecked")
+        @Override
+        public ResultSet build(Object o) {
+            return new ResultSetImpl((List<Object>) o, graph, cache);
+        }
+    };
+
+    /**
      * Creates a new transaction for a given graph.
      * @param connection the connection to use
      * @param graph the graph to use
@@ -61,13 +75,7 @@ public class GraphTransactionImpl extends Transaction implements com.falkordb.Gr
     @Override
     public Response<ResultSet> query(String query) {
         return appendWithResponse(
-                GraphCommand.QUERY, Arrays.asList(graphId, query, Utils.COMPACT_STRING), new Builder<ResultSet>() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    public ResultSet build(Object o) {
-                        return new ResultSetImpl((List<Object>) o, graph, cache);
-                    }
-                });
+                GraphCommand.QUERY, Arrays.asList(graphId, query, Utils.COMPACT_STRING), resultSetBuilder);
     }
 
     /**
@@ -78,13 +86,7 @@ public class GraphTransactionImpl extends Transaction implements com.falkordb.Gr
     @Override
     public Response<ResultSet> readOnlyQuery(String query) {
         return appendWithResponse(
-                GraphCommand.RO_QUERY, Arrays.asList(graphId, query, Utils.COMPACT_STRING), new Builder<ResultSet>() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    public ResultSet build(Object o) {
-                        return new ResultSetImpl((List<Object>) o, graph, cache);
-                    }
-                });
+                GraphCommand.RO_QUERY, Arrays.asList(graphId, query, Utils.COMPACT_STRING), resultSetBuilder);
     }
 
     /**
@@ -100,13 +102,7 @@ public class GraphTransactionImpl extends Transaction implements com.falkordb.Gr
         return appendWithResponse(
                 GraphCommand.QUERY,
                 Arrays.asList(graphId, query, Utils.COMPACT_STRING, Utils.TIMEOUT_STRING, Long.toString(timeout)),
-                new Builder<ResultSet>() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    public ResultSet build(Object o) {
-                        return new ResultSetImpl((List<Object>) o, graph, cache);
-                    }
-                });
+                resultSetBuilder);
     }
 
     /**
@@ -122,13 +118,7 @@ public class GraphTransactionImpl extends Transaction implements com.falkordb.Gr
         return appendWithResponse(
                 GraphCommand.RO_QUERY,
                 Arrays.asList(graphId, query, Utils.COMPACT_STRING, Utils.TIMEOUT_STRING, Long.toString(timeout)),
-                new Builder<ResultSet>() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    public ResultSet build(Object o) {
-                        return new ResultSetImpl((List<Object>) o, graph, cache);
-                    }
-                });
+                resultSetBuilder);
     }
 
     /**
@@ -142,13 +132,7 @@ public class GraphTransactionImpl extends Transaction implements com.falkordb.Gr
         return appendWithResponse(
                 GraphCommand.QUERY,
                 Arrays.asList(graphId, Utils.prepareQuery(query, params), Utils.COMPACT_STRING),
-                new Builder<ResultSet>() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    public ResultSet build(Object o) {
-                        return new ResultSetImpl((List<Object>) o, graph, cache);
-                    }
-                });
+                resultSetBuilder);
     }
 
     /**
@@ -162,13 +146,7 @@ public class GraphTransactionImpl extends Transaction implements com.falkordb.Gr
         return appendWithResponse(
                 GraphCommand.RO_QUERY,
                 Arrays.asList(graphId, Utils.prepareQuery(query, params), Utils.COMPACT_STRING),
-                new Builder<ResultSet>() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    public ResultSet build(Object o) {
-                        return new ResultSetImpl((List<Object>) o, graph, cache);
-                    }
-                });
+                resultSetBuilder);
     }
 
     /**
@@ -190,13 +168,7 @@ public class GraphTransactionImpl extends Transaction implements com.falkordb.Gr
                         Utils.COMPACT_STRING,
                         Utils.TIMEOUT_STRING,
                         Long.toString(timeout)),
-                new Builder<ResultSet>() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    public ResultSet build(Object o) {
-                        return new ResultSetImpl((List<Object>) o, graph, cache);
-                    }
-                });
+                resultSetBuilder);
     }
 
     /**
@@ -218,13 +190,7 @@ public class GraphTransactionImpl extends Transaction implements com.falkordb.Gr
                         Utils.COMPACT_STRING,
                         Utils.TIMEOUT_STRING,
                         Long.toString(timeout)),
-                new Builder<ResultSet>() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    public ResultSet build(Object o) {
-                        return new ResultSetImpl((List<Object>) o, graph, cache);
-                    }
-                });
+                resultSetBuilder);
     }
 
     /**

--- a/src/main/java/com/falkordb/impl/resultset/HeaderImpl.java
+++ b/src/main/java/com/falkordb/impl/resultset/HeaderImpl.java
@@ -11,7 +11,10 @@ import redis.clients.jedis.util.SafeEncoder;
 /**
  * Query result header interface implementation
  */
-public class HeaderImpl implements Header {
+// Final because the constructor can throw on a malformed reply: a partially-constructed non-final
+// class is reachable via a subclass finalizer (SpotBugs CT_CONSTRUCTOR_THROW). ResultSetImpl is final
+// for the same reason. Nothing extends this internal type.
+public final class HeaderImpl implements Header {
 
     // members
     private static final ResultSetColumnTypes[] COLUMN_TYPES = ResultSetColumnTypes.values();

--- a/src/main/java/com/falkordb/impl/resultset/HeaderImpl.java
+++ b/src/main/java/com/falkordb/impl/resultset/HeaderImpl.java
@@ -37,7 +37,7 @@ public final class HeaderImpl implements Header {
         List<ResultSetColumnTypes> types = new ArrayList<>(raw.size());
         List<String> names = new ArrayList<>(raw.size());
         for (List<Object> tuple : raw) {
-            types.add(columnType(((Long) tuple.get(0)).intValue()));
+            types.add(columnType((Long) tuple.get(0)));
             names.add(SafeEncoder.encode((byte[]) tuple.get(1)));
         }
         this.schemaTypes = Collections.unmodifiableList(types);
@@ -48,12 +48,14 @@ public final class HeaderImpl implements Header {
      * Resolves a server-supplied column-type ordinal, matching the guarded lookup
      * {@code ResultSetScalarTypes.getValue} performs for scalar types.
      */
-    private static ResultSetColumnTypes columnType(int index) {
-        try {
-            return COLUMN_TYPES[index];
-        } catch (IndexOutOfBoundsException e) {
+    private static ResultSetColumnTypes columnType(long index) {
+        // Range-check the reply's long BEFORE narrowing: intValue() keeps only the low 32 bits, so an
+        // out-of-range ordinal such as 4294967297 would wrap to 1 and be accepted as COLUMN_SCALAR —
+        // a hole in exactly the case this guard exists for.
+        if (index < 0 || index >= COLUMN_TYPES.length) {
             throw new JedisDataException("Unrecognized response type");
         }
+        return COLUMN_TYPES[(int) index];
     }
 
     /**

--- a/src/main/java/com/falkordb/impl/resultset/HeaderImpl.java
+++ b/src/main/java/com/falkordb/impl/resultset/HeaderImpl.java
@@ -2,8 +2,10 @@ package com.falkordb.impl.resultset;
 
 import com.falkordb.Header;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.util.SafeEncoder;
 
 /**
@@ -12,9 +14,10 @@ import redis.clients.jedis.util.SafeEncoder;
 public class HeaderImpl implements Header {
 
     // members
-    private final List<List<Object>> raw;
-    private final List<ResultSetColumnTypes> schemaTypes = new ArrayList<>();
-    private final List<String> schemaNames = new ArrayList<>();
+    private static final ResultSetColumnTypes[] COLUMN_TYPES = ResultSetColumnTypes.values();
+
+    private final List<ResultSetColumnTypes> schemaTypes;
+    private final List<String> schemaNames;
 
     /**
      * Parameterized constructor
@@ -25,7 +28,29 @@ public class HeaderImpl implements Header {
      * @param raw - raw representation of a header
      */
     public HeaderImpl(List<List<Object>> raw) {
-        this.raw = raw;
+        // Built once, up front, into immutable lists. Building lazily without synchronization let two
+        // threads both observe an empty list and both append to it, duplicating every column — reachable
+        // now that AsyncGraph hands a ResultSet to many threads.
+        List<ResultSetColumnTypes> types = new ArrayList<>(raw.size());
+        List<String> names = new ArrayList<>(raw.size());
+        for (List<Object> tuple : raw) {
+            types.add(columnType(((Long) tuple.get(0)).intValue()));
+            names.add(SafeEncoder.encode((byte[]) tuple.get(1)));
+        }
+        this.schemaTypes = Collections.unmodifiableList(types);
+        this.schemaNames = Collections.unmodifiableList(names);
+    }
+
+    /**
+     * Resolves a server-supplied column-type ordinal, matching the guarded lookup
+     * {@code ResultSetScalarTypes.getValue} performs for scalar types.
+     */
+    private static ResultSetColumnTypes columnType(int index) {
+        try {
+            return COLUMN_TYPES[index];
+        } catch (IndexOutOfBoundsException e) {
+            throw new JedisDataException("Unrecognized response type");
+        }
     }
 
     /**
@@ -33,9 +58,6 @@ public class HeaderImpl implements Header {
      */
     @Override
     public List<String> getSchemaNames() {
-        if (schemaNames.isEmpty()) {
-            buildSchema();
-        }
         return schemaNames;
     }
 
@@ -44,27 +66,7 @@ public class HeaderImpl implements Header {
      */
     @Override
     public List<ResultSetColumnTypes> getSchemaTypes() {
-        if (schemaTypes.isEmpty()) {
-            buildSchema();
-        }
         return schemaTypes;
-    }
-
-    /**
-     * Extracts schema names and types from the raw representation
-     */
-    private void buildSchema() {
-        for (List<Object> tuple : this.raw) {
-
-            // get type
-            ResultSetColumnTypes type = ResultSetColumnTypes.values()[((Long) tuple.get(0)).intValue()];
-            // get text
-            String text = SafeEncoder.encode((byte[]) tuple.get(1));
-            if (type != null) {
-                schemaTypes.add(type);
-                schemaNames.add(text);
-            }
-        }
     }
 
     @Override

--- a/src/main/java/com/falkordb/impl/resultset/RecordImpl.java
+++ b/src/main/java/com/falkordb/impl/resultset/RecordImpl.java
@@ -3,6 +3,7 @@ package com.falkordb.impl.resultset;
 import com.falkordb.Record;
 import java.util.List;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An implementation of the Record interface.
@@ -10,30 +11,30 @@ import java.util.Objects;
 public class RecordImpl implements Record {
 
     private final List<String> header;
-    private final List<Object> values;
+    private final List<@Nullable Object> values;
 
     /**
      * Creates a new RecordImpl.
      * @param header the header of the record
-     * @param values the values of the record
+     * @param values the values of the record; a NULL column is stored as {@code null}
      */
-    public RecordImpl(List<String> header, List<Object> values) {
+    public RecordImpl(List<String> header, List<@Nullable Object> values) {
         this.header = header;
         this.values = values;
     }
 
     @Override
-    public <T> T getValue(int index) {
+    public <T> @Nullable T getValue(int index) {
         return (T) this.values.get(index);
     }
 
     @Override
-    public <T> T getValue(String key) {
+    public <T> @Nullable T getValue(String key) {
         return getValue(indexOf(key));
     }
 
     @Override
-    public String getString(int index) {
+    public @Nullable String getString(int index) {
         Object value = this.values.get(index);
         // A NULL column deserializes to null; getValue is documented @Nullable, so report the same
         // absence here rather than throwing NPE from null.toString().
@@ -41,7 +42,7 @@ public class RecordImpl implements Record {
     }
 
     @Override
-    public String getString(String key) {
+    public @Nullable String getString(String key) {
         return getString(indexOf(key));
     }
 
@@ -64,7 +65,7 @@ public class RecordImpl implements Record {
     }
 
     @Override
-    public List<Object> values() {
+    public List<@Nullable Object> values() {
         return this.values;
     }
 

--- a/src/main/java/com/falkordb/impl/resultset/RecordImpl.java
+++ b/src/main/java/com/falkordb/impl/resultset/RecordImpl.java
@@ -29,17 +29,33 @@ public class RecordImpl implements Record {
 
     @Override
     public <T> T getValue(String key) {
-        return getValue(this.header.indexOf(key));
+        return getValue(indexOf(key));
     }
 
     @Override
     public String getString(int index) {
-        return this.values.get(index).toString();
+        Object value = this.values.get(index);
+        // A NULL column deserializes to null; getValue is documented @Nullable, so report the same
+        // absence here rather than throwing NPE from null.toString().
+        return value == null ? null : value.toString();
     }
 
     @Override
     public String getString(String key) {
-        return getString(this.header.indexOf(key));
+        return getString(indexOf(key));
+    }
+
+    /**
+     * Resolves a column name to its index, failing with the offending key rather than letting the
+     * -1 from a miss reach values.get() and surface as "Index -1 out of bounds".
+     */
+    private int indexOf(String key) {
+        int index = this.header.indexOf(key);
+        if (index < 0) {
+            throw new IllegalArgumentException(
+                    "No such column in this record: " + key + "; columns are " + this.header);
+        }
+        return index;
     }
 
     @Override

--- a/src/main/java/com/falkordb/impl/resultset/RecordImpl.java
+++ b/src/main/java/com/falkordb/impl/resultset/RecordImpl.java
@@ -15,7 +15,13 @@ public class RecordImpl implements Record {
 
     /**
      * Creates a new RecordImpl.
-     * @param header the header of the record
+     *
+     * <p>The header list is shared, not copied: every record in a result set holds the one schema
+     * list {@code HeaderImpl} built, so a copy here would cost an allocation per row. Callers must
+     * therefore pass an unmodifiable, unaliased list — {@code HeaderImpl.getSchemaNames()} is one —
+     * because it is handed straight back by {@link #keys()}, which is documented unmodifiable.
+     *
+     * @param header the header of the record; must be unmodifiable, as {@link #keys()} returns it
      * @param values the values of the record; a NULL column is stored as {@code null}
      */
     public RecordImpl(List<String> header, List<@Nullable Object> values) {

--- a/src/main/java/com/falkordb/impl/resultset/RecordImpl.java
+++ b/src/main/java/com/falkordb/impl/resultset/RecordImpl.java
@@ -31,6 +31,8 @@ public class RecordImpl implements Record {
 
     @Override
     public <T> @Nullable T getValue(int index) {
+        // Unchecked and erased: nothing here can verify T, so the compiler inserts the checkcast at the
+        // caller's assignment. Documented on Record#getValue(int) and pinned by RecordImplTest.
         return (T) this.values.get(index);
     }
 

--- a/src/main/java/com/falkordb/impl/resultset/ResultSetImpl.java
+++ b/src/main/java/com/falkordb/impl/resultset/ResultSetImpl.java
@@ -406,7 +406,7 @@ public final class ResultSetImpl implements ResultSet {
      * @return scalar type
      */
     private ResultSetScalarTypes getValueTypeFromObject(Object rawScalarType) {
-        return ResultSetScalarTypes.getValue(((Long) rawScalarType).intValue());
+        return ResultSetScalarTypes.getValue((Long) rawScalarType);
     }
 
     @Override

--- a/src/main/java/com/falkordb/impl/resultset/ResultSetImpl.java
+++ b/src/main/java/com/falkordb/impl/resultset/ResultSetImpl.java
@@ -11,6 +11,7 @@ import com.falkordb.impl.graph_cache.GraphCache;
 import java.time.*;
 import java.util.*;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 import redis.clients.jedis.BuilderFactory;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.util.SafeEncoder;
@@ -88,7 +89,7 @@ public final class ResultSetImpl implements ResultSet {
         // go over each raw result
         for (List<Object> row : rawResultSet) {
 
-            List<Object> parsedRow = new ArrayList<>(row.size());
+            List<@Nullable Object> parsedRow = new ArrayList<>(row.size());
             // go over each object in the result
             for (int i = 0; i < row.size(); i++) {
                 // get raw representation of the object

--- a/src/main/java/com/falkordb/impl/resultset/ResultSetImpl.java
+++ b/src/main/java/com/falkordb/impl/resultset/ResultSetImpl.java
@@ -390,7 +390,8 @@ public final class ResultSetImpl implements ResultSet {
                     try {
                         return parseFloat(SafeEncoder.encode(val));
                     } catch (NumberFormatException e) {
-                        // Handle the exception appropriately
+                        // parseFloat already maps FalkorDB's C spellings of the non-finite values, so
+                        // anything still failing here is genuinely malformed.
                         throw new GraphException("Invalid float value in vector data", e);
                     }
                 })

--- a/src/main/java/com/falkordb/impl/resultset/ResultSetImpl.java
+++ b/src/main/java/com/falkordb/impl/resultset/ResultSetImpl.java
@@ -335,17 +335,47 @@ public final class ResultSetImpl implements ResultSet {
         try {
             return Double.parseDouble(text);
         } catch (NumberFormatException e) {
-            String value = text.trim().toLowerCase(Locale.ROOT);
-            boolean negative = value.startsWith("-");
-            String magnitude = negative || value.startsWith("+") ? value.substring(1) : value;
-            if ("inf".equals(magnitude) || "infinity".equals(magnitude)) {
-                return negative ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
-            }
-            if ("nan".equals(magnitude)) {
-                return Double.NaN;
-            }
-            throw e;
+            return nonFinite(text, e);
         }
+    }
+
+    /**
+     * The {@code vecf32} counterpart of {@link #parseDouble}. Vector elements arrive with the same
+     * spellings — {@code RETURN vecf32([1.0/0.0, 0.0/0.0])} sends {@code inf} and {@code nan} — which
+     * {@link Float#parseFloat} rejects just as {@link Double#parseDouble} does.
+     *
+     * @param text the raw textual float
+     * @return the parsed value
+     */
+    private static float parseFloat(String text) {
+        try {
+            return Float.parseFloat(text);
+        } catch (NumberFormatException e) {
+            // Narrowing is exact for the non-finite values: (float) Double.POSITIVE_INFINITY is
+            // Float.POSITIVE_INFINITY, and (float) Double.NaN is Float.NaN.
+            return (float) nonFinite(text, e);
+        }
+    }
+
+    /**
+     * Maps FalkorDB's C-style spellings of the non-finite values, rethrowing the original failure for
+     * input that is genuinely malformed rather than merely spelled the C way.
+     *
+     * @param text     the raw text that failed to parse
+     * @param original the failure to rethrow if the text is not a recognised non-finite spelling
+     * @return the non-finite value the text denotes
+     */
+    private static double nonFinite(String text, NumberFormatException original) {
+        String value = text.trim().toLowerCase(Locale.ROOT);
+        boolean negative = value.startsWith("-");
+        String magnitude = negative || value.startsWith("+") ? value.substring(1) : value;
+        if ("inf".equals(magnitude) || "infinity".equals(magnitude)) {
+            return negative ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
+        }
+        if ("nan".equals(magnitude)) {
+            return Double.NaN;
+        }
+        throw original;
     }
 
     private Object deserializePoint(Object rawScalarData) {
@@ -357,7 +387,7 @@ public final class ResultSetImpl implements ResultSet {
         return array.stream()
                 .map(val -> {
                     try {
-                        return Float.parseFloat(SafeEncoder.encode(val));
+                        return parseFloat(SafeEncoder.encode(val));
                     } catch (NumberFormatException e) {
                         // Handle the exception appropriately
                         throw new GraphException("Invalid float value in vector data", e);

--- a/src/main/java/com/falkordb/impl/resultset/ResultSetImpl.java
+++ b/src/main/java/com/falkordb/impl/resultset/ResultSetImpl.java
@@ -289,7 +289,7 @@ public final class ResultSetImpl implements ResultSet {
             case VALUE_BOOLEAN:
                 return Boolean.parseBoolean(SafeEncoder.encode((byte[]) obj));
             case VALUE_DOUBLE:
-                return Double.parseDouble(SafeEncoder.encode((byte[]) obj));
+                return parseDouble(SafeEncoder.encode((byte[]) obj));
             case VALUE_INTEGER:
                 return (Long) obj;
             case VALUE_STRING:
@@ -319,6 +319,32 @@ public final class ResultSetImpl implements ResultSet {
             case VALUE_UNKNOWN:
             default:
                 return obj;
+        }
+    }
+
+    /**
+     * Parses a double from the server's textual form. FalkorDB spells non-finite values the C way —
+     * {@code inf}, {@code -inf}, {@code nan}, {@code -nan} — none of which
+     * {@link Double#parseDouble} accepts (it requires {@code Infinity} / {@code NaN}), so a query such
+     * as {@code RETURN 1.0/0.0} used to escape as an unwrapped NumberFormatException.
+     *
+     * @param text the raw textual double
+     * @return the parsed value
+     */
+    private static double parseDouble(String text) {
+        try {
+            return Double.parseDouble(text);
+        } catch (NumberFormatException e) {
+            String value = text.trim().toLowerCase(Locale.ROOT);
+            boolean negative = value.startsWith("-");
+            String magnitude = negative || value.startsWith("+") ? value.substring(1) : value;
+            if ("inf".equals(magnitude) || "infinity".equals(magnitude)) {
+                return negative ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
+            }
+            if ("nan".equals(magnitude)) {
+                return Double.NaN;
+            }
+            throw e;
         }
     }
 

--- a/src/main/java/com/falkordb/impl/resultset/ResultSetScalarTypes.java
+++ b/src/main/java/com/falkordb/impl/resultset/ResultSetScalarTypes.java
@@ -23,11 +23,15 @@ enum ResultSetScalarTypes {
 
     private static final ResultSetScalarTypes[] values = values();
 
-    public static ResultSetScalarTypes getValue(int index) {
-        try {
-            return values[index];
-        } catch (IndexOutOfBoundsException e) {
+    /**
+     * Resolves a server-supplied scalar-type ordinal. Takes a long and range-checks it before
+     * narrowing: intValue() keeps only the low 32 bits, so an out-of-range ordinal such as
+     * 4294967297 would wrap to 1 and be accepted as VALUE_NULL.
+     */
+    public static ResultSetScalarTypes getValue(long index) {
+        if (index < 0 || index >= values.length) {
             throw new JedisDataException("Unrecognized response type");
         }
+        return values[(int) index];
     }
 }

--- a/src/test/java/com/falkordb/GraphAPIIT.java
+++ b/src/test/java/com/falkordb/GraphAPIIT.java
@@ -1246,6 +1246,23 @@ public class GraphAPIIT {
     }
 
     @Test
+    public void testNonFiniteVectorElements() {
+        // Vector elements arrive with the same C spellings as scalar doubles — verified on the wire:
+        //   RETURN vecf32([1.0, 1.0/0.0, 0.0/0.0])  ->  type 12, elements "1", "inf", "nan"
+        // so Float.parseFloat rejected them exactly as Double.parseDouble rejected the scalar form.
+        List<Float> vector = client.query("RETURN vecf32([1.0, 1.0/0.0, -1.0/0.0, 0.0/0.0]) AS v")
+                .iterator()
+                .next()
+                .getValue("v");
+
+        Assertions.assertEquals(4, vector.size());
+        Assertions.assertEquals(1.0f, vector.get(0));
+        Assertions.assertEquals(Float.POSITIVE_INFINITY, vector.get(1));
+        Assertions.assertEquals(Float.NEGATIVE_INFINITY, vector.get(2));
+        Assertions.assertTrue(Float.isNaN(vector.get(3)));
+    }
+
+    @Test
     public void testGetStringOnNullValue() {
         // A missing property deserializes to null; getString must report that, not NPE.
         client.query("CREATE (:person{name:'roi'})");

--- a/src/test/java/com/falkordb/GraphAPIIT.java
+++ b/src/test/java/com/falkordb/GraphAPIIT.java
@@ -1231,6 +1231,33 @@ public class GraphAPIIT {
     }
 
     @Test
+    public void testNonFiniteDoubles() {
+        // FalkorDB spells non-finite doubles the C way — "inf", "-inf", "-nan" — which
+        // Double.parseDouble rejects (Java wants "Infinity"/"NaN"), so these queries used to escape as
+        // an unwrapped NumberFormatException.
+        Assertions.assertEquals(
+                Double.POSITIVE_INFINITY,
+                client.query("RETURN 1.0/0.0 AS d").iterator().next().getValue("d"));
+        Assertions.assertEquals(
+                Double.NEGATIVE_INFINITY,
+                client.query("RETURN -1.0/0.0 AS d").iterator().next().getValue("d"));
+        Assertions.assertTrue(Double.isNaN(
+                (Double) client.query("RETURN 0.0/0.0 AS d").iterator().next().getValue("d")));
+    }
+
+    @Test
+    public void testGetStringOnNullValue() {
+        // A missing property deserializes to null; getString must report that, not NPE.
+        client.query("CREATE (:person{name:'roi'})");
+        Record record = client.query("MATCH (p:person) RETURN p.missingProp AS m")
+                .iterator()
+                .next();
+
+        Assertions.assertNull(record.getValue("m"));
+        Assertions.assertNull(record.getString("m"));
+    }
+
+    @Test
     public void testExplainContextedAPI() {
         try (GraphContext context = client.getContext()) {
             // Create some test data first

--- a/src/test/java/com/falkordb/impl/resultset/HeaderImplTest.java
+++ b/src/test/java/com/falkordb/impl/resultset/HeaderImplTest.java
@@ -74,6 +74,18 @@ public class HeaderImplTest {
     }
 
     @Test
+    public void schemaListsAreUnmodifiable() {
+        // Behaviour change vs 0.10.1, which handed back the header's internal ArrayList so a caller
+        // could corrupt the schema in place. Documented on the Header interface; locked in here.
+        HeaderImpl header = new HeaderImpl(Collections.singletonList(column(2L, "n")));
+
+        assertThrows(UnsupportedOperationException.class, () -> header.getSchemaNames()
+                .add("injected"));
+        assertThrows(UnsupportedOperationException.class, () -> header.getSchemaTypes()
+                .clear());
+    }
+
+    @Test
     public void concurrentFirstAccessBuildsTheSchemaExactlyOnce() throws Exception {
         // AsyncGraph hands ResultSets to many threads. Building the schema lazily without
         // synchronization let two threads both see an empty list and both append to it, duplicating

--- a/src/test/java/com/falkordb/impl/resultset/HeaderImplTest.java
+++ b/src/test/java/com/falkordb/impl/resultset/HeaderImplTest.java
@@ -1,19 +1,86 @@
 package com.falkordb.impl.resultset;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.falkordb.Header;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.Test;
+import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class HeaderImplTest {
 
+    private static List<Object> column(long type, String name) {
+        return Arrays.asList((Object) type, SafeEncoder.encode(name));
+    }
+
     @Test
     public void equalsHashCodeContract() {
-        // equals/hashCode compare the schema derived from `raw` (getSchemaTypes/getSchemaNames), not the
-        // raw source list, so `raw` is ignored here. The lazily-built schema lists are always
-        // constructor-initialized, so NULL_FIELDS is safe.
+        // equals/hashCode compare the parsed schema, which is now the entire state (the raw source list
+        // is no longer retained). The lists are always constructor-initialized, so NULL_FIELDS is safe.
         EqualsVerifier.forClass(HeaderImpl.class)
                 .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE, Warning.NULL_FIELDS)
-                .withIgnoredFields("raw")
                 .verify();
+    }
+
+    @Test
+    public void parsesColumnNamesAndTypes() {
+        // Ordinals: 0 COLUMN_UNKNOWN, 1 COLUMN_SCALAR, 2 COLUMN_NODE, 3 COLUMN_RELATION.
+        HeaderImpl header = new HeaderImpl(Arrays.asList(column(2L, "n"), column(3L, "r")));
+
+        assertEquals(Arrays.asList("n", "r"), header.getSchemaNames());
+        assertEquals(
+                Arrays.asList(Header.ResultSetColumnTypes.COLUMN_NODE, Header.ResultSetColumnTypes.COLUMN_RELATION),
+                header.getSchemaTypes());
+    }
+
+    @Test
+    public void unknownColumnTypeIsReportedAsAProtocolError() {
+        // A newer server sending a column-type ordinal this client does not know must produce the same
+        // graceful error ResultSetScalarTypes.getValue gives for scalars, not a bare
+        // ArrayIndexOutOfBoundsException from indexing values() with an unvalidated ordinal. The schema
+        // is parsed in the constructor, so this now fails fast there rather than on first access.
+        List<List<Object>> raw = Collections.singletonList(column(99L, "future"));
+
+        assertThrows(JedisDataException.class, () -> new HeaderImpl(raw));
+    }
+
+    @Test
+    public void concurrentFirstAccessBuildsTheSchemaExactlyOnce() throws Exception {
+        // AsyncGraph hands ResultSets to many threads. Building the schema lazily without
+        // synchronization let two threads both see an empty list and both append to it, duplicating
+        // every column. Run enough racing rounds that an unsynchronized build reliably double-populates.
+        int threads = 8;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            for (int round = 0; round < 200; round++) {
+                HeaderImpl header = new HeaderImpl(Collections.singletonList(column(2L, "n")));
+                CyclicBarrier start = new CyclicBarrier(threads);
+                List<Callable<List<String>>> tasks = new ArrayList<>(threads);
+                for (int t = 0; t < threads; t++) {
+                    tasks.add(() -> {
+                        start.await(5, TimeUnit.SECONDS);
+                        return header.getSchemaNames();
+                    });
+                }
+                for (Future<List<String>> f : pool.invokeAll(tasks)) {
+                    assertEquals(Collections.singletonList("n"), f.get(), "schema duplicated under concurrent access");
+                }
+            }
+        } finally {
+            pool.shutdownNow();
+        }
     }
 }

--- a/src/test/java/com/falkordb/impl/resultset/HeaderImplTest.java
+++ b/src/test/java/com/falkordb/impl/resultset/HeaderImplTest.java
@@ -2,6 +2,7 @@ package com.falkordb.impl.resultset;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.falkordb.Header;
 import java.util.ArrayList;
@@ -110,6 +111,9 @@ public class HeaderImplTest {
             }
         } finally {
             pool.shutdownNow();
+            // 1600 tasks across 200 rounds: wait for the workers to actually go away rather than
+            // leaving them to be reaped while the rest of the suite runs.
+            assertTrue(pool.awaitTermination(10, TimeUnit.SECONDS), "worker threads did not terminate");
         }
     }
 }

--- a/src/test/java/com/falkordb/impl/resultset/HeaderImplTest.java
+++ b/src/test/java/com/falkordb/impl/resultset/HeaderImplTest.java
@@ -86,10 +86,11 @@ public class HeaderImplTest {
     }
 
     @Test
-    public void concurrentFirstAccessBuildsTheSchemaExactlyOnce() throws Exception {
-        // AsyncGraph hands ResultSets to many threads. Building the schema lazily without
-        // synchronization let two threads both see an empty list and both append to it, duplicating
-        // every column. Run enough racing rounds that an unsynchronized build reliably double-populates.
+    public void concurrentReadsSeeTheSchemaExactlyOnce() throws Exception {
+        // AsyncGraph hands ResultSets to many threads. The schema is now built once in the constructor,
+        // but it used to be built lazily without synchronization, which let two threads both see an
+        // empty list and both append to it, duplicating every column. Race enough rounds that a
+        // regression back to an unsynchronized lazy build reliably double-populates.
         int threads = 8;
         ExecutorService pool = Executors.newFixedThreadPool(threads);
         try {

--- a/src/test/java/com/falkordb/impl/resultset/HeaderImplTest.java
+++ b/src/test/java/com/falkordb/impl/resultset/HeaderImplTest.java
@@ -58,6 +58,22 @@ public class HeaderImplTest {
     }
 
     @Test
+    public void outOfRangeOrdinalThatWrapsToAValidIntIsRejected() {
+        // 4294967297 == 2^32 + 1, so intValue() keeps only the low 32 bits and yields 1 — which would
+        // silently pass as COLUMN_SCALAR if the ordinal were narrowed before being range-checked.
+        List<List<Object>> raw = Collections.singletonList(column(4294967297L, "wrapped"));
+
+        assertThrows(JedisDataException.class, () -> new HeaderImpl(raw));
+    }
+
+    @Test
+    public void negativeOrdinalIsRejected() {
+        List<List<Object>> raw = Collections.singletonList(column(-1L, "negative"));
+
+        assertThrows(JedisDataException.class, () -> new HeaderImpl(raw));
+    }
+
+    @Test
     public void concurrentFirstAccessBuildsTheSchemaExactlyOnce() throws Exception {
         // AsyncGraph hands ResultSets to many threads. Building the schema lazily without
         // synchronization let two threads both see an empty list and both append to it, duplicating

--- a/src/test/java/com/falkordb/impl/resultset/RecordImplTest.java
+++ b/src/test/java/com/falkordb/impl/resultset/RecordImplTest.java
@@ -41,6 +41,16 @@ public class RecordImplTest {
     }
 
     @Test
+    public void keysReflectsTheSchemaListItWasBuiltFrom() {
+        // Records share the result set's schema list, which is now unmodifiable, so keys() is too.
+        // Behaviour change vs 0.10.1, where mutating it corrupted every record in the result set.
+        RecordImpl record = new RecordImpl(
+                Collections.unmodifiableList(Collections.singletonList("name")), Collections.singletonList("a"));
+
+        assertThrows(UnsupportedOperationException.class, () -> record.keys().add("injected"));
+    }
+
+    @Test
     public void unknownKeyIsReportedWithTheKeyName() {
         // header.indexOf(key) returns -1 for an unknown column, which used to reach values.get(-1) and
         // surface as "Index -1 out of bounds" with no mention of the offending key.

--- a/src/test/java/com/falkordb/impl/resultset/RecordImplTest.java
+++ b/src/test/java/com/falkordb/impl/resultset/RecordImplTest.java
@@ -43,6 +43,29 @@ public class RecordImplTest {
     }
 
     @Test
+    public void getValueDoesNotCheckTheRequestedType() {
+        // <T> is inferred from the assignment and erased, so the unchecked cast inside getValue cannot
+        // verify anything: the compiler inserts the checkcast at the CALLER. A wrong type therefore
+        // fails in user code rather than here -- and does not fail at all while the value stays
+        // untyped. Both halves are documented on Record#getValue; pin them so a future signature
+        // change has to face the contract.
+        RecordImpl record = new RecordImpl(Collections.singletonList("n"), Collections.singletonList((Object) 42L));
+
+        assertThrows(ClassCastException.class, () -> {
+            String misdeclared = record.getValue(0);
+            assertNull(misdeclared, "unreachable: the checkcast throws before this runs");
+        });
+        assertThrows(ClassCastException.class, () -> {
+            String misdeclared = record.getValue("n");
+            assertNull(misdeclared, "unreachable: the checkcast throws before this runs");
+        });
+
+        // The silent half: no narrowing, no exception, wrong type never noticed.
+        Object untyped = record.getValue(0);
+        assertEquals(42L, untyped);
+    }
+
+    @Test
     public void valuesMayContainNullElements() {
         // A NULL column is stored as null, so values() is List<@Nullable Object>. The @NullMarked
         // package would otherwise promise callers that every element is non-null.

--- a/src/test/java/com/falkordb/impl/resultset/RecordImplTest.java
+++ b/src/test/java/com/falkordb/impl/resultset/RecordImplTest.java
@@ -7,8 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 public class RecordImplTest {
@@ -38,6 +40,19 @@ public class RecordImplTest {
 
         assertEquals("42", record.getString(0));
         assertEquals("x", record.getString("b"));
+    }
+
+    @Test
+    public void valuesMayContainNullElements() {
+        // A NULL column is stored as null, so values() is List<@Nullable Object>. The @NullMarked
+        // package would otherwise promise callers that every element is non-null.
+        RecordImpl record = new RecordImpl(Arrays.asList("a", "b"), Arrays.asList((Object) "x", null));
+
+        List<@Nullable Object> values = record.values();
+
+        assertEquals(2, values.size());
+        assertEquals("x", values.get(0));
+        assertNull(values.get(1));
     }
 
     @Test

--- a/src/test/java/com/falkordb/impl/resultset/RecordImplTest.java
+++ b/src/test/java/com/falkordb/impl/resultset/RecordImplTest.java
@@ -1,5 +1,12 @@
 package com.falkordb.impl.resultset;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.Test;
@@ -12,5 +19,39 @@ public class RecordImplTest {
         EqualsVerifier.forClass(RecordImpl.class)
                 .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
                 .verify();
+    }
+
+    @Test
+    public void getStringReturnsNullForANullValue() {
+        // A NULL column deserializes to null (`MATCH (n) RETURN n.missingProp`). getValue is documented
+        // @Nullable, so getString must report the same absence rather than NPE on null.toString().
+        RecordImpl record = new RecordImpl(Collections.singletonList("n"), Collections.singletonList(null));
+
+        assertNull(record.getValue(0));
+        assertNull(record.getString(0));
+        assertNull(record.getString("n"));
+    }
+
+    @Test
+    public void getStringStillRendersNonNullValues() {
+        RecordImpl record = new RecordImpl(Arrays.asList("a", "b"), Arrays.asList((Object) 42L, "x"));
+
+        assertEquals("42", record.getString(0));
+        assertEquals("x", record.getString("b"));
+    }
+
+    @Test
+    public void unknownKeyIsReportedWithTheKeyName() {
+        // header.indexOf(key) returns -1 for an unknown column, which used to reach values.get(-1) and
+        // surface as "Index -1 out of bounds" with no mention of the offending key.
+        RecordImpl record = new RecordImpl(Collections.singletonList("name"), Collections.singletonList("a"));
+
+        IllegalArgumentException fromGetValue =
+                assertThrows(IllegalArgumentException.class, () -> record.getValue("nmae"));
+        assertTrue(fromGetValue.getMessage().contains("nmae"), "message must name the missing key");
+
+        IllegalArgumentException fromGetString =
+                assertThrows(IllegalArgumentException.class, () -> record.getString("nmae"));
+        assertTrue(fromGetString.getMessage().contains("nmae"), "message must name the missing key");
     }
 }

--- a/src/test/java/com/falkordb/impl/resultset/ResultSetImplTest.java
+++ b/src/test/java/com/falkordb/impl/resultset/ResultSetImplTest.java
@@ -2,11 +2,17 @@ package com.falkordb.impl.resultset;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.falkordb.Record;
 import com.falkordb.ResultSet;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class ResultSetImplTest {
 
@@ -21,5 +27,28 @@ public class ResultSetImplTest {
         assertTrue(resultSet.getHeader().getSchemaNames().isEmpty());
         assertFalse(resultSet.iterator().hasNext());
         assertEquals(0, resultSet.getStatistics().nodesCreated());
+    }
+
+    @Test
+    public void recordsFromAParsedReplyExposeAnUnmodifiableKeyList() {
+        // keys() is documented unmodifiable, but RecordImpl deliberately SHARES the schema list
+        // rather than copying it per row, so the guarantee lives in the parse path. Assert it on a
+        // record built the way every user-visible record is, instead of only on one handed a list
+        // the test itself made unmodifiable.
+        List<Object> column = Arrays.asList(1L, SafeEncoder.encode("n")); // COLUMN_SCALAR
+        List<List<Object>> rawHeader = Collections.singletonList(column);
+        List<Object> cell = Arrays.asList(2L, SafeEncoder.encode("v")); // VALUE_STRING
+        List<List<Object>> rawRows = Collections.singletonList(Collections.singletonList((Object) cell));
+        List<Object> rawResponse = Arrays.asList(rawHeader, rawRows, new ArrayList<>());
+
+        ResultSet resultSet = new ResultSetImpl(rawResponse, null, null);
+        Record record = resultSet.iterator().next();
+
+        assertEquals(Collections.singletonList("n"), record.keys());
+        assertEquals("v", record.getString(0));
+        assertThrows(UnsupportedOperationException.class, () -> record.keys().add("injected"));
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> resultSet.getHeader().getSchemaNames().add("injected"));
     }
 }

--- a/src/test/java/com/falkordb/impl/resultset/ResultSetScalarTypesTest.java
+++ b/src/test/java/com/falkordb/impl/resultset/ResultSetScalarTypesTest.java
@@ -1,0 +1,29 @@
+package com.falkordb.impl.resultset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.exceptions.JedisDataException;
+
+public class ResultSetScalarTypesTest {
+
+    @Test
+    public void resolvesKnownOrdinals() {
+        assertEquals(ResultSetScalarTypes.VALUE_NULL, ResultSetScalarTypes.getValue(1L));
+        assertEquals(ResultSetScalarTypes.VALUE_DOUBLE, ResultSetScalarTypes.getValue(5L));
+    }
+
+    @Test
+    public void unknownOrdinalIsReportedAsAProtocolError() {
+        assertThrows(JedisDataException.class, () -> ResultSetScalarTypes.getValue(99L));
+        assertThrows(JedisDataException.class, () -> ResultSetScalarTypes.getValue(-1L));
+    }
+
+    @Test
+    public void outOfRangeOrdinalThatWrapsToAValidIntIsRejected() {
+        // 4294967297 == 2^32 + 1: narrowing to int first would yield 1 and be accepted as VALUE_NULL,
+        // so the range check has to happen on the long the server actually sent.
+        assertThrows(JedisDataException.class, () -> ResultSetScalarTypes.getValue(4294967297L));
+    }
+}


### PR DESCRIPTION
The follow-up findings from the review that produced #383. Each fix has a test
that was **watched failing against unfixed code first**, and every claim below was
verified against a live FalkorDB rather than inferred.

Two of the original findings are **not** here — see *Dropped* at the end. That's
the important part of this PR to read.

## 1. Non-finite doubles crashed the read path

I probed a live server rather than trusting the finding:

```
RETURN 1.0/0.0   -> type 5 (VALUE_DOUBLE), value "inf"
RETURN -1.0/0.0  -> "-inf"
RETURN 0.0/0.0   -> "-nan"
```

`Double.parseDouble` accepts none of those — it wants `Infinity`/`NaN` — so any
query producing a non-finite double escaped as an unwrapped
`NumberFormatException`. Note the asymmetry removed: `Utils.appendNumber` already
rejects non-finite doubles on the *way in*, while the read path crashed on them.

The fast path is untouched; only its failure is inspected, and genuinely malformed
input still rethrows the original exception.

## 2. `HeaderImpl` duplicated columns under concurrent access

Lazy schema building was unsynchronized and appended without clearing. The new
test makes it vivid — 8 racing threads on a **single-column** header produced:

```
expected: <[n]> but was: <[n, n, n, n, n, n, n, n]>
```

Reachable since `AsyncGraph` began handing a `ResultSet` across threads.
`ResultSetImpl.parseResult` indexes `getSchemaTypes()` positionally, so a
duplicated schema misaligns every row.

Same commit fixes the unvalidated ordinal: `ResultSetColumnTypes.values()[...]`
indexed with a server-supplied ordinal gave a bare
`ArrayIndexOutOfBoundsException` for an unknown column type. It now uses the
guarded lookup `ResultSetScalarTypes.getValue` already performs for scalars. The
`if (type != null)` that followed was dead code — array indexing throws rather
than returning null.

## 3. `Record` null and unknown-column handling

`getString(int)` called `toString()` with no null check, so a NULL column threw
NPE — while `getValue` is documented `@Nullable` and returns null for that same
cell. `getValue(String)`/`getString(String)` passed `indexOf(key)` straight to
`values.get()`, so a typo surfaced as `Index -1 out of bounds` with no mention of
the key.

**Behaviour change on a public interface**, called out deliberately: unknown keys
now throw `IllegalArgumentException` (naming the key and listing available
columns) rather than `IndexOutOfBoundsException`, and `getString` may return null
rather than throwing. Both are now documented on `Record` with `@Nullable` and
`@throws`. `japicmp` reports **no API break**.

## 4. Shared `ResultSet` builder (refactor, no behaviour change)

16 byte-identical anonymous `Builder<ResultSet>` blocks — 8 per class — collapsed
to one shared field each. Also normalises the `@SuppressWarnings("unchecked")`
that some copies carried and others didn't. Jedis `Builder<T>` is an abstract
class, not a functional interface, so this is a field holding an anonymous
subclass, not a lambda.

## 5. `Automatic-Module-Name`

Pinned to **`jfalkordb`** — the name Java already derives from the jar filename,
so it matches what the published 0.10.1 artifact resolves as:

```
0.10.1                 -> jfalkordb@0.10.1 automatic
this PR                -> jfalkordb@0.10.2-SNAPSHOT automatic
```

An earlier revision of this PR used `com.falkordb`, which would have broken
`requires jfalkordb;` for existing modular consumers. Pinning the current name
keeps the whole benefit (it now survives a rename, a shade, or a version bump) at
zero cost. Adopting reverse-DNS `com.falkordb` remains possible later as a
deliberate change with a `requires` migration note. Manifest entry only, safe at
release 8, zero runtime cost.

## 6. `Record.values()` had an unsound nullness contract

`com.falkordb` is `@NullMarked`, so `List<Object> values()` promised callers that every
element is non-null — over a list the client itself fills with nulls:

```java
case VALUE_NULL:
    return null;                       // ResultSetImpl.deserializeScalar
...
parsedRow.add(deserializeScalar(obj)); // stored straight into the record
```

An existing IT already asserted exactly that shape
(`assertEquals(Arrays.asList(null, null, null), record.values())`), so a JSpecify-aware
caller got no warning before dereferencing an element with a real NPE path. Note the
asymmetry removed: `getValue(int)` — the single-element accessor over the *same* list —
was already `@Nullable`, so the bulk accessor was the only unwarned route to those cells.

Now `List<@Nullable Object>`, with the matching `RecordImpl` field, constructor parameter
and return type, plus the `ResultSetImpl` row buffer that holds the nulls. Type
annotations leave erasure and the generic signature untouched, so this is source- and
binary-compatible — `japicmp` reports `No changes.`, and it is **not** in the breaking
table below: it makes existing metadata honest rather than changing behaviour.

## Dropped: the temporal-truncation finding was wrong

I claimed all four temporal types silently truncate sub-second components. **That
was incorrect**, and probing the server disproved it:

```
localdatetime({... second:0, millisecond:500})  -> 1704110400
localdatetime({... second:0})                   -> 1704110400   # identical
localdatetime({... second:0, microsecond:500})  -> 1704110400   # identical
duration({milliseconds:1500})                   -> error: unknown key
localtime({hour:12,minute:0,second:0})          -> -2208945600
```

The **server** discards sub-second precision before it reaches the client, so
there is nothing for `Instant.ofEpochSecond` to truncate. `duration` doesn't even
accept a `milliseconds` key — my example query was invalid. And `VALUE_TIME` is an
epoch timestamp anchored at 1900-01-01, not seconds-of-day, so routing it through
an `Instant` is correct by design rather than "coincidental" as I claimed.

No change made. The existing code was right.

## Dropped: the `GraphContextImpl` double-close, for now

`deleteGraph()` closes the pooled connection in its `catch` and rethrows, after
which the caller's try-with-resources closes it again. The asymmetry is real — no
other method in that class closes on error.

But I wrote the IT and **it passed against unfixed code**: the second close is
benign in this Jedis/commons-pool2 version, so I have no failing test and won't
ship an unverified change to error handling. Proving it needs pool introspection
(a `maxTotal=1` pool, asserting the connection isn't handed to two borrowers).
Left for a follow-up that can demonstrate harm.

## Also still open

The pipeline/transaction cache-clear ordering (cache cleared at command-*append*
time, not after the DELETE executes). The clean fix is to clear when the response
is built, but Jedis builds responses lazily on `Response.get()`, so a caller that
never reads the response would never clear the cache at all — a worse bug.
Deferred pending a design that doesn't regress that.

## Breaking changes (why this is `fix!:` and not `fix:`)

Five observable runtime behaviours differ from 0.10.1. **`japicmp` reports no
break** because no signature changed — it cannot see any of these — so they are
declared here instead. Per the repo rule that a user-facing break is at least a
minor bump, the `fix!:` title makes release-please cut **0.11.0**, not 0.10.2.

| Call | 0.10.1 | This PR | Migration |
| --- | --- | --- | --- |
| `Record.getValue(String)` / `getString(String)`, unknown column | `IndexOutOfBoundsException` (`Index -1 out of bounds`) | `IllegalArgumentException` naming the key | Catch `IllegalArgumentException`, or guard with `containsKey` |
| `Record.getString(int)` / `getString(String)`, NULL column | `NullPointerException` | returns `null` | Null-check the result (matches `getValue`, already `@Nullable`) |
| `Header.getSchemaNames()`, `Header.getSchemaTypes()`, `Record.keys()` | mutable internal list | unmodifiable list | `new ArrayList<>(header.getSchemaNames())` if you need to mutate |
| A malformed / future column-type ordinal in the header | `ArrayIndexOutOfBoundsException`, thrown **lazily** at the first `getSchemaTypes()` call | `JedisDataException("Unrecognized response type")`, thrown **eagerly** while the reply is parsed | Catch `JedisDataException` around the query rather than around the accessor |
| Non-finite doubles (`RETURN 1.0/0.0`) and `vecf32` floats | `NumberFormatException: For input string: "inf"` / `GraphException: Invalid float value in vector data` | `Double.POSITIVE_INFINITY` / `NEGATIVE_INFINITY` / `NaN` | None — the value now parses instead of throwing. Only affects code that *relied* on the throw |

One more change is **binary**-incompatible but invisible to the `api-diff` gate,
because `com.falkordb.impl` is excluded from it as an internal package:
`HeaderImpl` is now `final` (required by SpotBugs `CT_CONSTRUCTOR_THROW`, since
the constructor can now throw). `extends HeaderImpl` compiled against 0.10.1 and
no longer does. `ResultSetImpl` was already `final` in 0.10.1 and `RecordImpl`
stays non-final, so this is the only one. The package is documented-internal and
nothing in-tree subclasses it, so the practical risk is negligible — but it is
recorded here rather than left to be discovered.

The unmodifiable-list change was an unnoticed consequence of parsing the header eagerly rather than
a deliberate API decision, surfaced in review. It is worth keeping — 0.10.1
handed back the internal `ArrayList`, so a caller could corrupt the schema, and
because records share that list, every record in the result set — but it had to
be declared rather than shipped silently in a patch. The contract is now
documented on `Header` and `Record`, which previously said nothing about
mutability, and locked in by tests.

## Validation

| Gate | Result |
| --- | --- |
| `verify` | pass — 231 unit, 121 IT, exit 0 (re-run after the rebase onto Jedis 8) |
| `fmt-check` | pass |
| `javadoc` | pass, with `failOnWarnings` now active from #386 |
| `api-diff` | pass — `No changes.` vs 0.10.1 |
| `examples` | pass |
| `lint` (SpotBugs + Error Prone) | pass on CI — **not runnable locally** (Error Prone needs JDK 21, unavailable here; fails identically on unmodified branch code) |

## Since the last review round

Rebased onto `master` (picks up Jedis 8.0.0, Maven 3.9.16, CodeQL 4.37.7) and re-validated
locally against a live FalkorDB: `verify` 230 unit + 121 IT green, `fmt-check` and `javadoc`
green. Four review comments addressed — the header concurrency test renamed to describe the eager
build it now guards, that test made to await worker termination, and the placeholder comment in
`deserializeVector` replaced, plus `Record.getValue`'s unchecked `<T>` contract documented and
pinned by a test (signature unchanged; the API fix is deferred to #400). No behaviour change from
any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for deserializing positive/negative infinity and NaN values.
  - Added stable module metadata to published JARs for improved Java module compatibility.
  - Added clearer nullable-value handling for record fields and collections.

- **Bug Fixes**
  - String retrieval now safely returns `null` for stored null values.
  - Improved error messages for unknown columns and invalid column types.
  - Schema access is now immutable, consistent, and thread-safe.
  - Invalid scalar type ordinals are now rejected reliably.

- **Tests**
  - Expanded coverage for special numeric values, null handling, schema parsing, immutability, concurrency, and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




