### PR TITLE
fix(cache): warm the graph cache with a read-only query so replica reads work

### DIFF
--- a/src/main/java/com/falkordb/impl/graph_cache/GraphCacheList.java
+++ b/src/main/java/com/falkordb/impl/graph_cache/GraphCacheList.java
@@ -3,6 +3,7 @@ package com.falkordb.impl.graph_cache;
 import com.falkordb.Graph;
 import com.falkordb.Record;
 import com.falkordb.ResultSet;
+import com.falkordb.impl.Utils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -17,7 +18,7 @@ class GraphCacheList {
     private final List<String> data = new CopyOnWriteArrayList<>();
     // Serializes cache refresh; don't synchronize on `data` itself (it's a concurrent collection).
     // This is a ReentrantLock rather than a `synchronized` block on purpose: refreshing the cache
-    // issues a blocking query (getProcedureInfo -> graph.callProcedure), and on JDK 21-23 a
+    // issues a blocking query (getProcedureInfo -> graph.readOnlyQuery), and on JDK 21-23 a
     // `synchronized` monitor held across a blocking call PINS the carrier thread, so many concurrent
     // queries on virtual threads would not scale. A ReentrantLock held across the same blocking call
     // does not pin. (It is still reentrant, matching `synchronized`, so a refresh that recursively
@@ -53,10 +54,21 @@ class GraphCacheList {
     }
 
     /**
-     * Auxiliary method to parse a procedure result set and refresh the cache
+     * Auxiliary method to parse a procedure result set and refresh the cache.
+     *
+     * The procedure is issued as a read-only query rather than through
+     * {@code callProcedure}, which routes to GRAPH.QUERY. GRAPH.QUERY is a write
+     * command, so a replica rejects it with READONLY. Because cache warming is
+     * triggered while decoding a compact response that contains a node, an edge
+     * or a path, sending it as a write turned every entity returning
+     * {@code readOnlyQuery} into a failure against a replica.
+     *
+     * db.labels, db.relationshipTypes and db.propertyKeys are all read-only, so
+     * GRAPH.RO_QUERY serves them on a primary and on a replica alike.
      */
     private void getProcedureInfo(Graph graph) {
-        ResultSet resultSet = graph.callProcedure(procedure);
+        String preparedProcedure = Utils.prepareProcedure(procedure, Utils.DUMMY_LIST, Utils.DUMMY_MAP);
+        ResultSet resultSet = graph.readOnlyQuery(preparedProcedure);
         List<String> newData = new ArrayList<>();
         int i = 0;
         for (Record record : resultSet) {

--- a/src/test/java/com/falkordb/ReplicaReadIT.java
+++ b/src/test/java/com/falkordb/ReplicaReadIT.java
@@ -1,0 +1,175 @@
+package com.falkordb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.falkordb.graph_entities.Node;
+import com.falkordb.graph_entities.Path;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Reads from a real replica.
+ *
+ * <p>The rest of the suite runs against a single server, where every command is legal, so it cannot
+ * observe how the client behaves against a read-only replica. That gap hid a defect in which any
+ * {@link Graph#readOnlyQuery(String)} returning a node, a relationship or a path failed with {@code
+ * READONLY You can't write against a read only replica}: responses are decoded in compact mode, so
+ * label and property-key ids had to be resolved through {@code GraphCache}, which warmed itself with
+ * {@code GRAPH.QUERY}, a write.
+ *
+ * <p>Returning a path here is therefore the point of the test. A scalar projection never populates
+ * the cache and passes even against a buggy client.
+ */
+public class ReplicaReadIT {
+
+    private static final String PRIMARY_NETWORK_ALIAS = "primary";
+    private static final Duration REPLICATION_TIMEOUT = Duration.ofSeconds(30);
+    private static final String GRAPH_NAME = "replica-read-it";
+
+    private static Network network;
+    private static GenericContainer<?> primaryContainer;
+    private static GenericContainer<?> replicaContainer;
+    private static Driver primaryDriver;
+    private static Driver replicaDriver;
+
+    @BeforeAll
+    static void startPrimaryAndReplica() throws Exception {
+        DockerImageName image = FalkorDbImage.resolve(FalkorDbImage.pickOverride(
+                System.getProperty("FALKORDB_IMAGE"), () -> System.getenv("FALKORDB_IMAGE")));
+
+        network = Network.newNetwork();
+        primaryContainer = new GenericContainer<>(image)
+                .withExposedPorts(6379)
+                .withNetwork(network)
+                .withNetworkAliases(PRIMARY_NETWORK_ALIAS)
+                .waitingFor(Wait.forListeningPort());
+        primaryContainer.start();
+
+        replicaContainer = new GenericContainer<>(image)
+                .withExposedPorts(6379)
+                .withNetwork(network)
+                .waitingFor(Wait.forListeningPort());
+        replicaContainer.start();
+
+        // The alias is resolved inside the Docker network by the replica itself.
+        redisCli(replicaContainer, "REPLICAOF", PRIMARY_NETWORK_ALIAS, "6379");
+        awaitReplicationLink();
+
+        primaryDriver = FalkorDB.driver(primaryContainer.getHost(), primaryContainer.getMappedPort(6379));
+        replicaDriver = FalkorDB.driver(replicaContainer.getHost(), replicaContainer.getMappedPort(6379));
+
+        primaryDriver
+                .graph(GRAPH_NAME)
+                .query("CREATE (:Location {locationId:'L1'})-[:SCHEDULED]->(:Location {locationId:'L2'})");
+        awaitGraphOnReplica();
+    }
+
+    @AfterAll
+    static void stopPrimaryAndReplica() {
+        closeQuietly(primaryDriver);
+        closeQuietly(replicaDriver);
+        if (replicaContainer != null) {
+            replicaContainer.stop();
+        }
+        if (primaryContainer != null) {
+            primaryContainer.stop();
+        }
+        if (network != null) {
+            network.close();
+        }
+    }
+
+    @Test
+    public void readOnlyQueryReturningAPathSucceedsAgainstAReplica() {
+        // A cold cache is what exercises the label/property-key resolution path.
+        try (Graph replica = replicaDriver.graph(GRAPH_NAME)) {
+            ResultSet resultSet = replica.readOnlyQuery(
+                    "MATCH p = (:Location {locationId:$from})-[:SCHEDULED]->(:Location) RETURN p",
+                    Collections.singletonMap("from", "L1"));
+
+            assertEquals(1, resultSet.size());
+            Object value = resultSet.iterator().next().getValue(0);
+            assertTrue(value instanceof Path, "expected a Path, got " + value);
+
+            Path path = (Path) value;
+            assertEquals(1, path.length());
+            // Resolving these names is exactly what used to require a write command.
+            Node origin = path.getNodes().get(0);
+            assertEquals("Location", origin.getLabel(0));
+            assertNotNull(origin.getProperty("locationId"));
+            assertEquals("L1", origin.getProperty("locationId").getValue());
+            assertEquals("SCHEDULED", path.getEdges().get(0).getRelationshipType());
+        }
+    }
+
+    @Test
+    public void readOnlyQueryReturningScalarsAlsoSucceedsAgainstAReplica() {
+        try (Graph replica = replicaDriver.graph(GRAPH_NAME)) {
+            Map<String, Object> parameters = Collections.singletonMap("from", "L1");
+            ResultSet resultSet = replica.readOnlyQuery(
+                    "MATCH (a:Location {locationId:$from})-[:SCHEDULED]->(b:Location) RETURN b.locationId", parameters);
+
+            assertEquals(1, resultSet.size());
+            Object value = resultSet.iterator().next().getValue(0);
+            assertEquals("L2", value);
+        }
+    }
+
+    private static void awaitReplicationLink() throws Exception {
+        long deadline = System.nanoTime() + REPLICATION_TIMEOUT.toNanos();
+        String lastSeen = "";
+        while (System.nanoTime() < deadline) {
+            lastSeen = redisCli(replicaContainer, "INFO", "replication");
+            if (lastSeen.contains("role:slave") && lastSeen.contains("master_link_status:up")) {
+                return;
+            }
+            Thread.sleep(250);
+        }
+        throw new IllegalStateException("replica never linked to the primary. Last INFO replication:\n" + lastSeen);
+    }
+
+    private static void awaitGraphOnReplica() throws Exception {
+        long deadline = System.nanoTime() + REPLICATION_TIMEOUT.toNanos();
+        while (System.nanoTime() < deadline) {
+            String keys = redisCli(replicaContainer, "EXISTS", GRAPH_NAME);
+            if ("1".equals(keys.trim())) {
+                return;
+            }
+            Thread.sleep(250);
+        }
+        throw new IllegalStateException("the graph never replicated to the replica");
+    }
+
+    private static String redisCli(GenericContainer<?> container, String... arguments) throws Exception {
+        String[] command = new String[arguments.length + 1];
+        command[0] = "redis-cli";
+        System.arraycopy(arguments, 0, command, 1, arguments.length);
+        Container.ExecResult result = container.execInContainer(command);
+        if (result.getExitCode() != 0) {
+            throw new IllegalStateException("redis-cli failed: " + result.getStderr());
+        }
+        return result.getStdout();
+    }
+
+    private static void closeQuietly(Driver driver) {
+        if (driver == null) {
+            return;
+        }
+        try {
+            driver.close();
+        } catch (Exception ignored) {
+            // best-effort cleanup between test classes
+        }
+    }
+}

--- a/src/test/java/com/falkordb/ReplicaReadIT.java
+++ b/src/test/java/com/falkordb/ReplicaReadIT.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.Container;
@@ -45,6 +46,14 @@ public class ReplicaReadIT {
 
     @BeforeAll
     static void startPrimaryAndReplica() throws Exception {
+        // This topology cannot be served by an external FALKORDB_HOST/FALKORDB_PORT server: it needs two
+        // servers wired by REPLICAOF on a shared network, which only the Testcontainers path can build.
+        // Honour the override contract and skip rather than starting containers behind the user's back,
+        // so `just verify-local` keeps working where Testcontainers cannot reach Docker.
+        Assumptions.assumeFalse(
+                TestServer.isExternal(),
+                "the primary/replica topology requires Testcontainers, not an external server");
+
         DockerImageName image = FalkorDbImage.resolve(FalkorDbImage.pickOverride(
                 System.getProperty("FALKORDB_IMAGE"), () -> System.getenv("FALKORDB_IMAGE")));
 
@@ -131,7 +140,11 @@ public class ReplicaReadIT {
         String lastSeen = "";
         while (System.nanoTime() < deadline) {
             lastSeen = redisCli(replicaContainer, "INFO", "replication");
-            if (lastSeen.contains("role:slave") && lastSeen.contains("master_link_status:up")) {
+            // Redis reports the legacy `role:slave`; accept `role:replica` too so the check survives a
+            // Redis-family image variant that adopts the newer wording (FALKORDB_IMAGE matrixes over
+            // versions). `master_link_status:up` is the substantive gate either way.
+            boolean linkedAsReplica = lastSeen.contains("role:slave") || lastSeen.contains("role:replica");
+            if (linkedAsReplica && lastSeen.contains("master_link_status:up")) {
                 return;
             }
             Thread.sleep(250);

--- a/src/test/java/com/falkordb/impl/graph_cache/GraphCacheListTest.java
+++ b/src/test/java/com/falkordb/impl/graph_cache/GraphCacheListTest.java
@@ -77,6 +77,20 @@ class GraphCacheListTest {
     }
 
     @Test
+    void warmsTheCacheWithAReadOnlyQuerySoReplicasAcceptIt() {
+        CountingGraph graph = new CountingGraph("a", "b", "c");
+        GraphCacheList cache = new GraphCacheList("db.labels");
+
+        assertEquals("a", cache.getCachedData(0, graph));
+
+        assertEquals(1, graph.calls.get(), "the cache must warm through readOnlyQuery");
+        assertEquals(
+                Collections.singletonList("CALL db.labels()"),
+                graph.issuedQueries,
+                "the warming call must be the prepared procedure, sent as a read-only query");
+    }
+
+    @Test
     void clearForcesARefreshOnNextGet() {
         CountingGraph graph = new CountingGraph("a", "b", "c");
         GraphCacheList cache = new GraphCacheList("db.labels");
@@ -89,9 +103,15 @@ class GraphCacheListTest {
         assertEquals(2, graph.calls.get(), "after clear the cache must re-fetch");
     }
 
-    /** A {@link Graph} that only implements {@code callProcedure(String)}, counting invocations. */
+    /**
+     * A {@link Graph} that only implements {@code readOnlyQuery(String)}, counting invocations.
+     *
+     * {@code callProcedure} deliberately fails. Cache warming must never route through it, because
+     * it issues GRAPH.QUERY, which a replica rejects with READONLY.
+     */
     private static final class CountingGraph implements Graph {
         final AtomicInteger calls = new AtomicInteger();
+        final List<String> issuedQueries = Collections.synchronizedList(new ArrayList<>());
         private final List<String> values;
 
         CountingGraph(String... values) {
@@ -100,8 +120,9 @@ class GraphCacheListTest {
         }
 
         @Override
-        public ResultSet callProcedure(String procedure) {
+        public ResultSet readOnlyQuery(String query) {
             calls.incrementAndGet();
+            issuedQueries.add(query);
             List<Record> records = new ArrayList<>();
             for (String v : values) {
                 records.add(new RecordImpl(Collections.singletonList("col"), Collections.singletonList(v)));
@@ -109,14 +130,16 @@ class GraphCacheListTest {
             return new ListResultSet(records);
         }
 
+        @Override
+        public ResultSet callProcedure(String procedure) {
+            throw new AssertionError(
+                    "cache warming must not use callProcedure: it issues GRAPH.QUERY, "
+                            + "which a replica rejects with READONLY");
+        }
+
         // --- unused Graph operations ---
         @Override
         public ResultSet query(String query) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public ResultSet readOnlyQuery(String query) {
             throw new UnsupportedOperationException();
         }
 

--- a/src/test/java/com/falkordb/impl/graph_cache/GraphCacheListTest.java
+++ b/src/test/java/com/falkordb/impl/graph_cache/GraphCacheListTest.java
@@ -132,9 +132,8 @@ class GraphCacheListTest {
 
         @Override
         public ResultSet callProcedure(String procedure) {
-            throw new AssertionError(
-                    "cache warming must not use callProcedure: it issues GRAPH.QUERY, "
-                            + "which a replica rejects with READONLY");
+            throw new AssertionError("cache warming must not use callProcedure: it issues GRAPH.QUERY, "
+                    + "which a replica rejects with READONLY");
         }
 
         // --- unused Graph operations ---


### PR DESCRIPTION
## Summary

`readOnlyQuery` cannot read from a replica whenever the result contains a node, a relationship or a path. It fails with:

```
READONLY You can't write against a read only replica.
```

The request itself is correct, `GRAPH.RO_QUERY` goes out as expected. The failure happens while **decoding** the reply.

Responses are decoded in compact mode, so labels, relationship types and property keys arrive as integer ids rather than strings. `ResultSetImpl` resolves them through `GraphCache`, which warmed itself via `callProcedure`. `AbstractGraph.callProcedure` routes through `query`, which issues `GRAPH.QUERY`, a write command. A replica rejects it.

So the client issued a write in order to decode a read.

`db.labels`, `db.relationshipTypes` and `db.propertyKeys` are all read-only, so the prepared procedure can go through `readOnlyQuery` instead. Against a primary nothing changes, `GRAPH.RO_QUERY` serves these procedures identically.

### Why this went unnoticed

- Queries returning only scalars never touch the cache, so they always worked against a replica.
- Once the cache is warm the same query succeeds, so it looked intermittent rather than deterministic.

## Changes

- `GraphCacheList.getProcedureInfo` now sends the prepared procedure through `readOnlyQuery` instead of `callProcedure`. No public API change, no new interface methods.
- `GraphCacheListTest`: the `CountingGraph` mock now counts `readOnlyQuery` and makes `callProcedure` fail, so a regression is caught at unit level without needing a replica in CI. Added `warmsTheCacheWithAReadOnlyQuerySoReplicasAcceptIt`, which asserts the warming call is exactly `CALL db.labels()`.

## Testing

**Unit:** full suite green, 232 tests.

Regression check, reverting only the one line in `getProcedureInfo`:

```
Tests run: 4, Failures: 4  <- without the fix
Tests run: 4, Failures: 0  <- with the fix
```

**Against a live primary and replica** (FalkorDB Cloud, Sentinel managed, one primary and one replica). Identical source file, the published client versus this branch built locally, reading a path from the replica with a cold cache:

| Client | Result |
|---|---|
| `0.3.0` published | `FAIL: GraphException: ... READONLY You can't write against a read only replica.` |
| this branch | `PASS: stock readOnlyQuery returned 3 paths from the replica` |

Query used, returning full paths so the cache is exercised:

```cypher
MATCH p = (start:Location)-[:SCHEUDLED*1..3]->(end:Location {locationId: $locationId})
WHERE size(nodes(p)) = size(list.dedup(nodes(p)))
RETURN p
```

Labels and relationship types come back correctly resolved on the patched run, confirming the cache warmed over `GRAPH.RO_QUERY`:

```
Path{nodes=[Node{labels=[Location], id=6, propertyMap={locationId=...L4}}, ...],
     edges=[Edge{relationshipType='SCHEUDLED', ...}]}
```

Server side command counters over one run, after `CONFIG RESETSTAT`, before the fix:

| | `graph.QUERY` | `graph.RO_QUERY` |
|---|---|---|
| primary | 19 calls | 0 |
| replica | 0 calls, **7 rejected** | 15 calls |

The 7 rejected calls on the replica are the cache warming attempts.

## Memory / Performance Impact

N/A. Same number of round trips, same payloads, only the command name changes.

## Related Issues

None open that I could find. Raised from a customer scaling reads across replicas, where the Java client is currently unusable for that purpose without a workaround.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cache warming now uses read-only queries, allowing metadata retrieval to work correctly on replicas.
  * Improved compatibility when retrieving labels, relationship types, and property keys across primary and replica databases.
  * Read-only queries on replicas now correctly support path results and scalar values.

* **Tests**
  * Added coverage confirming cache warming uses the read-only query path and avoids write-oriented procedure calls.
  * Added integration coverage for primary-replica query behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->