### PR TITLE
test: cover list-of-maps bulk create with map query parameters

### DIFF
--- a/src/test/java/com/falkordb/ParameterRoundTripIT.java
+++ b/src/test/java/com/falkordb/ParameterRoundTripIT.java
@@ -126,6 +126,7 @@ public class ParameterRoundTripIT {
         Iterator<Record> it = rs.iterator();
 
         Node first = it.next().getValue("n");
+        assertEquals(3, first.getNumberOfProperties(), "alice should have exactly her own three properties");
         assertEquals("alice", first.getProperty("name").getValue());
         assertEquals(30L, ((Number) first.getProperty("age").getValue()).longValue());
         assertEquals("she said \"hi\"", first.getProperty("favourite quote").getValue());
@@ -133,6 +134,10 @@ public class ParameterRoundTripIT {
         Node second = it.next().getValue("n");
         assertEquals("bob", second.getProperty("name").getValue());
         assertEquals(40L, ((Number) second.getProperty("age").getValue()).longValue());
+        // Each element must be encoded independently: a key present only on alice must not leak onto
+        // bob. Without this, an encoder that merged/reused keys across list elements would still pass.
+        assertNull(second.getProperty("favourite quote"), "bob must not inherit alice's key");
+        assertEquals(2, second.getNumberOfProperties(), "bob should have exactly his own two properties");
 
         assertFalse(it.hasNext(), "expected exactly two nodes");
     }

--- a/src/test/java/com/falkordb/ParameterRoundTripIT.java
+++ b/src/test/java/com/falkordb/ParameterRoundTripIT.java
@@ -100,6 +100,43 @@ public class ParameterRoundTripIT {
         assertEquals("value with \" quote", map.get("needs quoting!"));
     }
 
+    /**
+     * Bulk-create driven by a list-of-maps parameter — the pattern from issue #68. Unlike
+     * {@link #mapRoundTrips()} the map is not merely echoed back: it is consumed by {@code SET n = map}
+     * as the property source, so the encoded map literal has to be usable as a Cypher map expression
+     * and not just a value the server can parse.
+     */
+    @Test
+    public void listOfMapsDrivesBulkCreate() {
+        Map<String, Object> alice = new LinkedHashMap<>();
+        alice.put("name", "alice");
+        alice.put("age", 30);
+        // A key needing backtick-quoting and a value needing escaping, to keep the encoder honest.
+        alice.put("favourite quote", "she said \"hi\"");
+        Map<String, Object> bob = new LinkedHashMap<>();
+        bob.put("name", "bob");
+        bob.put("age", 40);
+
+        ResultSet created = client.query(
+                "UNWIND $props AS map CREATE (n:BulkPerson) SET n = map RETURN count(n) AS c",
+                Collections.singletonMap("props", Arrays.asList(alice, bob)));
+        assertEquals(2L, ((Number) created.iterator().next().getValue("c")).longValue());
+
+        ResultSet rs = client.query("MATCH (n:BulkPerson) RETURN n ORDER BY n.name");
+        Iterator<Record> it = rs.iterator();
+
+        Node first = it.next().getValue("n");
+        assertEquals("alice", first.getProperty("name").getValue());
+        assertEquals(30L, ((Number) first.getProperty("age").getValue()).longValue());
+        assertEquals("she said \"hi\"", first.getProperty("favourite quote").getValue());
+
+        Node second = it.next().getValue("n");
+        assertEquals("bob", second.getProperty("name").getValue());
+        assertEquals(40L, ((Number) second.getProperty("age").getValue()).longValue());
+
+        assertFalse(it.hasNext(), "expected exactly two nodes");
+    }
+
     @ParameterizedTest(name = "integer {0} round-trips as long")
     @MethodSource("integerBoundaries")
     public void integerBoundariesRoundTrip(Object input, long expected) {


### PR DESCRIPTION
## Summary

Investigating #68 showed there was **nothing to implement** — map query parameters have been fully supported since the parameter-path hardening in e098807 (#317, released in **v0.10.0**), which introduced `Utils.appendMap`.

I verified the exact scenario from the issue against a real FalkorDB (Testcontainers) before concluding this:

```java
api.query("UNWIND $props AS map CREATE (n:P) SET n = map RETURN count(n) AS c",
          Collections.singletonMap("props", Arrays.asList(alice, bob)));
// -> created=2, nodes: alice, bob
```

It works. What was genuinely missing was **test coverage for that pattern**, so this PR adds it rather than adding redundant production code.

The existing `mapRoundTrips` test only echoes a map back via `RETURN $p AS v`. The issue's pattern is meaningfully different: the map is *consumed* by `SET n = map` as a property source, so the encoded literal must be valid as a Cypher **map expression**, not merely a parseable value. A regression in that direction would slip past the round-trip test today.

## Changes

- Add `ParameterRoundTripIT.listOfMapsDrivesBulkCreate` covering `UNWIND $props AS map CREATE (n) SET n = map`, asserting the created node count and every property value, and that no extra nodes appear.
- Include a key requiring backtick-quoting (`favourite quote`) and a value requiring escaping (`she said "hi"`) so the test also pins the encoder's quoting rules on this path.

No production code changed.

## Testing

- `./mvnw verify -Dit.test=ParameterRoundTripIT` — 32/32 green
- `just verify` (`./mvnw -B -Dgpg.skip=true verify`) — **122 tests, 0 failures**, Animal Sniffer Java-8 check clean
- `just fmt-check` (`./mvnw -B -Pquality spotless:check`) — BUILD SUCCESS

## Memory / Performance Impact

N/A — test-only change.

## Related Issues

Closes #68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added integration coverage for bulk node creation using lists of map parameters.
  - Verifies preservation of standard, numeric, quoted-key, and escaped-string properties.
  - Confirms that the operation creates exactly two nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->