### PR TITLE
build: bump api.diff.baseline to 0.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 		     breaks by default; a reviewed, intentional break is approved by overriding it to false (the
 		     CI `api-diff` job sets -Dapi.diff.fail=false when the PR carries the `breaking-change`
 		     label). -->
-		<api.diff.baseline>0.11.0</api.diff.baseline>
+		<api.diff.baseline>0.11.1</api.diff.baseline>
 		<api.diff.fail>true</api.diff.fail>
 	</properties>
 


### PR DESCRIPTION
## Summary

0.11.1 is published to Maven Central, so the API-diff gate should compare against it.
This is the documented post-release step — the same follow-up #388 and #403 did for
0.10.1 and 0.11.0 — and the `pom.xml` comment on the property calls for it explicitly:

> `api.diff.baseline` is the last PUBLISHED release the public API is compared against —
> it must be bumped to the new version as part of releasing

Left at `0.11.0`, the gate would keep re-reporting the 0.11.1 delta on every future PR
instead of diffing against what users can actually resolve.

## Changes

- `api.diff.baseline`: `0.11.0` → `0.11.1`

## Testing

- Verified `jfalkordb-0.11.1.jar` is published on Maven Central (HTTP 200).
- CI's `api-diff` job will run japicmp against the new baseline.

## Related Issues

N/A