### PR TITLE
docs: document that path node order is independent of edge direction

### DIFF
--- a/src/main/java/com/falkordb/graph_entities/Path.java
+++ b/src/main/java/com/falkordb/graph_entities/Path.java
@@ -5,6 +5,22 @@ import java.util.Objects;
 
 /**
  * This class represents a path in the graph.
+ *
+ * <p><strong>Node order and edge direction are independent.</strong> {@link #getNodes()} returns the
+ * nodes in <em>traversal</em> order — the order the pattern walked them — while each {@link Edge} in
+ * {@link #getEdges()} keeps the direction it is <em>stored</em> with in the graph, via
+ * {@link Edge#getSource()} and {@link Edge#getDestination()}. For a reverse or undirected match the
+ * two deliberately disagree.
+ *
+ * <p>Given {@code CREATE (a:A)-[:R]->(b:B)}, the undirected query
+ * {@code MATCH p = (b:B)-[:R]-(a:A) RETURN p} yields a path whose nodes are {@code [b, a]} while its
+ * single edge still reports {@code source = a} and {@code destination = b}. Preserving both is
+ * lossless: edges are never reoriented to follow the traversal.
+ *
+ * <p>Code bridging this class to an API that requires each relationship to be oriented along the
+ * traversal (for example the Neo4j driver's {@code Path}/{@code InternalPath}, which rejects a
+ * mismatch) must detect the reversed step — the edge whose {@code source} is not the node it is
+ * being attached to — and flip its endpoints when converting.
  */
 public final class Path {
 
@@ -22,7 +38,11 @@ public final class Path {
     }
 
     /**
-     * Returns the nodes of the path.
+     * Returns the nodes of the path, in traversal order.
+     *
+     * <p>This order reflects how the pattern walked the graph and is independent of the direction the
+     * path's edges are stored with; see the {@linkplain Path class documentation}.
+     *
      * @return List of nodes.
      */
     public List<Node> getNodes() {
@@ -30,7 +50,12 @@ public final class Path {
     }
 
     /**
-     * Returns the edges of the path.
+     * Returns the edges of the path, each retaining its stored direction.
+     *
+     * <p>An edge's {@link Edge#getSource()} and {@link Edge#getDestination()} are as stored in the
+     * graph, so for a reverse or undirected match they need not follow the order of
+     * {@link #getNodes()}; see the {@linkplain Path class documentation}.
+     *
      * @return List of edges.
      */
     public List<Edge> getEdges() {

--- a/src/test/java/com/falkordb/GraphAPIIT.java
+++ b/src/test/java/com/falkordb/GraphAPIIT.java
@@ -854,6 +854,35 @@ public class GraphAPIIT {
         }
     }
 
+    /**
+     * A reverse/undirected match returns nodes in traversal order while the edge keeps its stored
+     * direction, so the two intentionally disagree (issue #393). Pins that contract, which adapters
+     * onto stricter path APIs (such as the Neo4j driver's) depend on.
+     */
+    @Test
+    public void testUndirectedPathKeepsStoredEdgeDirection() {
+        client.query("CREATE (:PathA {id: 1})-[:PathR]->(:PathB {id: 2})");
+
+        ResultSet resultSet = client.query("MATCH p = (b:PathB)-[:PathR]-(a:PathA) RETURN p");
+        Assertions.assertEquals(1, resultSet.size());
+
+        Path path = resultSet.iterator().next().getValue("p");
+
+        // Nodes come back in traversal order: the match started at PathB.
+        Assertions.assertEquals(2, path.nodeCount());
+        Assertions.assertEquals(2L, path.firstNode().getProperty("id").getValue());
+        Assertions.assertEquals(1L, path.lastNode().getProperty("id").getValue());
+
+        // The edge is NOT reoriented to follow that traversal: it still points PathA -> PathB, so its
+        // source is the path's LAST node. An adapter must flip the endpoints rather than assume they
+        // line up with the node order.
+        Assertions.assertEquals(1, path.length());
+        Edge edge = path.getEdge(0);
+        Assertions.assertEquals("PathR", edge.getRelationshipType());
+        Assertions.assertEquals(path.lastNode().getId(), edge.getSource());
+        Assertions.assertEquals(path.firstNode().getId(), edge.getDestination());
+    }
+
     @Test
     public void testNullGraphEntities() {
         // Create two nodes connected by a single outgoing edge.


### PR DESCRIPTION
## Summary

Follow-up to #393. I reproduced the report against a real FalkorDB and the client is **behaving correctly** — but the contract that makes it correct was undocumented, which is what made it look like a bug.

FalkorDB returns path **nodes in traversal order** while each **edge keeps its stored direction**. JFalkorDB preserves both and never reorients edges. For a reverse or undirected match the two legitimately disagree:

```cypher
CREATE (a:PathA)-[:PathR]->(b:PathB)
MATCH p = (b:PathB)-[:PathR]-(a:PathA) RETURN p
```
```
nodes = [PathB, PathA]      // traversal order
edge  = source=PathA, destination=PathB   // stored direction
```

The `IllegalArgumentException: Node argument 0 is not an endpoint of relationship argument 1` in the report comes from `org.neo4j.driver.internal.InternalPath`, which requires each relationship to be oriented along the traversal. That contract is stricter than FalkorDB's, so the **adapter** must flip the endpoints on a reversed step. There is no Neo4j dependency here, so no production fix belongs in this repo.

This PR closes the documentation gap instead, and pins the behaviour so it cannot regress silently.

## Changes

- Document the node-order / edge-direction split on `Path`, with a worked reverse-match example and explicit guidance for adapters onto stricter path APIs.
- Expand `getNodes()` / `getEdges()` Javadoc to state traversal order and stored direction respectively, cross-linking the class docs.
- Add `GraphAPIIT.testUndirectedPathKeepsStoredEdgeDirection`, asserting the traversal-ordered nodes **and** that the edge's `source` is the path's *last* node — i.e. exactly the mismatch adapters must handle. The existing `testPath` only covers directed traversal, so this case was untested.

No production behaviour changed; this is docs plus test coverage.

## Testing

- `./mvnw verify -Dit.test='GraphAPIIT#testUndirectedPathKeepsStoredEdgeDirection+testPath'` — 2/2 green
- `just verify` — **123 tests, 0 failures**, Animal Sniffer Java-8 check clean
- `just javadoc` (strict `doclint=all` + `failOnWarnings`) — BUILD SUCCESS
- `just api-diff` (japicmp vs last release) — BUILD SUCCESS, no API break
- `just fmt-check` — clean

## Memory / Performance Impact

N/A — documentation and test only.

## Related Issues

References #393 (the runtime fix belongs in the reporter's Neo4j adapter, not here)