### PR TITLE
build: let release-please own the version numbers so they stop drifting

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -47,3 +47,5 @@ dev
 env
 arg
 URI
+README's
+updaters

--- a/README.md
+++ b/README.md
@@ -17,12 +17,15 @@ FalkorDB Java client
 
 ## Official Releases
 
+<!-- The version below is NOT auto-updated: release-please would rewrite it to a -SNAPSHOT (see
+     release-please-config.json). ReadmeVersionTest keeps it honest against CHANGELOG.md instead. -->
+
 ```xml
   <dependencies>
     <dependency>
       <groupId>com.falkordb</groupId>
       <artifactId>jfalkordb</artifactId>
-      <version>0.11.0</version>
+      <version>0.11.1</version>
     </dependency>
   </dependencies>
 ```
@@ -45,7 +48,7 @@ and
     <dependency>
       <groupId>com.falkordb</groupId>
       <artifactId>jfalkordb</artifactId>
-      <version>0.11.1-SNAPSHOT</version>
+      <version>0.11.2-SNAPSHOT</version> <!-- x-release-please-version -->
     </dependency>
   </dependencies>
 ```

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -23,7 +23,10 @@
         <maven.compiler.release>21</maven.compiler.release>
         <maven.deploy.skip>true</maven.deploy.skip>
         <gpg.skip>true</gpg.skip>
-        <jfalkordb.version>0.10.0-SNAPSHOT</jfalkordb.version>
+        <!-- Overridden by `just bench` with the root project's actual version; the default keeps
+             this module runnable stand-alone against the current -SNAPSHOT.
+             Kept current by release-please via its x-release-please-version marker. -->
+        <jfalkordb.version>0.11.2-SNAPSHOT</jfalkordb.version> <!-- x-release-please-version -->
         <uberjar.name>benchmarks</uberjar.name>
     </properties>
 

--- a/docs/release-please-setup.md
+++ b/docs/release-please-setup.md
@@ -67,6 +67,32 @@ the Maven Central publish.
 If the App token step fails, re-check that the App is **installed on the repo** and that both secrets
 are set (the private key must be the complete `.pem`).
 
+## Version numbers outside `pom.xml` (`extra-files`)
+
+`README.md` and the four sibling modules (`examples`, `smoke-test`, `pin-check`, `benchmarks`) also
+name a version, and nothing owned them until #401 — so they drifted quietly, the README's release
+snippet ending up two releases stale and every sibling module defaulting to `0.10.0-SNAPSHOT`. They
+are now listed as `extra-files` in `release-please-config.json` and carry an
+`x-release-please-version` marker on the line to rewrite.
+
+**Only snapshot-tracking numbers can be marked, and this is the trap to know about.** With
+`release-type: java`, every release PR is followed by a **snapshot PR**, and
+`buildSnapshotPullRequest` re-applies the *same* `extra-files` updaters with the `-SNAPSHOT`
+version. So a marked line ends each release cycle holding `X.Y.Z-SNAPSHOT`, never the release. That
+is exactly right for the README's **Snapshots** block and for the modules' `jfalkordb.version`
+default — all of which should track master's snapshot — and exactly wrong for the README's
+**Official Releases** block, the one users copy into their own `pom.xml`.
+
+So the release snippet is deliberately **not** marked; adding a marker there would leave it pointing
+at a version that was never published to Maven Central. `ReadmeVersionTest` guards it instead, by
+comparing it with the newest entry in `CHANGELOG.md` (and guards the marked lines by comparing them
+with `pom.xml`, so a broken marker fails loudly rather than silently resuming the drift).
+
+**Practical consequence:** `ReadmeVersionTest` fails on the Release PR, because release-please has
+written the new version into `CHANGELOG.md` while the release snippet still names the previous one.
+That is intended — it is the release-time check that makes the drift impossible to ship. Update that
+one `<version>` line in the Release PR before merging it.
+
 ## Branch protection
 
 Ensure the required status checks (`build`, `format`, `lint`, `smoke-jdk8`, `api-diff`, `lint-title`)

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -22,8 +22,9 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <gpg.skip>true</gpg.skip>
         <!-- Overridden by `just examples` with the root project's actual version; the default keeps
-             this module buildable stand-alone against the current -SNAPSHOT. -->
-        <jfalkordb.version>0.10.0-SNAPSHOT</jfalkordb.version>
+             this module buildable stand-alone against the current -SNAPSHOT.
+             Kept current by release-please via its x-release-please-version marker. -->
+        <jfalkordb.version>0.11.2-SNAPSHOT</jfalkordb.version> <!-- x-release-please-version -->
     </properties>
 
     <dependencies>

--- a/pin-check/pom.xml
+++ b/pin-check/pom.xml
@@ -27,8 +27,9 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <gpg.skip>true</gpg.skip>
         <!-- Overridden by `just pin-check` with the root project's actual version; the default keeps
-             the module runnable stand-alone against the current -SNAPSHOT. -->
-        <jfalkordb.version>0.10.0-SNAPSHOT</jfalkordb.version>
+             the module runnable stand-alone against the current -SNAPSHOT.
+             Kept current by release-please via its x-release-please-version marker. -->
+        <jfalkordb.version>0.11.2-SNAPSHOT</jfalkordb.version> <!-- x-release-please-version -->
     </properties>
 
     <dependencies>

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,12 @@
       "release-type": "java",
       "bump-minor-pre-major": true,
       "extra-files": [
-        { "type": "pom", "path": "pom.xml" }
+        { "type": "pom", "path": "pom.xml" },
+        { "type": "generic", "path": "README.md" },
+        { "type": "generic", "path": "examples/pom.xml" },
+        { "type": "generic", "path": "smoke-test/pom.xml" },
+        { "type": "generic", "path": "pin-check/pom.xml" },
+        { "type": "generic", "path": "benchmarks/pom.xml" }
       ]
     }
   }

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -25,8 +25,9 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <gpg.skip>true</gpg.skip>
         <!-- Overridden by `just verify-jdk8` with the root project's actual version; the default
-             keeps the smoke build runnable stand-alone against the current -SNAPSHOT. -->
-        <jfalkordb.version>0.10.0-SNAPSHOT</jfalkordb.version>
+             keeps the smoke build runnable stand-alone against the current -SNAPSHOT.
+             Kept current by release-please via its x-release-please-version marker. -->
+        <jfalkordb.version>0.11.2-SNAPSHOT</jfalkordb.version> <!-- x-release-please-version -->
     </properties>
 
     <dependencies>

--- a/src/test/java/com/falkordb/ReadmeVersionTest.java
+++ b/src/test/java/com/falkordb/ReadmeVersionTest.java
@@ -101,14 +101,15 @@ class ReadmeVersionTest {
     void siblingModulesTrackTheProjectVersion() throws IOException {
         String projectVersion = firstMatch(PROJECT_VERSION, read("pom.xml"), "project version in pom.xml");
         for (String module : new String[] {"examples", "smoke-test", "pin-check", "benchmarks"}) {
-            String pom = read(module + "/pom.xml");
+            String line = lineDeclaring(
+                    "jfalkordb.version", read(module + "/pom.xml"), "jfalkordb.version in " + module + "/pom.xml");
             String declared = firstMatch(
                     Pattern.compile("<jfalkordb\\.version>([^<]+)</jfalkordb\\.version>"),
-                    pom,
+                    line,
                     "jfalkordb.version in " + module + "/pom.xml");
             assertEquals(projectVersion, declared, module + "/pom.xml's jfalkordb.version default is stale (#401)");
             assertTrue(
-                    pom.contains("<jfalkordb.version>" + declared + "</jfalkordb.version> " + MARKER),
+                    line.contains(MARKER),
                     module + "/pom.xml lost its x-release-please-version marker, so its default will "
                             + "drift again - check release-please-config.json (#401)");
         }
@@ -145,26 +146,36 @@ class ReadmeVersionTest {
         }
 
         assertTrue(
-                versionedXmlBlockIn(
-                                firstMatch(
-                                        Pattern.compile(String.format(SECTION, "Snapshots")),
-                                        read("README.md"),
-                                        "\"Snapshots\" section of README.md"),
-                                "Snapshots")
+                lineDeclaring("version", xmlBlockUnderHeading("Snapshots"), "README.md's snapshot <version>")
                         .contains(MARKER),
                 "README.md's \"Snapshots\" snippet lost its x-release-please-version marker, so release-please "
                         + "will stop updating it and it will go stale again (#401)");
     }
 
     private static String versionUnderHeading(String heading) throws IOException {
+        return firstMatch(
+                XML_VERSION,
+                xmlBlockUnderHeading(heading),
+                "<version> in the ```xml block under README.md heading \"" + heading + "\"");
+    }
+
+    /** The fenced {@code ```xml} block carrying the version that a README heading advertises. */
+    private static String xmlBlockUnderHeading(String heading) throws IOException {
         String section = firstMatch(
                 Pattern.compile(String.format(SECTION, Pattern.quote(heading))),
                 read("README.md"),
                 "\"" + heading + "\" section of README.md");
-        return firstMatch(
-                XML_VERSION,
-                versionedXmlBlockIn(section, heading),
-                "<version> in the ```xml block under README.md heading \"" + heading + "\"");
+        return versionedXmlBlockIn(section, heading);
+    }
+
+    /**
+     * The whole line declaring {@code <tag>}, because release-please's {@code Generic} updater is
+     * line-scoped: it rewrites the first semver-looking string on any line carrying the marker.
+     * Neither the marker's position on that line nor the whitespace around it matters to it, so
+     * nothing here should assert either.
+     */
+    private static String lineDeclaring(String tag, String content, String what) {
+        return firstMatch(Pattern.compile("(?m)^(.*<" + Pattern.quote(tag) + ">.*)$"), content, what);
     }
 
     /**

--- a/src/test/java/com/falkordb/ReadmeVersionTest.java
+++ b/src/test/java/com/falkordb/ReadmeVersionTest.java
@@ -38,8 +38,16 @@ import org.junit.jupiter.api.Test;
  */
 class ReadmeVersionTest {
 
-    /** The {@code <version>} inside the fenced XML block that follows a given README heading. */
-    private static final String VERSION_AFTER_HEADING = "(?s)##\\s+%s\\b.*?<version>([^<]+)</version>";
+    /** Everything under a {@code ## Heading} up to the next one, so a match cannot leak sideways. */
+    private static final String SECTION = "(?ms)^##\\s+%s\\b(.*?)(?=^##\\s|\\z)";
+
+    /** The body of a fenced {@code ```xml} block. Reluctant, so it stops at that block's fence. */
+    private static final Pattern FENCED_XML = Pattern.compile("(?s)```xml\\s(.*?)```");
+
+    private static final Pattern XML_VERSION = Pattern.compile("<version>([^<]+)</version>");
+
+    /** The marker that hands a line to release-please. */
+    private static final String MARKER = "<!-- x-release-please-version -->";
 
     /** release-please writes the newest release first, as {@code ## [x.y.z](compare-link) (date)}. */
     private static final Pattern LATEST_CHANGELOG_VERSION = Pattern.compile("(?m)^##\\s+\\[([^\\]]+)\\]");
@@ -100,18 +108,78 @@ class ReadmeVersionTest {
                     "jfalkordb.version in " + module + "/pom.xml");
             assertEquals(projectVersion, declared, module + "/pom.xml's jfalkordb.version default is stale (#401)");
             assertTrue(
-                    pom.contains("<jfalkordb.version>" + declared
-                            + "</jfalkordb.version> <!-- x-release-please-version -->"),
+                    pom.contains("<jfalkordb.version>" + declared + "</jfalkordb.version> " + MARKER),
                     module + "/pom.xml lost its x-release-please-version marker, so its default will "
                             + "drift again - check release-please-config.json (#401)");
         }
     }
 
+    /**
+     * The three tests above compare versions, so they only notice drift once it has happened. This
+     * one asserts the machinery that prevents it: every file carrying a marker must also be listed in
+     * {@code release-please-config.json}, and every marker must still be there. Delete either half
+     * and the versions still agree today, but the next release silently resumes the drift #401 was
+     * filed about.
+     */
+    @Test
+    void releasePleaseStillOwnsEveryVersionOutsideTheRootPom() throws IOException {
+        String config = read("release-please-config.json");
+        String extraFiles = firstMatch(
+                Pattern.compile("(?s)\"extra-files\"\\s*:\\s*\\[(.*?)]"),
+                config,
+                "extra-files in " + "release-please-config.json");
+
+        for (String path : new String[] {
+            "README.md", "examples/pom.xml", "smoke-test/pom.xml", "pin-check/pom.xml", "benchmarks/pom.xml"
+        }) {
+            String entry = firstMatch(
+                    Pattern.compile("(\\{[^{}]*\"path\"\\s*:\\s*\"" + Pattern.quote(path) + "\"[^{}]*})"),
+                    extraFiles,
+                    "\"" + path + "\" among the extra-files in release-please-config.json");
+            assertTrue(
+                    Pattern.compile("\"type\"\\s*:\\s*\"generic\"")
+                            .matcher(entry)
+                            .find(),
+                    "release-please-config.json lists " + path + " but not with \"type\": \"generic\", so its "
+                            + "x-release-please-version markers may stop being honoured (#401)");
+        }
+
+        assertTrue(
+                versionedXmlBlockIn(
+                                firstMatch(
+                                        Pattern.compile(String.format(SECTION, "Snapshots")),
+                                        read("README.md"),
+                                        "\"Snapshots\" section of README.md"),
+                                "Snapshots")
+                        .contains(MARKER),
+                "README.md's \"Snapshots\" snippet lost its x-release-please-version marker, so release-please "
+                        + "will stop updating it and it will go stale again (#401)");
+    }
+
     private static String versionUnderHeading(String heading) throws IOException {
-        return firstMatch(
-                Pattern.compile(String.format(VERSION_AFTER_HEADING, Pattern.quote(heading))),
+        String section = firstMatch(
+                Pattern.compile(String.format(SECTION, Pattern.quote(heading))),
                 read("README.md"),
-                "<version> under README.md heading \"" + heading + "\"");
+                "\"" + heading + "\" section of README.md");
+        return firstMatch(
+                XML_VERSION,
+                versionedXmlBlockIn(section, heading),
+                "<version> in the ```xml block under README.md heading \"" + heading + "\"");
+    }
+
+    /**
+     * The first fenced {@code ```xml} block of the section that declares a {@code <version>}. Not
+     * simply the first block: the "Snapshots" section opens with a {@code <repositories>} snippet.
+     */
+    private static String versionedXmlBlockIn(String section, String heading) {
+        Matcher blocks = FENCED_XML.matcher(section);
+        while (blocks.find()) {
+            if (XML_VERSION.matcher(blocks.group(1)).find()) {
+                return blocks.group(1);
+            }
+        }
+        throw new AssertionError("README.md's \"" + heading + "\" section has no ```xml block declaring a <version>; "
+                + "has the file's layout changed?");
     }
 
     private static String firstMatch(Pattern pattern, String haystack, String what) {

--- a/src/test/java/com/falkordb/ReadmeVersionTest.java
+++ b/src/test/java/com/falkordb/ReadmeVersionTest.java
@@ -1,0 +1,129 @@
+package com.falkordb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the version numbers users copy out of {@code README.md}, which nothing owned before and
+ * which therefore drifted silently: at the time this test was written the release snippet was two
+ * releases stale and the snapshot snippet one ahead of nothing at all.
+ *
+ * <p>The two snippets are owned differently, because release-please can only own one of them:
+ *
+ * <ul>
+ *   <li><b>Snapshots</b> — carries an {@code x-release-please-version} marker, so release-please
+ *       rewrites it. Verified here against {@code pom.xml} so a broken marker or a dropped {@code
+ *       extra-files} entry fails loudly instead of silently resuming the drift.
+ *   <li><b>Official Releases</b> — deliberately <em>not</em> marked. Because this project releases
+ *       with {@code release-type: java}, release-please follows every release PR with a snapshot PR,
+ *       and that snapshot PR re-applies the same {@code extra-files} updaters with the {@code
+ *       -SNAPSHOT} version. A marker here would therefore leave the block users copy pointing at a
+ *       version that was never published to Maven Central. It is checked against {@code
+ *       CHANGELOG.md} instead — the release-time check the issue proposed as the alternative.
+ * </ul>
+ *
+ * <p>So this test failing on a release PR is <em>the point</em>: it means the release snippet still
+ * names the previous release and needs its one line updated before shipping.
+ *
+ * @see <a href="https://github.com/FalkorDB/JFalkorDB/issues/401">#401</a>
+ */
+class ReadmeVersionTest {
+
+    /** The {@code <version>} inside the fenced XML block that follows a given README heading. */
+    private static final String VERSION_AFTER_HEADING = "(?s)##\\s+%s\\b.*?<version>([^<]+)</version>";
+
+    /** release-please writes the newest release first, as {@code ## [x.y.z](compare-link) (date)}. */
+    private static final Pattern LATEST_CHANGELOG_VERSION = Pattern.compile("(?m)^##\\s+\\[([^\\]]+)\\]");
+
+    /** The root project version, i.e. the first {@code <version>} after our own artifactId. */
+    private static final Pattern PROJECT_VERSION =
+            Pattern.compile("(?s)<artifactId>jfalkordb</artifactId>\\s*<version>([^<]+)</version>");
+
+    @Test
+    void officialReleasesSnippetNamesTheLatestRelease() throws IOException {
+        String readmeVersion = versionUnderHeading("Official Releases");
+        String released = firstMatch(LATEST_CHANGELOG_VERSION, read("CHANGELOG.md"), "latest CHANGELOG.md version");
+        assertEquals(
+                released,
+                readmeVersion,
+                "README.md's \"Official Releases\" snippet is the block users copy into their pom.xml, "
+                        + "but it names a version that is not the latest release. Update it to " + released
+                        + ". It is not auto-updated on purpose - see this test's Javadoc and issue #401.");
+    }
+
+    @Test
+    void officialReleasesSnippetNeverNamesASnapshot() throws IOException {
+        String readmeVersion = versionUnderHeading("Official Releases");
+        assertTrue(
+                !readmeVersion.contains("SNAPSHOT"),
+                "README.md's \"Official Releases\" snippet names \"" + readmeVersion
+                        + "\", which is not published to Maven Central, so the snippet cannot resolve. "
+                        + "This is what happens if an x-release-please-version marker is added to that "
+                        + "block: the snapshot PR that follows every release rewrites it. See issue #401.");
+    }
+
+    @Test
+    void snapshotsSnippetTracksTheProjectVersion() throws IOException {
+        String readmeVersion = versionUnderHeading("Snapshots");
+        String projectVersion = firstMatch(PROJECT_VERSION, read("pom.xml"), "project version in pom.xml");
+        assertEquals(
+                projectVersion,
+                readmeVersion,
+                "README.md's \"Snapshots\" snippet should track pom.xml. It carries an "
+                        + "x-release-please-version marker, so a mismatch means release-please stopped "
+                        + "updating it - check the extra-files entry in release-please-config.json (#401).");
+    }
+
+    /**
+     * The sibling modules build against the client through a {@code jfalkordb.version} property whose
+     * default drifted for the same reason the README did. Each carries the same marker, and each is
+     * only overridden by {@code just}, so a stale default silently builds an example, a benchmark or
+     * a JDK-8 smoke test against an old client instead of the one in the working tree.
+     */
+    @Test
+    void siblingModulesTrackTheProjectVersion() throws IOException {
+        String projectVersion = firstMatch(PROJECT_VERSION, read("pom.xml"), "project version in pom.xml");
+        for (String module : new String[] {"examples", "smoke-test", "pin-check", "benchmarks"}) {
+            String pom = read(module + "/pom.xml");
+            String declared = firstMatch(
+                    Pattern.compile("<jfalkordb\\.version>([^<]+)</jfalkordb\\.version>"),
+                    pom,
+                    "jfalkordb.version in " + module + "/pom.xml");
+            assertEquals(projectVersion, declared, module + "/pom.xml's jfalkordb.version default is stale (#401)");
+            assertTrue(
+                    pom.contains("<jfalkordb.version>" + declared
+                            + "</jfalkordb.version> <!-- x-release-please-version -->"),
+                    module + "/pom.xml lost its x-release-please-version marker, so its default will "
+                            + "drift again - check release-please-config.json (#401)");
+        }
+    }
+
+    private static String versionUnderHeading(String heading) throws IOException {
+        return firstMatch(
+                Pattern.compile(String.format(VERSION_AFTER_HEADING, Pattern.quote(heading))),
+                read("README.md"),
+                "<version> under README.md heading \"" + heading + "\"");
+    }
+
+    private static String firstMatch(Pattern pattern, String haystack, String what) {
+        Matcher matcher = pattern.matcher(haystack);
+        assertTrue(matcher.find(), "could not find the " + what + "; has the file's layout changed?");
+        return matcher.group(1).trim();
+    }
+
+    /** Reads a file relative to the project root, which is Surefire's working directory. */
+    private static String read(String relativePath) throws IOException {
+        Path path = Paths.get(relativePath);
+        assertTrue(Files.isRegularFile(path), "expected to find " + relativePath + " at " + path.toAbsolutePath());
+        return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
Fixes #401

## The drift, as found on `master`

| File | Said | Should say |
| --- | --- | --- |
| README **Official Releases** (the block users copy) | `0.11.0` | `0.11.1` — one release stale |
| README **Snapshots** | `0.11.1-SNAPSHOT` | `0.11.2-SNAPSHOT` |
| `examples/pom.xml` | `0.10.0-SNAPSHOT` | `0.11.2-SNAPSHOT` |
| `smoke-test/pom.xml` | `0.10.0-SNAPSHOT` | `0.11.2-SNAPSHOT` |
| `pin-check/pom.xml` | `0.10.0-SNAPSHOT` | `0.11.2-SNAPSHOT` |
| `benchmarks/pom.xml` | `0.10.0-SNAPSHOT` | `0.11.2-SNAPSHOT` |

The issue predicted the drift would restart after 0.11.0, and it did. It also only spotted `examples/pom.xml`; **all four** sibling modules carried the same stale default. `just` overrides the property, so this was invisible through the recipes — but building a module directly resolved a client two minor versions old (I hit exactly this on #425, where the documented `exec:java` command silently ran against `0.10.0-SNAPSHOT`).

## What this does

`README.md` and the four module poms are now `extra-files` in `release-please-config.json`, with an `x-release-please-version` marker on the line to rewrite.

## One correction to the plan in the issue

The issue proposed putting the marker on the **Official Releases** snippet. That turns out to be backwards for this repo, and would actively break the snippet.

With `release-type: java`, every release PR is followed by a **snapshot PR**, and [`Java.buildSnapshotPullRequest`](https://github.com/googleapis/release-please/blob/v17.6.0/src/strategies/java.ts) re-applies the *same* `extra-files` updaters with the `-SNAPSHOT` version:

```ts
const updatesWithExtras = mergeUpdates(
  updates.concat(...(await this.extraFileUpdates(newVersion, versionsMap, this.dateFormat)))
);
```

Since the snapshot PR runs **last** in every cycle, a marked line comes to rest holding `X.Y.Z-SNAPSHOT`. There is no way to scope an updater to the release PR only — the sole knob is `skip-snapshot`, which would disable snapshot PRs altogether.

That is exactly right for the Snapshots block and the modules' defaults (all of which *should* track master's snapshot), and exactly wrong for the block users paste into their own `pom.xml` — it would leave them pointing at a version never published to Maven Central.

I verified this rather than reasoning about it, by running release-please 17.6.0's own `Generic` updater over the actual files for both PR versions:

```
══════ RELEASE PR  (version = 0.11.2) ══════
  README.md
     - <version>0.11.2-SNAPSHOT</version> <!-- x-release-please-version -->
     + <version>0.11.2</version> <!-- x-release-please-version -->
  examples/pom.xml
     - <jfalkordb.version>0.11.2-SNAPSHOT</jfalkordb.version> <!-- x-release-please-version -->
     + <jfalkordb.version>0.11.2</jfalkordb.version> <!-- x-release-please-version -->
  ...

══════ SNAPSHOT PR  (version = 0.11.3-SNAPSHOT) ══════
  README.md
     - <version>0.11.2-SNAPSHOT</version> <!-- x-release-please-version -->
     + <version>0.11.3-SNAPSHOT</version> <!-- x-release-please-version -->
  ...
```

Note the release snippet and each module's own `<version>1.0-SNAPSHOT</version>` are untouched in both runs — the `"type": "generic"` entries only ever rewrite marked lines.

## So the release snippet is guarded instead

This is the fallback the issue itself proposed ("a release-time check that fails when the README version and `<project><version>` disagree"). `ReadmeVersionTest` asserts:

1. the release snippet matches the newest entry in `CHANGELOG.md`;
2. it never names a `SNAPSHOT` (i.e. nobody re-adds the marker there);
3. the marked README line still tracks `pom.xml`;
4. all four modules track `pom.xml` **and** still carry their marker.

3 and 4 matter as much as the rest: if a marker or an `extra-files` entry is ever dropped, the drift resumes silently — these make it fail loudly. It is a plain unit test, so it runs inside the existing `build` gate with no new tooling or CI wiring.

Each assertion was verified to actually fail by reintroducing its drift, e.g.:

```
ReadmeVersionTest.officialReleasesSnippetNamesTheLatestRelease:55 README.md's "Official Releases"
snippet is the block users copy into their pom.xml, but it names a version that is not the latest
release. Update it to 0.11.1. ==> expected: <0.11.1> but was: <0.11.0>
```

### Expected: this test fails on the Release PR

By design. release-please writes the new version into `CHANGELOG.md` while the release snippet still names the previous one, so the check fires at exactly the moment a human is deciding to ship — update that one `<version>` line in the Release PR before merging. Documented in `docs/release-please-setup.md`.

## Validation

`just verify`, `just lint`, `just test` (263 unit + 125 IT), `just spellcheck` and `just examples` all green. Confirmed the modules' default now resolves `0.11.2-SNAPSHOT` instead of `0.10.0-SNAPSHOT`, and that `release-please-config.json` is valid JSON against its schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s official release and snapshot version references.
  * Added guidance for maintaining release versions across project files.

* **Chores**
  * Updated module version references to the current snapshot.
  * Expanded automated release configuration to update related project files.

* **Tests**
  * Added checks to keep README, release, and module version references synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->