### PR TITLE
build: bump api.diff.baseline to 0.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 		     breaks by default; a reviewed, intentional break is approved by overriding it to false (the
 		     CI `api-diff` job sets -Dapi.diff.fail=false when the PR carries the `breaking-change`
 		     label). -->
-		<api.diff.baseline>0.10.1</api.diff.baseline>
+		<api.diff.baseline>0.11.0</api.diff.baseline>
 		<api.diff.fail>true</api.diff.fail>
 	</properties>
 


### PR DESCRIPTION
## Summary

0.11.0 is published to Maven Central, so the API-diff gate should compare against it.
This is the documented post-release step — the same follow-up #388 did for 0.10.1 — and
the `pom.xml` comment on the property calls for it explicitly:

> `api.diff.baseline` is the last PUBLISHED release the public API is compared against —
> it must be bumped to the new version as part of releasing

Left at `0.10.1`, the gate would keep re-reporting the 0.11.0 delta on every future PR
instead of diffing against what users can actually resolve, so a genuinely new break
would be harder to spot among the noise.

## Changes

- `api.diff.baseline`: `0.10.1` → `0.11.0`

## Testing

Ran the `api-diff` gate locally against the new baseline. japicmp downloaded
`jfalkordb-0.11.0.jar` from Central and compared it to a build of `master`, which is the
code 0.11.0 was cut from:

```
[INFO] Downloading from central: https://repo1.maven.org/maven2/com/falkordb/jfalkordb/0.11.0/jfalkordb-0.11.0.jar
Comparing source compatibility of target/jfalkordb-0.11.0.jar against ~/.m2/.../jfalkordb-0.11.0.jar
No changes.
Semantic versioning suggestion: 0.0.1
```

That is the expected result and confirms the new baseline resolves and the gate is live
against it.

Also verified independently of this PR that the release itself is sound: all four
artifacts (pom, jar, sources, javadoc) return HTTP 200 from `repo1.maven.org`,
`maven-metadata.xml` reports `<latest>` and `<release>` as `0.11.0`, and resolving
`com.falkordb:jfalkordb:0.11.0` into a clean local repository and running it against a
live FalkorDB reproduces every behaviour the release notes claim — `Infinity` / `-Infinity`
/ `NaN` for non-finite doubles, `null` from `getString` on a NULL column,
`IllegalArgumentException` for an unknown column, and an unmodifiable schema list.

## Memory / Performance Impact

N/A — build-configuration only; nothing shipped changes.

## Related Issues

Follows #389 (release 0.11.0). Same post-release step as #388 (0.10.1).
The property comment notes this is intended to be automated later; #401 tracks the
related problem of the README versions drifting for the same "nothing owns it" reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the API compatibility comparison baseline to the latest published release.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->