### PR TITLE
feat: add Redis Sentinel support

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -49,3 +49,6 @@ arg
 URI
 README's
 updaters
+ACL
+ACLs
+failovers

--- a/README.md
+++ b/README.md
@@ -142,29 +142,93 @@ public class GraphExample {
 first checks for connection settings in the environment so the same artifact can be deployed across
 dev/CI/staging/prod without hand-rolled env-var plumbing. Resolution order:
 
-1. `FALKORDB_URL` — a full connection URI (`redis://`/`rediss://`, or the FalkorDB-branded
+1. `FALKORDB_SENTINEL_MASTER` together with `FALKORDB_SENTINELS` — connect through a
+   [Redis Sentinel](#high-availability-with-redis-sentinel) deployment. `FALKORDB_SENTINELS` is a
+   comma-separated list of `host:port` Sentinel addresses. Setting only one of the pair throws
+   `IllegalStateException`.
+2. `FALKORDB_URL` — a full connection URI (`redis://`/`rediss://`, or the FalkorDB-branded
    `falkor://`/`falkors://` aliases for them), covering host, port, credentials, and TLS in one
    value; delegates to `FalkorDB.driver(URI)`.
-2. `FALKORDB_HOST` together with `FALKORDB_PORT` — delegates to `FalkorDB.driver(host, port)`.
+3. `FALKORDB_HOST` together with `FALKORDB_PORT` — delegates to `FalkorDB.driver(host, port)`.
    Setting only one of the pair throws `IllegalStateException` rather than silently defaulting the
    other.
-3. Neither set — the unchanged `localhost:6379` default.
+4. None set — the unchanged `localhost:6379` default.
 
 ```bash
 export FALKORDB_URL=redis://<user>:<password>@db.example.com:6379
 # or, equivalently:
 export FALKORDB_HOST=db.example.com
 export FALKORDB_PORT=6379
+# or, to go through Sentinel:
+export FALKORDB_SENTINEL_MASTER=mymaster
+export FALKORDB_SENTINELS=sentinel-a:26379,sentinel-b:26379,sentinel-c:26379
 ```
 
 ```java
-// picks up FALKORDB_URL, or FALKORDB_HOST + FALKORDB_PORT, or falls back to localhost:6379
+// picks up the environment settings above, or falls back to localhost:6379
 Driver driver = FalkorDB.driver();
 ```
 
 This fallback applies **only** to the no-arg `driver()` overload — `driver(host, port)`,
 `driver(host, port, user, password)`, `driver(URI)`, and `builder()` always connect to exactly the
 arguments you pass them and never consult the environment.
+
+## High availability with Redis Sentinel
+
+[Redis Sentinel](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/) monitors a
+master and its replicas and promotes a replica when the master fails. Point the driver at a Sentinel
+and it discovers the current master, then follows failovers for the lifetime of the driver — queries
+issued after a promotion go to the new master without recreating the driver.
+
+Nothing needs configuring in the common case. Every factory method probes the endpoint it is given,
+and if that endpoint turns out to be a Sentinel it resolves the master automatically:
+
+```java
+// sentinel-a is a Sentinel, not a FalkorDB server — the driver works this out for itself
+try (Driver driver = FalkorDB.driver("sentinel-a", 26379)) {
+    Graph graph = driver.graph("social");
+    graph.query("CREATE (:Person {name:'Alice'})");
+}
+```
+
+This matches how the other FalkorDB clients behave, so the same deployment works whichever language
+a service is written in. An endpoint that is an ordinary FalkorDB server is used directly, exactly as
+in every previous release; an endpoint that cannot be probed at all also falls back to a direct
+connection, so nothing that worked before starts failing.
+
+Name the deployment explicitly when a Sentinel monitors more than one master (auto-detection cannot
+guess which one you want and will tell you so), when you want to list several Sentinels for
+redundancy, or simply to skip the probe:
+
+```java
+try (Driver driver = FalkorDB.builder()
+        .sentinel("mymaster", "sentinel-a:26379", "sentinel-b:26379", "sentinel-c:26379")
+        .build()) {
+    driver.graph("social").query("CREATE (:Person {name:'Alice'})");
+}
+```
+
+Credentials given with `credentials(...)` are used for the master. Sentinels frequently have their
+own ACLs, so they can be authenticated separately; when `sentinelCredentials(...)` is omitted the
+Sentinel connections reuse the master's credentials:
+
+```java
+Driver driver = FalkorDB.builder()
+        .sentinel("mymaster", "sentinel-a:26379")
+        .credentials("app-user", "app-password")
+        .sentinelCredentials("sentinel-user", "sentinel-password")
+        .build();
+```
+
+Auto-detection costs one `INFO` command on the first connection. To skip it — for instance when the
+address is known to be a plain server and its ACL forbids `INFO` — turn it off:
+
+```java
+Driver driver = FalkorDB.builder().host("db.example.com").autoDetectSentinel(false).build();
+```
+
+Building a driver still performs no I/O: the probe, like the first connection, happens when the
+driver is first used.
 
 ## Query parameters
 

--- a/src/main/java/com/falkordb/DriverEnvironment.java
+++ b/src/main/java/com/falkordb/DriverEnvironment.java
@@ -2,6 +2,8 @@ package com.falkordb;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import org.jspecify.annotations.Nullable;
@@ -24,6 +26,15 @@ final class DriverEnvironment {
 
     /** Server port env var; must be set together with {@link #HOST_VAR}. */
     static final String PORT_VAR = "FALKORDB_PORT";
+
+    /** Sentinel master-name env var; must be set together with {@link #SENTINELS_VAR}. */
+    static final String SENTINEL_MASTER_VAR = "FALKORDB_SENTINEL_MASTER";
+
+    /**
+     * Comma-separated {@code host:port} Sentinel addresses; must be set together with {@link
+     * #SENTINEL_MASTER_VAR}.
+     */
+    static final String SENTINELS_VAR = "FALKORDB_SENTINELS";
 
     /** Default host used when neither {@link #URL_VAR} nor {@link #HOST_VAR}/{@link #PORT_VAR} is set. */
     static final String DEFAULT_HOST = "localhost";
@@ -52,6 +63,17 @@ final class DriverEnvironment {
      *     FALKORDB_HOST}/{@code FALKORDB_PORT} is set
      */
     static Driver resolve(Function<String, @Nullable String> env) {
+        String sentinelMaster = trimToNull(env.apply(SENTINEL_MASTER_VAR));
+        String sentinels = trimToNull(env.apply(SENTINELS_VAR));
+        if ((sentinelMaster != null) != (sentinels != null)) {
+            throw new IllegalStateException("Set BOTH " + SENTINEL_MASTER_VAR + " and " + SENTINELS_VAR
+                    + " to configure FalkorDB.driver() against a Sentinel deployment, or neither.");
+        }
+        if (sentinelMaster != null) {
+            return FalkorDB.builder()
+                    .sentinel(sentinelMaster, parseSentinels(sentinels))
+                    .build();
+        }
         String url = trimToNull(env.apply(URL_VAR));
         if (url != null) {
             URI uri = toConnectionUri(url);
@@ -112,6 +134,30 @@ final class DriverEnvironment {
      */
     private static String redact(String value) {
         return USERINFO_PREFIX.matcher(value).replaceAll("$1<redacted>@");
+    }
+
+    /**
+     * Splits a comma-separated {@link #SENTINELS_VAR} value into {@code host:port} addresses, ignoring
+     * empty entries so a trailing comma is harmless. The addresses themselves are validated later, by
+     * the builder, so the error message for a malformed one is the same however it was configured.
+     *
+     * @param value the raw variable value, already trimmed to non-null
+     * @return the listed addresses, in order
+     * @throws IllegalStateException if the value lists no address at all
+     */
+    static List<String> parseSentinels(String value) {
+        List<String> addresses = new ArrayList<>();
+        for (String candidate : value.split(",")) {
+            String trimmed = candidate.trim();
+            if (!trimmed.isEmpty()) {
+                addresses.add(trimmed);
+            }
+        }
+        if (addresses.isEmpty()) {
+            throw new IllegalStateException(
+                    SENTINELS_VAR + " must list at least one host:port address, but was \"" + value + "\"");
+        }
+        return addresses;
     }
 
     private static int parsePort(String value) {

--- a/src/main/java/com/falkordb/DriverEnvironment.java
+++ b/src/main/java/com/falkordb/DriverEnvironment.java
@@ -147,7 +147,7 @@ final class DriverEnvironment {
      */
     static List<String> parseSentinels(String value) {
         List<String> addresses = new ArrayList<>();
-        for (String candidate : value.split(",")) {
+        for (String candidate : value.split(",", -1)) {
             String trimmed = candidate.trim();
             if (!trimmed.isEmpty()) {
                 addresses.add(trimmed);

--- a/src/main/java/com/falkordb/DriverEnvironment.java
+++ b/src/main/java/com/falkordb/DriverEnvironment.java
@@ -1,11 +1,11 @@
 package com.falkordb;
 
+import com.falkordb.impl.ConnectionUris;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
-import java.util.regex.Pattern;
 import org.jspecify.annotations.Nullable;
 import redis.clients.jedis.util.JedisURIHelper;
 
@@ -48,8 +48,6 @@ final class DriverEnvironment {
      * scheme-less mistake like {@code user:password@host:6379} — which {@link URI} happily parses as
      * an opaque URI rather than rejecting — is redacted just like a well-formed {@code redis://} URL.
      */
-    private static final Pattern USERINFO_PREFIX = Pattern.compile("(^|://)[^/?#@]*@");
-
     private DriverEnvironment() {}
 
     /**
@@ -83,8 +81,9 @@ final class DriverEnvironment {
                 // Same reasoning as in toConnectionUri: Jedis' InvalidURIException formats the whole
                 // URI (credentials included) into its message, so chaining it would undo redact().
                 // The exception's type is a safe breadcrumb; its message is not.
-                throw new IllegalStateException(URL_VAR + " is not a valid connection URI: \"" + redact(url)
-                        + "\" (rejected by " + e.getClass().getSimpleName() + ")");
+                throw new IllegalStateException(
+                        URL_VAR + " is not a valid connection URI: \"" + ConnectionUris.redact(url) + "\" (rejected by "
+                                + e.getClass().getSimpleName() + ")");
             }
         }
         String host = trimToNull(env.apply(HOST_VAR));
@@ -119,21 +118,14 @@ final class DriverEnvironment {
             // Deliberately not chained as the cause: URISyntaxException.getMessage() quotes the raw
             // input, which would put the credentials we just redacted straight back into the stack
             // trace. getReason() is the value-free half of it, so carry that instead.
-            throw new IllegalStateException(
-                    URL_VAR + " is not a valid connection URI: \"" + redact(value) + "\" (" + e.getReason() + ")");
+            throw new IllegalStateException(URL_VAR + " is not a valid connection URI: \""
+                    + ConnectionUris.redact(value) + "\" (" + e.getReason() + ")");
         }
         if (!JedisURIHelper.isValid(uri)) {
-            throw new IllegalStateException(URL_VAR + " is not a valid connection URI: \"" + redact(value) + "\"");
+            throw new IllegalStateException(
+                    URL_VAR + " is not a valid connection URI: \"" + ConnectionUris.redact(value) + "\"");
         }
         return uri;
-    }
-
-    /**
-     * Replaces any {@code userinfo@} credentials segment in {@code value} with a fixed placeholder,
-     * keeping the {@code ://} separator (or the start of the value) that anchored it.
-     */
-    private static String redact(String value) {
-        return USERINFO_PREFIX.matcher(value).replaceAll("$1<redacted>@");
     }
 
     /**

--- a/src/main/java/com/falkordb/FalkorDB.java
+++ b/src/main/java/com/falkordb/FalkorDB.java
@@ -339,10 +339,12 @@ public final class FalkorDB {
         /**
          * Enables or disables Sentinel auto-detection (default {@code true}).
          *
-         * <p>When enabled, {@link #build()} probes the configured host/port once with {@code INFO
-         * server}; if that endpoint is a Sentinel, the driver resolves the single master it monitors
-         * and connects to that instead, following failovers from then on. This mirrors falkordb-py,
-         * falkordb-go and falkordb-ts, so the same address works across FalkorDB clients.
+         * <p>When enabled, the driver probes the configured host/port once with {@code INFO server}
+         * the first time it is used; if that endpoint is a Sentinel, the driver resolves the single
+         * master it monitors and connects to that instead, following failovers from then on. This
+         * mirrors falkordb-py, falkordb-go and falkordb-ts, so the same address works across FalkorDB
+         * clients. Like every other connection, the probe happens on first use rather than in
+         * {@link #build()}, which performs no I/O.
          *
          * <p>The probe is best-effort and costs one round-trip: an endpoint that cannot be reached, or
          * that refuses {@code INFO}, simply yields an ordinary direct connection whose failure surfaces

--- a/src/main/java/com/falkordb/FalkorDB.java
+++ b/src/main/java/com/falkordb/FalkorDB.java
@@ -1,8 +1,13 @@
 package com.falkordb;
 
 import com.falkordb.impl.api.DriverImpl;
+import com.falkordb.impl.api.SentinelOptions;
 import java.net.URI;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -17,6 +22,11 @@ public final class FalkorDB {
      * localhost:6379} isn't what you want. Resolved in this order:
      *
      * <ol>
+     *   <li>{@code FALKORDB_SENTINEL_MASTER} together with {@code FALKORDB_SENTINELS} (a
+     *       comma-separated list of {@code host:port} Sentinel addresses) — connects through the named
+     *       Redis Sentinel deployment. Setting only one of the pair is rejected rather than silently
+     *       ignored. Credentials are not configurable this way; use {@link #builder()} if you need
+     *       them.
      *   <li>{@code FALKORDB_URL} — a full connection URI ({@code redis://} or {@code rediss://}, or
      *       the FalkorDB-branded {@code falkor://}/{@code falkors://} aliases for them); delegates to
      *       {@link #driver(URI)}, so it also carries credentials, a database index, and TLS.
@@ -34,24 +44,32 @@ public final class FalkorDB {
      * variables above is set. Set the host and port on the builder explicitly if you need it to
      * follow the environment.
      *
+     * <p>Whichever endpoint is resolved, it is checked for Redis Sentinel — see {@link
+     * Builder#autoDetectSentinel(boolean)}.
+     *
      * @return a new driver instance
      * @throws IllegalStateException if {@code FALKORDB_URL} is set but malformed, if {@code
-     *     FALKORDB_PORT} is set but not a valid integer, or if exactly one of {@code
-     *     FALKORDB_HOST}/{@code FALKORDB_PORT} is set
+     *     FALKORDB_PORT} is set but not a valid integer, if exactly one of {@code
+     *     FALKORDB_HOST}/{@code FALKORDB_PORT} is set, or if exactly one of {@code
+     *     FALKORDB_SENTINEL_MASTER}/{@code FALKORDB_SENTINELS} is set
      */
     public static Driver driver() {
         return DriverEnvironment.resolve(System::getenv);
     }
 
     /**
-     * Creates a new driver instance
+     * Creates a new driver instance.
+     *
+     * <p>If {@code host}/{@code port} turns out to be a Redis Sentinel, the driver transparently
+     * connects to the master it monitors instead, and follows failovers from then on — see {@link
+     * Builder#autoDetectSentinel(boolean)}.
      *
      * @param host host name
      * @param port port number
      * @return a new driver instance
      */
     public static Driver driver(String host, int port) {
-        return new DriverImpl(host, port);
+        return DriverImpl.connect(host, port, null, null, SentinelOptions.autoDetect());
     }
 
     /**
@@ -64,7 +82,7 @@ public final class FalkorDB {
      * @return a new driver instance
      */
     public static Driver driver(String host, int port, String user, final String password) {
-        return new DriverImpl(host, port, user, password);
+        return DriverImpl.connect(host, port, user, password, SentinelOptions.autoDetect());
     }
 
     /**
@@ -74,7 +92,7 @@ public final class FalkorDB {
      * @return a new driver instance
      */
     public static Driver driver(URI uri) {
-        return new DriverImpl(uri);
+        return DriverImpl.connect(uri, SentinelOptions.autoDetect());
     }
 
     /**
@@ -126,6 +144,11 @@ public final class FalkorDB {
         private @Nullable Integer poolMaxTotal;
         private @Nullable Integer poolMaxIdle;
         private @Nullable Duration poolMaxWait;
+        private @Nullable String sentinelMasterName;
+        private @Nullable List<String> sentinelAddresses;
+        private @Nullable String sentinelUser;
+        private @Nullable String sentinelPassword;
+        private boolean autoDetectSentinel = true;
 
         private Builder() {}
 
@@ -248,6 +271,94 @@ public final class FalkorDB {
         }
 
         /**
+         * Connects through a Redis Sentinel deployment, naming the monitored master explicitly.
+         *
+         * <p>Use this when {@linkplain #autoDetectSentinel(boolean) auto-detection} is not enough: it
+         * lists every Sentinel rather than a single seed, so the driver can still find the master when
+         * one Sentinel is down, and it names the master, so it works with a Sentinel monitoring more
+         * than one. Setting it makes {@link #host(String)} and {@link #port(int)} irrelevant — the
+         * master's address comes from the Sentinels — and suppresses probing entirely.
+         *
+         * <pre>{@code
+         * Driver driver = FalkorDB.builder()
+         *     .sentinel("mymaster", "sentinel-a:26379", "sentinel-b:26379", "sentinel-c:26379")
+         *     .credentials("user", "password")
+         *     .build();
+         * }</pre>
+         *
+         * @param masterName name of the monitored master, as given to {@code sentinel monitor}
+         * @param sentinels  the Sentinel endpoints in {@code host:port} form; at least one is required
+         * @return this builder
+         */
+        public Builder sentinel(String masterName, String... sentinels) {
+            return sentinel(masterName, sentinels == null ? null : Arrays.asList(sentinels));
+        }
+
+        /**
+         * Connects through a Redis Sentinel deployment, naming the monitored master explicitly. The
+         * {@linkplain #sentinel(String, String...) varargs form} documents the behaviour.
+         *
+         * @param masterName name of the monitored master, as given to {@code sentinel monitor}
+         * @param sentinels  the Sentinel endpoints in {@code host:port} form; at least one is required
+         * @return this builder
+         */
+        public Builder sentinel(String masterName, Collection<String> sentinels) {
+            this.sentinelMasterName = masterName;
+            this.sentinelAddresses = sentinels == null ? null : new ArrayList<>(sentinels);
+            return this;
+        }
+
+        /**
+         * Sets the username and password used to authenticate to the Sentinels themselves, which
+         * commonly carry ACLs of their own. Unset, the {@linkplain #credentials(String, String) data
+         * credentials} are reused.
+         *
+         * @param user     Sentinel username
+         * @param password Sentinel password
+         * @return this builder
+         */
+        public Builder sentinelCredentials(String user, String password) {
+            this.sentinelUser = user;
+            this.sentinelPassword = password;
+            return this;
+        }
+
+        /**
+         * Sets a password for password-only ({@code default} user) authentication to the Sentinels,
+         * clearing any previously set Sentinel username.
+         *
+         * @param password Sentinel password
+         * @return this builder
+         */
+        public Builder sentinelCredentials(String password) {
+            this.sentinelUser = null;
+            this.sentinelPassword = password;
+            return this;
+        }
+
+        /**
+         * Enables or disables Sentinel auto-detection (default {@code true}).
+         *
+         * <p>When enabled, {@link #build()} probes the configured host/port once with {@code INFO
+         * server}; if that endpoint is a Sentinel, the driver resolves the single master it monitors
+         * and connects to that instead, following failovers from then on. This mirrors falkordb-py,
+         * falkordb-go and falkordb-ts, so the same address works across FalkorDB clients.
+         *
+         * <p>The probe is best-effort and costs one round-trip: an endpoint that cannot be reached, or
+         * that refuses {@code INFO}, simply yields an ordinary direct connection whose failure surfaces
+         * on first use — the behaviour of every release before Sentinel support. Switch this off to
+         * skip the probe altogether when you know you are not talking to a Sentinel. It is ignored when
+         * {@link #sentinel(String, String...)} named a deployment explicitly.
+         *
+         * @param autoDetectSentinel whether to probe the endpoint for Sentinel mode
+         * @return this builder
+         */
+        public Builder autoDetectSentinel(boolean autoDetectSentinel) {
+            this.autoDetectSentinel = autoDetectSentinel;
+            return this;
+        }
+
+        /**
          * Validates the configuration and builds a driver. Unset options use the fixed defaults
          * documented on each setter, independently of the environment {@link FalkorDB#driver()} reads.
          * Range validation happens in {@link DriverImpl#create}.
@@ -266,7 +377,37 @@ public final class FalkorDB {
                     ? DriverImpl.DEFAULT_SOCKET_TIMEOUT_MILLIS
                     : toTimeoutMillis(socketTimeout, "socketTimeout");
             return DriverImpl.create(
-                    host, port, user, password, ssl, connectMillis, socketMillis, maxTotal, maxIdle, maxWait);
+                    host,
+                    port,
+                    user,
+                    password,
+                    ssl,
+                    connectMillis,
+                    socketMillis,
+                    maxTotal,
+                    maxIdle,
+                    maxWait,
+                    sentinelOptions());
+        }
+
+        /**
+         * Resolves the three Sentinel states this builder can express: an explicitly named deployment,
+         * the default probe, or no Sentinel handling at all. Sentinel credentials apply to all three,
+         * since even an auto-detected Sentinel may need its own ACL.
+         */
+        private SentinelOptions sentinelOptions() {
+            SentinelOptions options;
+            if (sentinelMasterName != null || sentinelAddresses != null) {
+                options = SentinelOptions.explicit(sentinelMasterName, sentinelAddresses);
+            } else if (autoDetectSentinel) {
+                options = SentinelOptions.autoDetect();
+            } else {
+                options = SentinelOptions.disabled();
+            }
+            if (sentinelUser != null || sentinelPassword != null) {
+                options = options.withCredentials(sentinelUser, sentinelPassword);
+            }
+            return options;
         }
 
         /**

--- a/src/main/java/com/falkordb/impl/ConnectionUris.java
+++ b/src/main/java/com/falkordb/impl/ConnectionUris.java
@@ -18,8 +18,14 @@ public final class ConnectionUris {
      * Matches a {@code userinfo@} segment, anchored either at the start of the value or at the
      * {@code ://} after the scheme. Excluding {@code /?#} keeps the match inside the authority, so a
      * later {@code @} in a path or query cannot drag the rest of the URI into the redaction.
+     *
+     * <p>{@code @} itself is deliberately <em>not</em> excluded, so the greedy match runs to the last
+     * {@code @} in the authority rather than the first. A password containing an unescaped {@code @}
+     * — precisely the kind of value that gets rejected and quoted back in an error — would otherwise
+     * keep everything after that first {@code @}: {@code redis://user:p@ss@host} redacted to the
+     * first delimiter leaves {@code <redacted>@ss@host}, publishing the tail of the password.
      */
-    private static final Pattern USERINFO_PREFIX = Pattern.compile("(^|://)[^/?#@]*@");
+    private static final Pattern USERINFO_PREFIX = Pattern.compile("(^|://)[^/?#]*@");
 
     private ConnectionUris() {}
 

--- a/src/main/java/com/falkordb/impl/ConnectionUris.java
+++ b/src/main/java/com/falkordb/impl/ConnectionUris.java
@@ -1,6 +1,8 @@
 package com.falkordb.impl;
 
+import java.net.URI;
 import java.util.regex.Pattern;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Helpers for talking about connection URIs without leaking what is embedded in them.
@@ -28,10 +30,17 @@ public final class ConnectionUris {
      * that most need redacting are the malformed ones, and a URI that Java cannot parse into an
      * authority still has the password sitting in plain sight in its string form.
      *
-     * @param value a connection URI in string form, possibly malformed
-     * @return the same value with any {@code userinfo@} segment replaced
+     * <p>Tolerates {@code null} rather than rejecting it. This only ever runs while something is
+     * already going wrong, and throwing a {@link NullPointerException} out of the code that builds an
+     * error message would replace a useful diagnostic with a useless one.
+     *
+     * @param value a connection URI in string form, possibly malformed or {@code null}
+     * @return the same value with any {@code userinfo@} segment replaced, or {@code "null"}
      */
-    public static String redact(String value) {
+    public static String redact(@Nullable String value) {
+        if (value == null) {
+            return "null";
+        }
         return USERINFO_PREFIX.matcher(value).replaceAll("$1<redacted>@");
     }
 
@@ -39,9 +48,9 @@ public final class ConnectionUris {
      * Renders a connection URI for use in a message, with any credentials replaced.
      *
      * @param uri the URI to describe, possibly {@code null}
-     * @return the URI in string form with any {@code userinfo@} segment replaced
+     * @return the URI in string form with any {@code userinfo@} segment replaced, or {@code "null"}
      */
-    public static String redact(java.net.URI uri) {
-        return redact(String.valueOf(uri));
+    public static String redact(@Nullable URI uri) {
+        return redact(uri == null ? null : uri.toString());
     }
 }

--- a/src/main/java/com/falkordb/impl/ConnectionUris.java
+++ b/src/main/java/com/falkordb/impl/ConnectionUris.java
@@ -1,0 +1,47 @@
+package com.falkordb.impl;
+
+import java.util.regex.Pattern;
+
+/**
+ * Helpers for talking about connection URIs without leaking what is embedded in them.
+ *
+ * <p>A connection URI routinely carries a password in its userinfo segment, so any message that
+ * quotes one back — an exception, a log line, a crash report — is a credential disclosure waiting to
+ * be filed as a bug. This lives in one place because the redaction has to be identical everywhere:
+ * two copies of a rule like this drift, and the copy that drifts is the one that leaks.
+ */
+public final class ConnectionUris {
+
+    /**
+     * Matches a {@code userinfo@} segment, anchored either at the start of the value or at the
+     * {@code ://} after the scheme. Excluding {@code /?#} keeps the match inside the authority, so a
+     * later {@code @} in a path or query cannot drag the rest of the URI into the redaction.
+     */
+    private static final Pattern USERINFO_PREFIX = Pattern.compile("(^|://)[^/?#@]*@");
+
+    private ConnectionUris() {}
+
+    /**
+     * Replaces any credentials in a connection URI with a fixed placeholder.
+     *
+     * <p>Deliberately operates on the text rather than on {@link java.net.URI} accessors: the values
+     * that most need redacting are the malformed ones, and a URI that Java cannot parse into an
+     * authority still has the password sitting in plain sight in its string form.
+     *
+     * @param value a connection URI in string form, possibly malformed
+     * @return the same value with any {@code userinfo@} segment replaced
+     */
+    public static String redact(String value) {
+        return USERINFO_PREFIX.matcher(value).replaceAll("$1<redacted>@");
+    }
+
+    /**
+     * Renders a connection URI for use in a message, with any credentials replaced.
+     *
+     * @param uri the URI to describe, possibly {@code null}
+     * @return the URI in string form with any {@code userinfo@} segment replaced
+     */
+    public static String redact(java.net.URI uri) {
+        return redact(String.valueOf(uri));
+    }
+}

--- a/src/main/java/com/falkordb/impl/api/DriverImpl.java
+++ b/src/main/java/com/falkordb/impl/api/DriverImpl.java
@@ -128,16 +128,18 @@ public class DriverImpl implements Driver {
     }
 
     /**
-     * Rejects a URI Jedis would not accept, with the message Jedis' own URI-based pool constructor
-     * used before this driver assembled the client config itself.
+     * Rejects a URI Jedis would not accept, standing in for the check Jedis' own URI-based pool
+     * constructor performed before this driver assembled the client config itself.
      */
     private static void requireValidUri(URI uri) {
         if (!JedisURIHelper.isValid(uri)) {
-            // Jedis' own message quotes the URI verbatim, which puts any embedded password into the
-            // message and every stack trace that carries it. Same reasoning as DriverEnvironment:
-            // the rejected value is worth reporting, its credentials are not.
+            // Deliberately not Jedis' wording. Its message quotes the URI verbatim, which puts any
+            // embedded password into the message and every stack trace that carries it -- same
+            // reasoning as DriverEnvironment: the rejected value is worth reporting, its credentials
+            // are not. Since the text has to change anyway, it is also spelled "due to" rather than
+            // reproducing the "due invalid URI" of the original.
             throw new InvalidURIException(
-                    String.format("Cannot open Redis connection due invalid URI. %s", ConnectionUris.redact(uri)));
+                    String.format("Cannot open Redis connection due to invalid URI. %s", ConnectionUris.redact(uri)));
         }
     }
 

--- a/src/main/java/com/falkordb/impl/api/DriverImpl.java
+++ b/src/main/java/com/falkordb/impl/api/DriverImpl.java
@@ -62,7 +62,7 @@ public class DriverImpl implements Driver {
      * Read deadline for the one-shot Sentinel probe when the driver's own socket timeout is the
      * default {@link #DEFAULT_SOCKET_TIMEOUT_MILLIS} (0 = no deadline). That default is right for
      * graph queries, which may legitimately run for minutes, but wrong for a probe: an endpoint that
-     * completes the TCP handshake and then never answers would hang driver creation forever. Jedis'
+     * completes the TCP handshake and then never answers would hang the first query forever. Jedis'
      * {@link Protocol#DEFAULT_TIMEOUT} is a deliberate reuse — the probe is a single round-trip, so
      * the same bound that is considered enough to establish a connection is enough to answer it.
      */
@@ -495,12 +495,19 @@ public class DriverImpl implements Driver {
      * across the Sentinel probe's network I/O, which pins a virtual thread's carrier — exactly what
      * the {@code pin-check} gate exists to prevent. Two threads racing here therefore both build a
      * pool and one is discarded, which is cheap and happens at most once per driver.
+     *
+     * <p>A closed driver never builds a pool. Without that check, borrowing from a driver that was
+     * closed before it was ever used would run the whole resolution — Sentinel probe included — only
+     * to hand back a pool it immediately closes: real network I/O after {@code close()}, reported as
+     * an exhausted-pool error rather than as the programming mistake it is. (A driver closed *after*
+     * being used keeps reporting that through Jedis, as it always has.)
      */
     private Pool<Jedis> pool() {
         Pool<Jedis> existing = resolvedPool.get();
         if (existing != null) {
             return existing;
         }
+        requireOpen();
         Pool<Jedis> created = poolFactory.get();
         if (!resolvedPool.compareAndSet(null, created)) {
             closeQuietly(created);
@@ -509,8 +516,16 @@ public class DriverImpl implements Driver {
         if (closed.get()) {
             // close() ran while this pool was being built; honour it rather than leak the pool.
             closeQuietly(created);
+            resolvedPool.compareAndSet(created, null);
+            requireOpen();
         }
         return created;
+    }
+
+    private void requireOpen() {
+        if (closed.get()) {
+            throw new IllegalStateException("the driver is closed");
+        }
     }
 
     private static void closeQuietly(Pool<Jedis> pool) {

--- a/src/main/java/com/falkordb/impl/api/DriverImpl.java
+++ b/src/main/java/com/falkordb/impl/api/DriverImpl.java
@@ -1,6 +1,7 @@
 package com.falkordb.impl.api;
 
 import com.falkordb.Driver;
+import com.falkordb.impl.ConnectionUris;
 import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -132,7 +133,11 @@ public class DriverImpl implements Driver {
      */
     private static void requireValidUri(URI uri) {
         if (!JedisURIHelper.isValid(uri)) {
-            throw new InvalidURIException(String.format("Cannot open Redis connection due invalid URI. %s", uri));
+            // Jedis' own message quotes the URI verbatim, which puts any embedded password into the
+            // message and every stack trace that carries it. Same reasoning as DriverEnvironment:
+            // the rejected value is worth reporting, its credentials are not.
+            throw new InvalidURIException(
+                    String.format("Cannot open Redis connection due invalid URI. %s", ConnectionUris.redact(uri)));
         }
     }
 

--- a/src/main/java/com/falkordb/impl/api/DriverImpl.java
+++ b/src/main/java/com/falkordb/impl/api/DriverImpl.java
@@ -501,6 +501,11 @@ public class DriverImpl implements Driver {
      * to hand back a pool it immediately closes: real network I/O after {@code close()}, reported as
      * an exhausted-pool error rather than as the programming mistake it is. (A driver closed *after*
      * being used keeps reporting that through Jedis, as it always has.)
+     *
+     * <p>{@code resolvedPool} is write-once: it goes from null to a pool and never back. That is what
+     * lets the loser of the race read the winner's pool without a retry and without ever seeing null.
+     * A pool closed underneath us stays published — the driver is closed, so reporting that through
+     * Jedis is the same thing that happens to a driver closed after being used.
      */
     private Pool<Jedis> pool() {
         Pool<Jedis> existing = resolvedPool.get();
@@ -514,10 +519,10 @@ public class DriverImpl implements Driver {
             return resolvedPool.get();
         }
         if (closed.get()) {
-            // close() ran while this pool was being built; honour it rather than leak the pool.
+            // close() ran while this pool was being built. If it read resolvedPool before the CAS
+            // above it saw nothing to close, so closing here is what prevents a leak; if it read
+            // after, it closed this pool already and doing so again is harmless.
             closeQuietly(created);
-            resolvedPool.compareAndSet(created, null);
-            requireOpen();
         }
         return created;
     }

--- a/src/main/java/com/falkordb/impl/api/DriverImpl.java
+++ b/src/main/java/com/falkordb/impl/api/DriverImpl.java
@@ -5,11 +5,16 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.jspecify.annotations.Nullable;
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisSentinelPool;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.SslOptions;
 import redis.clients.jedis.exceptions.InvalidURIException;
@@ -53,7 +58,29 @@ public class DriverImpl implements Driver {
      */
     public static final Duration DEFAULT_POOL_MAX_WAIT = GenericObjectPoolConfig.DEFAULT_MAX_WAIT;
 
-    private final Pool<Jedis> pool;
+    /**
+     * Read deadline for the one-shot Sentinel probe when the driver's own socket timeout is the
+     * default {@link #DEFAULT_SOCKET_TIMEOUT_MILLIS} (0 = no deadline). That default is right for
+     * graph queries, which may legitimately run for minutes, but wrong for a probe: an endpoint that
+     * completes the TCP handshake and then never answers would hang driver creation forever. Jedis'
+     * {@link Protocol#DEFAULT_TIMEOUT} is a deliberate reuse — the probe is a single round-trip, so
+     * the same bound that is considered enough to establish a connection is enough to answer it.
+     */
+    public static final int DEFAULT_SENTINEL_PROBE_TIMEOUT_MILLIS = Protocol.DEFAULT_TIMEOUT;
+
+    /**
+     * The pool actually in use. Resolved on first demand rather than in the constructor, because
+     * Sentinel {@linkplain Sentinels#detect detection} needs a round-trip and driver creation has
+     * always been I/O-free: a {@link JedisPool} connects lazily, so building a driver against a server
+     * that is not up yet has always been legal and must stay that way. See {@link #pool()}.
+     */
+    private final AtomicReference<Pool<Jedis>> resolvedPool = new AtomicReference<>();
+
+    /** Builds the pool the first time one is needed. */
+    private final Supplier<Pool<Jedis>> poolFactory;
+
+    /** Set by {@link #close()}, so a closed driver never silently rebuilds its pool. */
+    private final AtomicBoolean closed = new AtomicBoolean();
 
     /**
      * Creates a client running on the specific host/port
@@ -94,11 +121,19 @@ public class DriverImpl implements Driver {
      * with every other factory.
      */
     private static JedisPool uriPool(URI uri) {
+        requireValidUri(uri);
+        return new JedisPool(
+                new GenericObjectPoolConfig<Jedis>(), JedisURIHelper.getHostAndPort(uri), uriClientConfig(uri));
+    }
+
+    /**
+     * Rejects a URI Jedis would not accept, with the message Jedis' own URI-based pool constructor
+     * used before this driver assembled the client config itself.
+     */
+    private static void requireValidUri(URI uri) {
         if (!JedisURIHelper.isValid(uri)) {
             throw new InvalidURIException(String.format("Cannot open Redis connection due invalid URI. %s", uri));
         }
-        return new JedisPool(
-                new GenericObjectPoolConfig<Jedis>(), JedisURIHelper.getHostAndPort(uri), uriClientConfig(uri));
     }
 
     /**
@@ -118,6 +153,128 @@ public class DriverImpl implements Driver {
                 .database(JedisURIHelper.getDBIndex(uri))
                 .protocol(JedisURIHelper.getRedisProtocol(uri));
         return builder.build();
+    }
+
+    /**
+     * Connects to a seed host/port, transparently switching to Redis Sentinel per {@code sentinel}.
+     *
+     * <p>This is what the {@code com.falkordb.FalkorDB.driver(...)} factories call, and it is where
+     * Sentinel auto-detection lives. The {@link #DriverImpl(String, int) constructors} deliberately do
+     * not probe: they are pure wiring around a lazily-connecting {@link JedisPool}, and callers that
+     * hold one directly have already chosen their endpoint.
+     *
+     * @param host     server host
+     * @param port     server port
+     * @param user     username, or {@code null} for none
+     * @param password password, or {@code null} for none
+     * @param sentinel how to treat the endpoint with respect to Sentinel
+     * @return a new driver, backed by a direct or a failover-aware pool as {@code sentinel} dictates
+     */
+    public static Driver connect(
+            String host, int port, @Nullable String user, @Nullable String password, SentinelOptions sentinel) {
+        DefaultJedisClientConfig dataConfig = clientConfig(user, password);
+        HostAndPort seed = new HostAndPort(host, port);
+        return new DriverImpl(() -> resolvePool(seed, new GenericObjectPoolConfig<Jedis>(), dataConfig, sentinel));
+    }
+
+    /**
+     * Connects to a seed URI, transparently switching to Redis Sentinel per {@code sentinel}. The
+     * URI's credentials, database index and TLS scheme are carried over to the master connections.
+     *
+     * @param uri      server uri
+     * @param sentinel how to treat the endpoint with respect to Sentinel
+     * @return a new driver, backed by a direct or a failover-aware pool as {@code sentinel} dictates
+     * @throws InvalidURIException if the URI is not a valid Redis connection URI
+     */
+    public static Driver connect(URI uri, SentinelOptions sentinel) {
+        requireValidUri(uri);
+        HostAndPort seed = JedisURIHelper.getHostAndPort(uri);
+        DefaultJedisClientConfig dataConfig = uriClientConfig(uri);
+        return new DriverImpl(() -> resolvePool(seed, new GenericObjectPoolConfig<Jedis>(), dataConfig, sentinel));
+    }
+
+    /**
+     * Chooses the pool a seed endpoint should be served by.
+     *
+     * <p>Explicit configuration wins outright and never probes — the caller has already said what the
+     * deployment looks like, and can list more Sentinels than a single seed could reveal. Otherwise
+     * the endpoint is probed only if auto-detection is on, and anything less than a positive
+     * identification leaves us on the direct pool that every previous release would have built.
+     */
+    private static Pool<Jedis> resolvePool(
+            HostAndPort seed,
+            GenericObjectPoolConfig<Jedis> poolConfig,
+            DefaultJedisClientConfig dataConfig,
+            SentinelOptions sentinel) {
+        if (sentinel.isExplicit()) {
+            return Sentinels.pool(
+                    sentinel.masterName(),
+                    sentinel.addresses(),
+                    poolConfig,
+                    dataConfig,
+                    sentinelClientConfig(dataConfig, sentinel));
+        }
+        if (sentinel.isAutoDetect()) {
+            Pool<Jedis> detected = Sentinels.detect(
+                    seed,
+                    probeClientConfig(dataConfig, sentinel),
+                    poolConfig,
+                    dataConfig,
+                    sentinelClientConfig(dataConfig, sentinel));
+            if (detected != null) {
+                return detected;
+            }
+        }
+        return new JedisPool(poolConfig, seed, dataConfig);
+    }
+
+    /**
+     * The config used for connections to the Sentinels themselves: the data connections' transport
+     * settings (TLS and timeouts) with the Sentinel credentials substituted when they were given.
+     *
+     * <p>Rebuilt rather than reused even when the credentials are identical, because the data config
+     * may carry a database index — {@code driver(URI)} takes one from the URI's path — and Jedis
+     * issues {@code SELECT} for any non-zero index on every connection it opens, including the ones to
+     * the Sentinels. Sentinel implements no {@code SELECT}, and {@code JedisSentinelPool} reports the
+     * resulting error as the Sentinel being unreachable, so a perfectly healthy deployment would look
+     * dead. A Sentinel has no keyspace to select in any case.
+     *
+     * <p>The socket timeout is passed through untouched, including the default 0. {@link
+     * JedisSentinelPool}'s master listener holds a {@code SUBSCRIBE} on each Sentinel to learn about
+     * failovers, and a read deadline there would tear that subscription down and rebuild it on a
+     * timer. Bounding the read is the one-shot {@linkplain #probeClientConfig probe}'s job, not this
+     * connection's.
+     */
+    static DefaultJedisClientConfig sentinelClientConfig(
+            DefaultJedisClientConfig dataConfig, SentinelOptions sentinel) {
+        // Without Sentinel credentials, reuse the data ones as falkordb-go does, so the common
+        // single-ACL deployment needs no extra configuration.
+        boolean ownCredentials = sentinel.hasCredentials();
+        return buildClientConfig(
+                ownCredentials ? sentinel.user() : dataConfig.getUser(),
+                ownCredentials ? sentinel.password() : dataConfig.getPassword(),
+                dataConfig.getSslOptions() != null,
+                dataConfig.getConnectionTimeoutMillis(),
+                dataConfig.getSocketTimeoutMillis());
+    }
+
+    /**
+     * The config used for the one-shot detection probe: the Sentinel config with a read deadline
+     * forced on, so an endpoint that accepts connections but never answers cannot hang driver
+     * creation. An explicitly configured socket timeout is respected; the driver's default of "no
+     * deadline" is replaced by {@link #DEFAULT_SENTINEL_PROBE_TIMEOUT_MILLIS}.
+     */
+    static DefaultJedisClientConfig probeClientConfig(DefaultJedisClientConfig dataConfig, SentinelOptions sentinel) {
+        DefaultJedisClientConfig base = sentinelClientConfig(dataConfig, sentinel);
+        int socketTimeoutMillis = base.getSocketTimeoutMillis() > 0
+                ? base.getSocketTimeoutMillis()
+                : DEFAULT_SENTINEL_PROBE_TIMEOUT_MILLIS;
+        return buildClientConfig(
+                base.getUser(),
+                base.getPassword(),
+                base.getSslOptions() != null,
+                base.getConnectionTimeoutMillis(),
+                socketTimeoutMillis);
     }
 
     /**
@@ -167,6 +324,58 @@ public class DriverImpl implements Driver {
             int poolMaxTotal,
             int poolMaxIdle,
             Duration poolMaxWait) {
+        return create(
+                host,
+                port,
+                user,
+                password,
+                ssl,
+                connectionTimeoutMillis,
+                socketTimeoutMillis,
+                poolMaxTotal,
+                poolMaxIdle,
+                poolMaxWait,
+                SentinelOptions.autoDetect());
+    }
+
+    /**
+     * Creates a driver from already-resolved connection settings, including how to treat Redis
+     * Sentinel. This is the overload {@code FalkorDB.builder()} actually calls; the {@linkplain
+     * #create(String, int, String, String, boolean, int, int, int, int, Duration) shorter one}
+     * delegates here with {@linkplain SentinelOptions#autoDetect() auto-detection}, which is the
+     * builder's default.
+     *
+     * @param host                     server host (the seed endpoint, ignored when {@code sentinel} is
+     *                                 {@linkplain SentinelOptions#explicit explicit}, though still
+     *                                 range-checked)
+     * @param port                     server port
+     * @param user                     username, or {@code null} for none
+     * @param password                 password, or {@code null} for none
+     * @param ssl                      whether to connect over TLS
+     * @param connectionTimeoutMillis  connection (connect) timeout in milliseconds
+     * @param socketTimeoutMillis      socket (read) timeout in milliseconds ({@code 0} = no deadline)
+     * @param poolMaxTotal             maximum pool size
+     * @param poolMaxIdle              maximum idle connections in the pool
+     * @param poolMaxWait              maximum time to wait for a connection when the pool is exhausted
+     * @param sentinel                 how to treat the endpoint with respect to Sentinel
+     * @return a new driver backed by the assembled pool
+     * @throws IllegalArgumentException if {@code host} is null/blank, {@code port} is outside
+     *                                  {@code [1, 65535]}, the pool sizing is invalid, a timeout is
+     *                                  negative, {@code poolMaxWait} is null, or {@code sentinel} is
+     *                                  null or carries an unparseable address
+     */
+    public static Driver create(
+            String host,
+            int port,
+            String user,
+            String password,
+            boolean ssl,
+            int connectionTimeoutMillis,
+            int socketTimeoutMillis,
+            int poolMaxTotal,
+            int poolMaxIdle,
+            Duration poolMaxWait,
+            SentinelOptions sentinel) {
         if (host == null || host.trim().isEmpty()) {
             throw new IllegalArgumentException("host must not be null or blank");
         }
@@ -195,10 +404,14 @@ public class DriverImpl implements Driver {
         if (poolMaxWait == null) {
             throw new IllegalArgumentException("poolMaxWait must not be null");
         }
-        return new DriverImpl(new JedisPool(
-                buildPoolConfig(poolMaxTotal, poolMaxIdle, poolMaxWait),
-                new HostAndPort(normalizedHost, port),
-                buildClientConfig(user, password, ssl, connectionTimeoutMillis, socketTimeoutMillis)));
+        if (sentinel == null) {
+            throw new IllegalArgumentException("sentinel must not be null");
+        }
+        HostAndPort seed = new HostAndPort(normalizedHost, port);
+        GenericObjectPoolConfig<Jedis> poolConfig = buildPoolConfig(poolMaxTotal, poolMaxIdle, poolMaxWait);
+        DefaultJedisClientConfig dataConfig =
+                buildClientConfig(user, password, ssl, connectionTimeoutMillis, socketTimeoutMillis);
+        return new DriverImpl(() -> resolvePool(seed, poolConfig, dataConfig, sentinel));
     }
 
     /**
@@ -261,7 +474,51 @@ public class DriverImpl implements Driver {
      * @param pool jedis pool to wrap
      */
     public DriverImpl(Pool<Jedis> pool) {
-        this.pool = pool;
+        this.poolFactory = () -> pool;
+        this.resolvedPool.set(pool);
+    }
+
+    /**
+     * Creates a client whose pool is built on first use, so that Sentinel detection — which needs a
+     * round-trip — never happens while merely constructing a driver.
+     *
+     * @param poolFactory builds the pool the first time a connection is borrowed
+     */
+    private DriverImpl(Supplier<Pool<Jedis>> poolFactory) {
+        this.poolFactory = poolFactory;
+    }
+
+    /**
+     * The pool, building it on first demand.
+     *
+     * <p>Lock-free on purpose. The obvious {@code synchronized} memoisation would hold a monitor
+     * across the Sentinel probe's network I/O, which pins a virtual thread's carrier — exactly what
+     * the {@code pin-check} gate exists to prevent. Two threads racing here therefore both build a
+     * pool and one is discarded, which is cheap and happens at most once per driver.
+     */
+    private Pool<Jedis> pool() {
+        Pool<Jedis> existing = resolvedPool.get();
+        if (existing != null) {
+            return existing;
+        }
+        Pool<Jedis> created = poolFactory.get();
+        if (!resolvedPool.compareAndSet(null, created)) {
+            closeQuietly(created);
+            return resolvedPool.get();
+        }
+        if (closed.get()) {
+            // close() ran while this pool was being built; honour it rather than leak the pool.
+            closeQuietly(created);
+        }
+        return created;
+    }
+
+    private static void closeQuietly(Pool<Jedis> pool) {
+        try {
+            pool.close();
+        } catch (RuntimeException ignored) {
+            // Best-effort disposal of a pool that lost the creation race or was closed concurrently.
+        }
     }
 
     @Override
@@ -271,7 +528,7 @@ public class DriverImpl implements Driver {
 
     @Override
     public Jedis getConnection() {
-        return pool.getResource();
+        return pool().getResource();
     }
 
     /**
@@ -518,10 +775,15 @@ public class DriverImpl implements Driver {
     }
 
     /**
-     * Closes the Jedis pool
+     * Closes the Jedis pool. A driver whose pool was never built closes without building one, so
+     * creating and discarding a driver still performs no I/O.
      */
     @Override
     public void close() {
-        pool.close();
+        closed.set(true);
+        Pool<Jedis> existing = resolvedPool.get();
+        if (existing != null) {
+            existing.close();
+        }
     }
 }

--- a/src/main/java/com/falkordb/impl/api/DriverImpl.java
+++ b/src/main/java/com/falkordb/impl/api/DriverImpl.java
@@ -70,6 +70,14 @@ public class DriverImpl implements Driver {
     public static final int DEFAULT_SENTINEL_PROBE_TIMEOUT_MILLIS = Protocol.DEFAULT_TIMEOUT;
 
     /**
+     * Read deadline for the connections to the Sentinels themselves: none, whatever the data
+     * connections use. Once discovery is done, the only thing that connection does is hold a
+     * {@code SUBSCRIBE} open for {@code +switch-master}, so a socket timeout there bounds nothing —
+     * it just expires the subscription on a timer. See {@link #sentinelClientConfig}.
+     */
+    public static final int SENTINEL_SOCKET_TIMEOUT_MILLIS = 0;
+
+    /**
      * The pool actually in use. Resolved on first demand rather than in the constructor, because
      * Sentinel {@linkplain Sentinels#detect detection} needs a round-trip and driver creation has
      * always been I/O-free: a {@link JedisPool} connects lazily, so building a driver against a server
@@ -246,11 +254,14 @@ public class DriverImpl implements Driver {
      * resulting error as the Sentinel being unreachable, so a perfectly healthy deployment would look
      * dead. A Sentinel has no keyspace to select in any case.
      *
-     * <p>The socket timeout is passed through untouched, including the default 0. {@link
-     * JedisSentinelPool}'s master listener holds a {@code SUBSCRIBE} on each Sentinel to learn about
-     * failovers, and a read deadline there would tear that subscription down and rebuild it on a
-     * timer. Bounding the read is the one-shot {@linkplain #probeClientConfig probe}'s job, not this
-     * connection's.
+     * <p>The read deadline is forced off — {@link #SENTINEL_SOCKET_TIMEOUT_MILLIS} — rather than
+     * inherited. Once discovery is over, the only thing this connection does is hold {@link
+     * JedisSentinelPool}'s master listener {@code SUBSCRIBE}d to {@code +switch-master}, so a socket
+     * timeout of {@code T} bounds no request: it expires the subscription every {@code T}, and the
+     * listener responds by logging a warning and sleeping five seconds before resubscribing. A data
+     * socket timeout would therefore buy nothing and cost a permanent cycle of log noise and windows
+     * with nobody listening for failovers. Bounding the read is the one-shot {@linkplain
+     * #probeClientConfig probe}'s job, not this connection's.
      */
     static DefaultJedisClientConfig sentinelClientConfig(
             DefaultJedisClientConfig dataConfig, SentinelOptions sentinel) {
@@ -262,7 +273,7 @@ public class DriverImpl implements Driver {
                 ownCredentials ? sentinel.password() : dataConfig.getPassword(),
                 dataConfig.getSslOptions() != null,
                 dataConfig.getConnectionTimeoutMillis(),
-                dataConfig.getSocketTimeoutMillis());
+                SENTINEL_SOCKET_TIMEOUT_MILLIS);
     }
 
     /**
@@ -273,8 +284,10 @@ public class DriverImpl implements Driver {
      */
     static DefaultJedisClientConfig probeClientConfig(DefaultJedisClientConfig dataConfig, SentinelOptions sentinel) {
         DefaultJedisClientConfig base = sentinelClientConfig(dataConfig, sentinel);
-        int socketTimeoutMillis = base.getSocketTimeoutMillis() > 0
-                ? base.getSocketTimeoutMillis()
+        // Read the caller's choice off dataConfig, not off base: base's deadline is forced off for
+        // the subscription's sake, so deriving from it would silently ignore an explicit timeout.
+        int socketTimeoutMillis = dataConfig.getSocketTimeoutMillis() > 0
+                ? dataConfig.getSocketTimeoutMillis()
                 : DEFAULT_SENTINEL_PROBE_TIMEOUT_MILLIS;
         return buildClientConfig(
                 base.getUser(),

--- a/src/main/java/com/falkordb/impl/api/SentinelOptions.java
+++ b/src/main/java/com/falkordb/impl/api/SentinelOptions.java
@@ -1,0 +1,142 @@
+package com.falkordb.impl.api;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import org.jspecify.annotations.Nullable;
+import redis.clients.jedis.HostAndPort;
+
+/**
+ * Resolved Redis Sentinel settings for a driver, as gathered by {@code com.falkordb.FalkorDB}.
+ *
+ * <p>Internal wiring: it exists so {@link DriverImpl#create} keeps a readable signature instead of
+ * growing five more positional parameters, and it is public only because the {@code com.falkordb}
+ * factories live in another package. Users configure these through {@code FalkorDB.builder()}.
+ *
+ * <p>A value is in exactly one of three states:
+ *
+ * <ul>
+ *   <li>{@linkplain #explicit explicit} — the deployment is named up front, so no probing happens and
+ *       several Sentinels can be listed.
+ *   <li>{@linkplain #autoDetect() auto-detect} — the default: connect to whatever the caller gave,
+ *       and switch to Sentinel only if that endpoint turns out to be one.
+ *   <li>{@linkplain #disabled() disabled} — always connect directly, never probe.
+ * </ul>
+ *
+ * <p>Instances are immutable; {@link #withCredentials} returns a copy.
+ */
+public final class SentinelOptions {
+
+    private final boolean autoDetect;
+    private final @Nullable String masterName;
+    private final Set<HostAndPort> addresses;
+    private final @Nullable String user;
+    private final @Nullable String password;
+
+    private SentinelOptions(
+            boolean autoDetect,
+            @Nullable String masterName,
+            Set<HostAndPort> addresses,
+            @Nullable String user,
+            @Nullable String password) {
+        this.autoDetect = autoDetect;
+        this.masterName = masterName;
+        this.addresses = addresses;
+        this.user = user;
+        this.password = password;
+    }
+
+    /**
+     * Probe the endpoint the caller asked for and use Sentinel only if it turns out to be one. This is
+     * the default, and matches the other FalkorDB clients.
+     *
+     * @return auto-detecting options
+     */
+    public static SentinelOptions autoDetect() {
+        // A fresh instance rather than a shared constant: the class is immutable, but SpotBugs cannot
+        // see that through the Set field and flags handing the constant out (MS_EXPOSE_REP). Allocating
+        // once per driver is not worth suppressing a warning over.
+        return new SentinelOptions(true, null, Collections.<HostAndPort>emptySet(), null, null);
+    }
+
+    /**
+     * Never probe: connect directly to the endpoint the caller asked for.
+     *
+     * @return options with Sentinel support switched off
+     */
+    public static SentinelOptions disabled() {
+        return new SentinelOptions(false, null, Collections.<HostAndPort>emptySet(), null, null);
+    }
+
+    /**
+     * Connect through the named Sentinel deployment, without probing.
+     *
+     * <p>The addresses are parsed here rather than when the pool is eventually built, so a typo is
+     * reported by the call that contains it instead of by the first query minutes later. Only the
+     * network probe is deferred; validating static configuration needs no I/O and so is done eagerly.
+     *
+     * @param masterName name of the monitored master, as given to {@code sentinel monitor}
+     * @param addresses  the Sentinel endpoints in {@code host:port} form; must not be empty
+     * @return explicit Sentinel options
+     * @throws IllegalArgumentException if {@code masterName} is null or blank, or {@code addresses} is
+     *     null, empty, or contains an entry that is not a valid {@code host:port}
+     */
+    public static SentinelOptions explicit(@Nullable String masterName, @Nullable Collection<String> addresses) {
+        if (masterName == null || masterName.trim().isEmpty()) {
+            throw new IllegalArgumentException("sentinel master name must not be null or blank");
+        }
+        return new SentinelOptions(
+                false, masterName.trim(), Collections.unmodifiableSet(Sentinels.parseAddresses(addresses)), null, null);
+    }
+
+    /**
+     * Returns a copy authenticating to the Sentinels themselves with the given credentials. Sentinels
+     * commonly carry their own ACLs, separate from the data nodes'; when this is left unset the data
+     * credentials are reused, as falkordb-go does.
+     *
+     * @param user     Sentinel username, or {@code null} for password-only authentication
+     * @param password Sentinel password, or {@code null} for none
+     * @return a copy carrying these Sentinel credentials
+     */
+    public SentinelOptions withCredentials(@Nullable String user, @Nullable String password) {
+        return new SentinelOptions(autoDetect, masterName, addresses, user, password);
+    }
+
+    /** @return whether an unrecognised endpoint should be probed for Sentinel mode */
+    boolean isAutoDetect() {
+        return autoDetect;
+    }
+
+    /** @return whether the master and Sentinel addresses were configured explicitly */
+    boolean isExplicit() {
+        return masterName != null;
+    }
+
+    /** @return the configured master name, or {@code null} when not {@linkplain #isExplicit explicit} */
+    @Nullable
+    String masterName() {
+        return masterName;
+    }
+
+    /** @return the parsed Sentinel endpoints, empty when not {@linkplain #isExplicit explicit} */
+    Set<HostAndPort> addresses() {
+        return addresses;
+    }
+
+    /** @return the Sentinel username, or {@code null} to reuse the data credentials */
+    @Nullable
+    String user() {
+        return user;
+    }
+
+    /** @return the Sentinel password, or {@code null} to reuse the data credentials */
+    @Nullable
+    String password() {
+        return password;
+    }
+
+    /** @return whether Sentinel-specific credentials were set */
+    boolean hasCredentials() {
+        return user != null || password != null;
+    }
+}

--- a/src/main/java/com/falkordb/impl/api/SentinelOptions.java
+++ b/src/main/java/com/falkordb/impl/api/SentinelOptions.java
@@ -102,40 +102,68 @@ public final class SentinelOptions {
         return new SentinelOptions(autoDetect, masterName, addresses, user, password);
     }
 
-    /** @return whether an unrecognised endpoint should be probed for Sentinel mode */
+    /**
+     * Returns whether an unrecognised endpoint should be probed for Sentinel mode.
+     *
+     * @return whether an unrecognised endpoint should be probed for Sentinel mode
+     */
     boolean isAutoDetect() {
         return autoDetect;
     }
 
-    /** @return whether the master and Sentinel addresses were configured explicitly */
+    /**
+     * Returns whether the master and Sentinel addresses were configured explicitly.
+     *
+     * @return whether the master and Sentinel addresses were configured explicitly
+     */
     boolean isExplicit() {
         return masterName != null;
     }
 
-    /** @return the configured master name, or {@code null} when not {@linkplain #isExplicit explicit} */
+    /**
+     * Returns the configured master name.
+     *
+     * @return the master name, or {@code null} when not {@linkplain #isExplicit explicit}
+     */
     @Nullable
     String masterName() {
         return masterName;
     }
 
-    /** @return the parsed Sentinel endpoints, empty when not {@linkplain #isExplicit explicit} */
+    /**
+     * Returns the parsed Sentinel endpoints.
+     *
+     * @return the Sentinel endpoints, empty when not {@linkplain #isExplicit explicit}
+     */
     Set<HostAndPort> addresses() {
         return addresses;
     }
 
-    /** @return the Sentinel username, or {@code null} to reuse the data credentials */
+    /**
+     * Returns the username to authenticate with against the Sentinels.
+     *
+     * @return the Sentinel username, or {@code null} to reuse the data credentials
+     */
     @Nullable
     String user() {
         return user;
     }
 
-    /** @return the Sentinel password, or {@code null} to reuse the data credentials */
+    /**
+     * Returns the password to authenticate with against the Sentinels.
+     *
+     * @return the Sentinel password, or {@code null} to reuse the data credentials
+     */
     @Nullable
     String password() {
         return password;
     }
 
-    /** @return whether Sentinel-specific credentials were set */
+    /**
+     * Returns whether Sentinel-specific credentials were set.
+     *
+     * @return whether Sentinel-specific credentials were set
+     */
     boolean hasCredentials() {
         return user != null || password != null;
     }

--- a/src/main/java/com/falkordb/impl/api/Sentinels.java
+++ b/src/main/java/com/falkordb/impl/api/Sentinels.java
@@ -137,7 +137,7 @@ final class Sentinels {
         if (info == null) {
             return false;
         }
-        for (String line : info.split("\r\n|\n|\r")) {
+        for (String line : info.split("\r\n|\n|\r", -1)) {
             String trimmed = line.trim();
             if (trimmed.startsWith(REDIS_MODE_FIELD)) {
                 return SENTINEL_MODE.equalsIgnoreCase(

--- a/src/main/java/com/falkordb/impl/api/Sentinels.java
+++ b/src/main/java/com/falkordb/impl/api/Sentinels.java
@@ -26,12 +26,12 @@ import redis.clients.jedis.util.Pool;
  * take the single master reported by {@code SENTINEL MASTERS}), so pointing any FalkorDB client at a
  * Sentinel behaves the same way in every language.
  *
- * <p>Detection is deliberately best-effort. Driver creation used to perform no I/O at all — a {@link
- * redis.clients.jedis.JedisPool} connects lazily — so a probe that cannot reach the endpoint, or that
- * is refused {@code INFO} by an ACL, falls back to the ordinary direct pool and lets the failure
- * surface on first use exactly as it always did. Only once the endpoint has positively identified
- * itself as a Sentinel do problems become fatal: at that point a direct connection is certain to fail
- * on every graph command, so a clear error at construction beats a baffling one later.
+ * <p>Detection is deliberately best-effort. Driver creation performs no I/O — the pool, and so this
+ * probe, is resolved on first use — so a probe that cannot reach the endpoint, or that is refused
+ * {@code INFO} by an ACL, falls back to the ordinary direct pool and lets the failure surface exactly
+ * as it always did. Only once the endpoint has positively identified itself as a Sentinel do problems
+ * become fatal: at that point a direct connection is certain to fail on every graph command, so
+ * failing immediately with a clear error beats a baffling one later.
  */
 final class Sentinels {
 
@@ -53,7 +53,7 @@ final class Sentinels {
      *                       ordinary FalkorDB server
      * @param probeConfig    client config for the one-shot probe; unlike {@code sentinelConfig} this
      *                       must carry a bounded read timeout, so an endpoint that accepts the
-     *                       connection but never answers cannot hang driver creation
+     *                       connection but never answers cannot hang the first query
      * @param poolConfig     commons-pool2 sizing for the resulting pool
      * @param dataConfig     client config used for connections to the master (credentials, TLS, timeouts)
      * @param sentinelConfig client config used for connections to the Sentinels themselves

--- a/src/main/java/com/falkordb/impl/api/Sentinels.java
+++ b/src/main/java/com/falkordb/impl/api/Sentinels.java
@@ -1,0 +1,242 @@
+package com.falkordb.impl.api;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.jspecify.annotations.Nullable;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisClientConfig;
+import redis.clients.jedis.JedisSentinelPool;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.exceptions.JedisException;
+import redis.clients.jedis.util.Pool;
+
+/**
+ * Redis Sentinel support: recognising a Sentinel endpoint, resolving the master it monitors, and
+ * building the failover-aware pool that {@link DriverImpl} then holds like any other.
+ *
+ * <p>The auto-detection in {@link #detect} mirrors what the other FalkorDB clients do (falkordb-py,
+ * falkordb-go and falkordb-ts all probe {@code INFO server} for {@code redis_mode:sentinel}, then
+ * take the single master reported by {@code SENTINEL MASTERS}), so pointing any FalkorDB client at a
+ * Sentinel behaves the same way in every language.
+ *
+ * <p>Detection is deliberately best-effort. Driver creation used to perform no I/O at all — a {@link
+ * redis.clients.jedis.JedisPool} connects lazily — so a probe that cannot reach the endpoint, or that
+ * is refused {@code INFO} by an ACL, falls back to the ordinary direct pool and lets the failure
+ * surface on first use exactly as it always did. Only once the endpoint has positively identified
+ * itself as a Sentinel do problems become fatal: at that point a direct connection is certain to fail
+ * on every graph command, so a clear error at construction beats a baffling one later.
+ */
+final class Sentinels {
+
+    /** The {@code INFO server} field identifying the server's mode, and the value Sentinel reports. */
+    private static final String REDIS_MODE_FIELD = "redis_mode:";
+
+    private static final String SENTINEL_MODE = "sentinel";
+
+    /** The {@code SENTINEL MASTERS} reply field holding a monitored master's name. */
+    private static final String MASTER_NAME_FIELD = "name";
+
+    private Sentinels() {}
+
+    /**
+     * Detects whether {@code seed} is a Sentinel and, if so, builds a failover-aware pool for the
+     * master it monitors.
+     *
+     * @param seed           the endpoint the caller asked to connect to, which may be a Sentinel or an
+     *                       ordinary FalkorDB server
+     * @param probeConfig    client config for the one-shot probe; unlike {@code sentinelConfig} this
+     *                       must carry a bounded read timeout, so an endpoint that accepts the
+     *                       connection but never answers cannot hang driver creation
+     * @param poolConfig     commons-pool2 sizing for the resulting pool
+     * @param dataConfig     client config used for connections to the master (credentials, TLS, timeouts)
+     * @param sentinelConfig client config used for connections to the Sentinels themselves
+     * @return a {@link JedisSentinelPool} for the monitored master, or {@code null} when {@code seed}
+     *     is not a Sentinel or could not be probed — in which case the caller should connect directly
+     * @throws IllegalStateException if {@code seed} is a Sentinel but monitors anything other than
+     *     exactly one master, so no master name can be inferred
+     */
+    static @Nullable Pool<Jedis> detect(
+            HostAndPort seed,
+            JedisClientConfig probeConfig,
+            GenericObjectPoolConfig<Jedis> poolConfig,
+            JedisClientConfig dataConfig,
+            JedisClientConfig sentinelConfig) {
+        Jedis probe;
+        try {
+            // Opened outside the guarded region below because Jedis authenticates while constructing,
+            // so this can fail with an ACL error rather than a connection error. Failing to open the
+            // probe tells us nothing about the endpoint and so must fall back like any other failed
+            // probe -- in particular when Sentinel credentials were supplied for an endpoint that
+            // turns out to be an ordinary server and rejects them.
+            probe = new Jedis(seed, probeConfig);
+        } catch (JedisException ignored) {
+            return null;
+        }
+        List<Map<String, String>> masters;
+        try {
+            String info;
+            try {
+                info = probe.info("server");
+            } catch (JedisException ignored) {
+                // Unreachable, or INFO refused by an ACL: we cannot tell what this endpoint is, so
+                // leave the caller on the direct path it would have taken before Sentinel support.
+                return null;
+            }
+            if (!isSentinelInfo(info)) {
+                return null;
+            }
+            // Past this point the endpoint has named itself a Sentinel, so a failure is worth
+            // reporting: a direct connection would fail on every graph command anyway. Only losing the
+            // connection outright still falls back.
+            masters = probe.sentinelMasters();
+        } catch (JedisConnectionException ignored) {
+            return null;
+        } finally {
+            probe.close();
+        }
+        return pool(soleMasterName(masters), Collections.singleton(seed), poolConfig, dataConfig, sentinelConfig);
+    }
+
+    /**
+     * Builds a failover-aware pool for an explicitly configured Sentinel deployment.
+     *
+     * @param masterName     name of the monitored master, as given to {@code sentinel monitor}
+     * @param sentinels      the Sentinel endpoints to discover the master through; must not be empty
+     * @param poolConfig     commons-pool2 sizing for the resulting pool
+     * @param dataConfig     client config used for connections to the master
+     * @param sentinelConfig client config used for connections to the Sentinels themselves
+     * @return a pool that tracks the current master and follows failovers
+     */
+    static Pool<Jedis> pool(
+            String masterName,
+            Set<HostAndPort> sentinels,
+            GenericObjectPoolConfig<Jedis> poolConfig,
+            JedisClientConfig dataConfig,
+            JedisClientConfig sentinelConfig) {
+        return new JedisSentinelPool(masterName, sentinels, poolConfig, dataConfig, sentinelConfig);
+    }
+
+    /**
+     * Reads the {@code redis_mode} field of an {@code INFO server} reply. Parsed line-wise rather than
+     * with {@code contains("redis_mode:sentinel")} so that a value merely appearing somewhere else in
+     * the reply — a {@code config_file} path containing the word, say — cannot be mistaken for the
+     * mode. Redis separates INFO lines with CRLF; LF is accepted too so the parsing does not depend on
+     * it.
+     *
+     * @param info an {@code INFO server} reply, or {@code null}
+     * @return {@code true} if the reply reports {@code redis_mode:sentinel}
+     */
+    static boolean isSentinelInfo(@Nullable String info) {
+        if (info == null) {
+            return false;
+        }
+        for (String line : info.split("\r\n|\n|\r")) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith(REDIS_MODE_FIELD)) {
+                return SENTINEL_MODE.equalsIgnoreCase(
+                        trimmed.substring(REDIS_MODE_FIELD.length()).trim());
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Extracts the name of the one master a Sentinel monitors.
+     *
+     * <p>A Sentinel can monitor several masters, and then the endpoint alone does not say which one
+     * the caller meant — the other FalkorDB clients reject this case for the same reason. JFalkorDB
+     * can be told explicitly instead, so the message points at that escape hatch.
+     *
+     * @param masters the {@code SENTINEL MASTERS} reply
+     * @return the sole master's name
+     * @throws IllegalStateException if the Sentinel monitors zero or several masters, or if the reply
+     *     carries no usable name
+     */
+    static String soleMasterName(@Nullable List<Map<String, String>> masters) {
+        if (masters == null || masters.isEmpty()) {
+            throw new IllegalStateException("The Sentinel monitors no master, so there is nothing to connect to. "
+                    + "Configure the Sentinel with `sentinel monitor`, or name the master explicitly with "
+                    + "FalkorDB.builder().sentinel(masterName, sentinels...).");
+        }
+        if (masters.size() > 1) {
+            throw new IllegalStateException("The Sentinel monitors " + masters.size()
+                    + " masters " + names(masters) + ", so the master to connect to is ambiguous. "
+                    + "Name it explicitly with FalkorDB.builder().sentinel(masterName, sentinels...).");
+        }
+        String name = masters.get(0).get(MASTER_NAME_FIELD);
+        if (name == null || name.trim().isEmpty()) {
+            throw new IllegalStateException("The Sentinel reported a master without a name. "
+                    + "Name it explicitly with FalkorDB.builder().sentinel(masterName, sentinels...).");
+        }
+        return name.trim();
+    }
+
+    /** The monitored master names, for the ambiguity message above. */
+    private static List<String> names(List<Map<String, String>> masters) {
+        List<String> names = new ArrayList<>(masters.size());
+        for (Map<String, String> master : masters) {
+            names.add(master.get(MASTER_NAME_FIELD));
+        }
+        return names;
+    }
+
+    /**
+     * Parses {@code host:port} Sentinel addresses, preserving their order so the resulting set is
+     * tried in the order the caller listed them.
+     *
+     * @param addresses the addresses to parse; must not be empty and must not contain a blank entry
+     * @return the parsed endpoints
+     * @throws IllegalArgumentException if the collection is null/empty, or any entry is null, blank or
+     *     not a valid {@code host:port}
+     */
+    static Set<HostAndPort> parseAddresses(@Nullable Collection<String> addresses) {
+        if (addresses == null || addresses.isEmpty()) {
+            throw new IllegalArgumentException("at least one sentinel address is required");
+        }
+        Set<HostAndPort> parsed = new LinkedHashSet<>();
+        for (String address : addresses) {
+            parsed.add(parseAddress(address));
+        }
+        return parsed;
+    }
+
+    /**
+     * Parses a single {@code host:port} Sentinel address. Delegates the split to Jedis' own {@link
+     * HostAndPort#from} so bracketed IPv6 literals such as {@code [::1]:26379} are handled the same
+     * way Jedis handles them everywhere else, but reports failures as {@link IllegalArgumentException}
+     * naming the offending value, since this is user-supplied configuration.
+     *
+     * @param address the address to parse
+     * @return the parsed endpoint
+     * @throws IllegalArgumentException if the address is null, blank, or not a valid {@code host:port}
+     */
+    static HostAndPort parseAddress(@Nullable String address) {
+        if (address == null || address.trim().isEmpty()) {
+            throw new IllegalArgumentException("sentinel address must not be null or blank");
+        }
+        String trimmed = address.trim();
+        HostAndPort parsed;
+        try {
+            parsed = HostAndPort.from(trimmed);
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException(
+                    "sentinel address must be in host:port form, but was \"" + trimmed + "\"", e);
+        }
+        if (parsed.getHost() == null || parsed.getHost().trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "sentinel address must be in host:port form, but was \"" + trimmed + "\"");
+        }
+        if (parsed.getPort() < 1 || parsed.getPort() > 65535) {
+            throw new IllegalArgumentException(
+                    "sentinel port must be in [1, 65535], but was " + parsed.getPort() + " in \"" + trimmed + "\"");
+        }
+        return parsed;
+    }
+}

--- a/src/test/java/com/falkordb/ConfigBuilderTest.java
+++ b/src/test/java/com/falkordb/ConfigBuilderTest.java
@@ -4,9 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -158,5 +160,85 @@ class ConfigBuilderTest {
                 .connectionTimeout(Duration.ofNanos(500_000))
                 .build()
                 .close());
+    }
+
+    @Test
+    void sentinelSettersReturnSameBuilder() {
+        FalkorDB.Builder builder = FalkorDB.builder();
+        assertSame(builder, builder.sentinel("mymaster", "a:26379"));
+        assertSame(builder, builder.sentinel("mymaster", Collections.singletonList("a:26379")));
+        assertSame(builder, builder.sentinelCredentials("u", "p"));
+        assertSame(builder, builder.sentinelCredentials("p"));
+        assertSame(builder, builder.autoDetectSentinel(false));
+    }
+
+    @Test
+    void buildsAgainstAnExplicitSentinelDeployment() {
+        assertDoesNotThrow(() -> {
+            try (Driver driver = FalkorDB.builder()
+                    .sentinel("mymaster", "sentinel-a:26379", "sentinel-b:26379", "sentinel-c:26379")
+                    .credentials("user", "password")
+                    .sentinelCredentials("sentinel-user", "sentinel-password")
+                    .build()) {
+                assertNotNull(driver);
+            }
+        });
+    }
+
+    @Test
+    void sentinelBuildStaysLazy() {
+        // The whole point of resolving the pool on first use: naming a deployment that does not exist
+        // must not cost a DNS lookup or a connection attempt, exactly as a plain host/port build does
+        // not. If this ever regresses it will hang for the connect timeout rather than fail outright,
+        // so the assertion is on elapsed time.
+        long startedAt = System.nanoTime();
+        assertDoesNotThrow(() -> FalkorDB.builder()
+                .sentinel("mymaster", "sentinel-a.invalid:26379")
+                .build()
+                .close());
+        long elapsedMillis = (System.nanoTime() - startedAt) / 1_000_000L;
+
+        assertTrue(elapsedMillis < 1000, "building a driver must not connect, but took " + elapsedMillis + "ms");
+    }
+
+    @Test
+    void autoDetectingBuildStaysLazyToo() {
+        long startedAt = System.nanoTime();
+        assertDoesNotThrow(
+                () -> FalkorDB.builder().host("db.invalid").port(6380).build().close());
+        long elapsedMillis = (System.nanoTime() - startedAt) / 1_000_000L;
+
+        assertTrue(
+                elapsedMillis < 1000, "Sentinel detection must not run at build(), but took " + elapsedMillis + "ms");
+    }
+
+    @Test
+    void rejectsASentinelWithoutAMasterName() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FalkorDB.builder().sentinel(null, "a:26379").build());
+    }
+
+    @Test
+    void rejectsASentinelWithoutAddresses() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FalkorDB.builder().sentinel("mymaster").build());
+        assertThrows(IllegalArgumentException.class, () -> FalkorDB.builder()
+                .sentinel("mymaster", (java.util.Collection<String>) null)
+                .build());
+    }
+
+    @Test
+    void rejectsAMalformedSentinelAddress() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> FalkorDB.builder().sentinel("mymaster", "no-port-here").build());
+    }
+
+    @Test
+    void autoDetectionCanBeSwitchedOff() {
+        assertDoesNotThrow(
+                () -> FalkorDB.builder().autoDetectSentinel(false).build().close());
     }
 }

--- a/src/test/java/com/falkordb/ConfigBuilderTest.java
+++ b/src/test/java/com/falkordb/ConfigBuilderTest.java
@@ -1,14 +1,24 @@
 package com.falkordb;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -264,5 +274,62 @@ class ConfigBuilderTest {
         Driver driver = FalkorDB.builder().host("db.invalid").build();
         assertDoesNotThrow(driver::close);
         assertDoesNotThrow(driver::close);
+    }
+
+    @Test
+    void racingBorrowersAndCloseNeverSeeANullPool() throws Exception {
+        // Two borrowers race to resolve the pool while a third thread closes the driver. The loser of
+        // the resolution race must not read back a pool the winner has since withdrawn: doing so
+        // returns null and fails with a NullPointerException from deep inside getConnection() rather
+        // than saying the driver is closed. Failing to reach the server is expected here -- the host
+        // does not resolve -- so only the exception type is asserted.
+        ExecutorService threads = Executors.newFixedThreadPool(3);
+        try {
+            for (int attempt = 0; attempt < 40; attempt++) {
+                Driver driver = FalkorDB.builder()
+                        .host("db.invalid")
+                        .autoDetectSentinel(false)
+                        .build();
+                CyclicBarrier start = new CyclicBarrier(3);
+
+                List<Future<Throwable>> outcomes = new ArrayList<>();
+                for (int borrower = 0; borrower < 2; borrower++) {
+                    outcomes.add(threads.submit(() -> {
+                        start.await();
+                        try {
+                            driver.getConnection().close();
+                            return null;
+                        } catch (Throwable t) {
+                            return t;
+                        }
+                    }));
+                }
+                outcomes.add(threads.submit(() -> {
+                    start.await();
+                    driver.close();
+                    return null;
+                }));
+
+                for (Future<Throwable> outcome : outcomes) {
+                    Throwable thrown = outcome.get(30, TimeUnit.SECONDS);
+                    assertFalse(
+                            thrown instanceof NullPointerException,
+                            "a borrower racing close() saw a null pool: " + stackTraceOf(thrown));
+                }
+            }
+        } finally {
+            threads.shutdownNow();
+        }
+    }
+
+    private static String stackTraceOf(Throwable t) {
+        if (t == null) {
+            return "";
+        }
+        StringWriter out = new StringWriter();
+        try (PrintWriter writer = new PrintWriter(out)) {
+            t.printStackTrace(writer);
+        }
+        return out.toString();
     }
 }

--- a/src/test/java/com/falkordb/ConfigBuilderTest.java
+++ b/src/test/java/com/falkordb/ConfigBuilderTest.java
@@ -241,4 +241,28 @@ class ConfigBuilderTest {
         assertDoesNotThrow(
                 () -> FalkorDB.builder().autoDetectSentinel(false).build().close());
     }
+
+    @Test
+    void aDriverClosedBeforeUseFailsFastInsteadOfConnecting() {
+        // Resolving the pool lazily means a closed-but-never-used driver could otherwise run the whole
+        // resolution -- Sentinel probe included -- just to hand back a pool it immediately closes.
+        // That would be real network I/O after close(), surfacing as a pool error rather than as the
+        // programming mistake it is. The host is unroutable, so the elapsed time also shows that no
+        // connection was attempted.
+        Driver driver = FalkorDB.builder().host("db.invalid").build();
+        assertDoesNotThrow(driver::close);
+
+        long startedAt = System.nanoTime();
+        assertThrows(IllegalStateException.class, driver::getConnection);
+        long elapsedMillis = (System.nanoTime() - startedAt) / 1_000_000L;
+
+        assertTrue(elapsedMillis < 1000, "a closed driver must not connect, but took " + elapsedMillis + "ms");
+    }
+
+    @Test
+    void closingADriverTwiceIsHarmless() {
+        Driver driver = FalkorDB.builder().host("db.invalid").build();
+        assertDoesNotThrow(driver::close);
+        assertDoesNotThrow(driver::close);
+    }
 }

--- a/src/test/java/com/falkordb/DriverEnvironmentTest.java
+++ b/src/test/java/com/falkordb/DriverEnvironmentTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -256,5 +257,74 @@ class DriverEnvironmentTest {
             t.printStackTrace(writer);
         }
         return out.toString();
+    }
+
+    @Test
+    void sentinelVariablesConfigureASentinelDeployment() {
+        assertDoesNotThrow(() -> DriverEnvironment.resolve(env(
+                        DriverEnvironment.SENTINEL_MASTER_VAR, "mymaster",
+                        DriverEnvironment.SENTINELS_VAR, "a:26379,b:26379"))
+                .close());
+    }
+
+    @Test
+    void onlySentinelMasterSetThrows() {
+        IllegalStateException e = assertThrows(
+                IllegalStateException.class,
+                () -> DriverEnvironment.resolve(env(DriverEnvironment.SENTINEL_MASTER_VAR, "mymaster")));
+        assertTrue(e.getMessage().contains(DriverEnvironment.SENTINELS_VAR), e.getMessage());
+    }
+
+    @Test
+    void onlySentinelListSetThrows() {
+        IllegalStateException e = assertThrows(
+                IllegalStateException.class,
+                () -> DriverEnvironment.resolve(env(DriverEnvironment.SENTINELS_VAR, "a:26379")));
+        assertTrue(e.getMessage().contains(DriverEnvironment.SENTINEL_MASTER_VAR), e.getMessage());
+    }
+
+    @Test
+    void blankSentinelVariablesAreTreatedAsUnset() {
+        // Same rule as the host/port pair: a whitespace-only value must not trip the pairing check.
+        assertDoesNotThrow(() -> DriverEnvironment.resolve(env(
+                        DriverEnvironment.SENTINEL_MASTER_VAR, "  ",
+                        DriverEnvironment.SENTINELS_VAR, "   "))
+                .close());
+    }
+
+    @Test
+    void sentinelTakesPrecedenceOverUrlAndHostPort() {
+        // A malformed URL alongside a valid Sentinel configuration must not be reached at all, which
+        // is what proves the ordering rather than merely that both happen to work.
+        assertDoesNotThrow(() -> DriverEnvironment.resolve(env(
+                        DriverEnvironment.SENTINEL_MASTER_VAR, "mymaster",
+                        DriverEnvironment.SENTINELS_VAR, "a:26379",
+                        DriverEnvironment.URL_VAR, "not a uri at all",
+                        DriverEnvironment.HOST_VAR, "db.example.com"))
+                .close());
+    }
+
+    @Test
+    void sentinelListIsSplitTrimmedAndTolerantOfEmptyEntries() {
+        assertEquals(
+                Arrays.asList("a:26379", "b:26380", "c:26381"),
+                DriverEnvironment.parseSentinels(" a:26379 , b:26380,,c:26381 , "));
+    }
+
+    @Test
+    void sentinelListWithNoAddressesThrows() {
+        IllegalStateException e =
+                assertThrows(IllegalStateException.class, () -> DriverEnvironment.parseSentinels(",  ,"));
+        assertTrue(e.getMessage().contains(DriverEnvironment.SENTINELS_VAR), e.getMessage());
+    }
+
+    @Test
+    void malformedSentinelAddressIsRejected() {
+        // Address validation is the builder's, so this also pins that the env path routes through it.
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DriverEnvironment.resolve(env(
+                        DriverEnvironment.SENTINEL_MASTER_VAR, "mymaster",
+                        DriverEnvironment.SENTINELS_VAR, "no-port-here")));
     }
 }

--- a/src/test/java/com/falkordb/SentinelIT.java
+++ b/src/test/java/com/falkordb/SentinelIT.java
@@ -240,11 +240,15 @@ public class SentinelIT {
     }
 
     private static String redisCli(GenericContainer<?> container, int port, String... arguments) throws Exception {
-        String[] command = new String[arguments.length + 3];
+        String[] command = new String[arguments.length + 4];
         command[0] = "redis-cli";
         command[1] = "-p";
         command[2] = Integer.toString(port);
-        System.arraycopy(arguments, 0, command, 3, arguments.length);
+        // --raw keeps multi-bulk replies as plain newline-separated values. redis-cli already does
+        // that when its output is not a terminal, which is the case here, but saying so explicitly
+        // means the parsing below does not silently depend on that detection.
+        command[3] = "--raw";
+        System.arraycopy(arguments, 0, command, 4, arguments.length);
         Container.ExecResult result = container.execInContainer(command);
         if (result.getExitCode() != 0) {
             throw new IllegalStateException("redis-cli failed: " + result.getStderr());

--- a/src/test/java/com/falkordb/SentinelIT.java
+++ b/src/test/java/com/falkordb/SentinelIT.java
@@ -212,7 +212,7 @@ public class SentinelIT {
         } catch (Exception e) {
             throw new IllegalStateException("could not ask the Sentinel for the master address", e);
         }
-        String[] lines = address.trim().split("\\s+");
+        String[] lines = address.trim().split("\\s+", -1);
         assertTrue(lines.length >= 2, "unexpected Sentinel reply: " + address);
 
         try (Socket socket = new Socket()) {
@@ -229,14 +229,26 @@ public class SentinelIT {
         String lastSeen = "";
         while (System.nanoTime() < deadline) {
             lastSeen = redisCli(sentinelContainer, SENTINEL_PORT, "SENTINEL", "master", MASTER_NAME);
-            // `flags` degrades to s_down/o_down while Sentinel is still making up its mind about a
-            // master it has just been pointed at; only `master` on its own means it is usable.
-            if (lastSeen.contains("master") && !lastSeen.contains("_down")) {
+            // Exactly "master": the reply also contains the master's *name*, so a substring test would
+            // match `mymaster`, and `flags` degrades to values like `master,disconnected` or
+            // `s_down,master` while Sentinel is still making up its mind about a master it has just
+            // been pointed at. Only a bare `master` means it is usable.
+            if ("master".equals(fieldsOf(lastSeen).get("flags"))) {
                 return;
             }
             Thread.sleep(250);
         }
         throw new IllegalStateException("the Sentinel never reported a healthy master. Last reply:\n" + lastSeen);
+    }
+
+    /** Reads a {@code SENTINEL master} reply, which {@code --raw} renders as alternating field/value lines. */
+    private static Map<String, String> fieldsOf(String reply) {
+        String[] lines = reply.split("\n", -1);
+        Map<String, String> fields = new HashMap<>();
+        for (int i = 0; i + 1 < lines.length; i += 2) {
+            fields.put(lines[i].trim(), lines[i + 1].trim());
+        }
+        return fields;
     }
 
     private static String redisCli(GenericContainer<?> container, int port, String... arguments) throws Exception {

--- a/src/test/java/com/falkordb/SentinelIT.java
+++ b/src/test/java/com/falkordb/SentinelIT.java
@@ -1,0 +1,260 @@
+package com.falkordb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Connects through a real Redis Sentinel deployment.
+ *
+ * <p>The unit tests around {@code Sentinels} cover the parsing and the decision logic against
+ * synthetic replies, which is where the interesting edge cases are, but they cannot show that the
+ * driver actually reaches a master through a Sentinel: that depends on Jedis' {@code
+ * JedisSentinelPool}, on the client configs the driver derives for the data and Sentinel connections,
+ * and on Sentinel answering {@code INFO} and {@code SENTINEL MASTERS} the way detection assumes. This
+ * test runs the whole path against a master, a replica and a Sentinel monitoring them.
+ *
+ * <p>Writing (rather than reading) through the resolved pool is the point of the assertions: the
+ * topology contains a read-only replica, so a write proves the driver landed on the master
+ * specifically, which a read would not.
+ */
+public class SentinelIT {
+
+    private static final String MASTER_NETWORK_ALIAS = "master";
+    private static final String MASTER_NAME = "mymaster";
+    private static final int SENTINEL_PORT = 26379;
+    private static final Duration SENTINEL_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration REACHABILITY_TIMEOUT = Duration.ofSeconds(2);
+
+    private static Network network;
+    private static GenericContainer<?> masterContainer;
+    private static GenericContainer<?> replicaContainer;
+    private static GenericContainer<?> sentinelContainer;
+
+    private static String sentinelHost;
+    private static int sentinelPort;
+
+    @BeforeAll
+    static void startSentinelDeployment() throws Exception {
+        // Like ReplicaReadIT, this topology cannot be served by an external FALKORDB_HOST/FALKORDB_PORT
+        // server: it needs three servers wired together on a shared network.
+        Assumptions.assumeFalse(
+                TestServer.isExternal(), "the Sentinel topology requires Testcontainers, not an external server");
+
+        DockerImageName image = FalkorDbImage.resolve(FalkorDbImage.pickOverride(
+                System.getProperty("FALKORDB_IMAGE"), () -> System.getenv("FALKORDB_IMAGE")));
+
+        network = Network.newNetwork();
+        masterContainer = new GenericContainer<>(image)
+                .withExposedPorts(6379)
+                .withNetwork(network)
+                .withNetworkAliases(MASTER_NETWORK_ALIAS)
+                .waitingFor(Wait.forListeningPort());
+        masterContainer.start();
+
+        replicaContainer = new GenericContainer<>(image)
+                .withExposedPorts(6379)
+                .withNetwork(network)
+                .waitingFor(Wait.forListeningPort());
+        replicaContainer.start();
+        redisCli(replicaContainer, 6379, "REPLICAOF", MASTER_NETWORK_ALIAS, "6379");
+
+        sentinelContainer = new GenericContainer<>(image)
+                .withExposedPorts(SENTINEL_PORT)
+                .withNetwork(network)
+                // Sentinel rewrites its own configuration in place as it learns the topology, so the
+                // file has to be writable and to live somewhere writable (`dir /tmp` below).
+                .withCopyToContainer(Transferable.of(sentinelConfiguration(), 0666), "/tmp/sentinel.conf")
+                // The image's entrypoint script starts a FalkorDB server and ignores the command, so it
+                // has to be replaced outright rather than merely overridden with withCommand.
+                .withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint("redis-sentinel"))
+                .withCommand("/tmp/sentinel.conf")
+                .waitingFor(Wait.forListeningPort());
+        sentinelContainer.start();
+
+        sentinelHost = sentinelContainer.getHost();
+        sentinelPort = sentinelContainer.getMappedPort(SENTINEL_PORT);
+
+        awaitMonitoredMaster();
+    }
+
+    @AfterAll
+    static void stopSentinelDeployment() {
+        stopQuietly(sentinelContainer);
+        stopQuietly(replicaContainer);
+        stopQuietly(masterContainer);
+        if (network != null) {
+            network.close();
+        }
+    }
+
+    /**
+     * {@code resolve-hostnames} lets the deployment be described by its Docker network alias instead of
+     * an address that is only known once the container is running. The quorum is 1 because there is a
+     * single Sentinel here; failover behaviour is Sentinel's business, not the driver's.
+     */
+    private static String sentinelConfiguration() {
+        return "port " + SENTINEL_PORT + "\n"
+                + "dir /tmp\n"
+                + "sentinel resolve-hostnames yes\n"
+                + "sentinel monitor " + MASTER_NAME + " " + MASTER_NETWORK_ALIAS + " 6379 1\n"
+                + "sentinel down-after-milliseconds " + MASTER_NAME + " 5000\n"
+                + "sentinel failover-timeout " + MASTER_NAME + " 10000\n";
+    }
+
+    @Test
+    public void pointingTheDriverAtASentinelFindsTheMaster() throws Exception {
+        assumeMasterIsReachableFromHere();
+
+        // No Sentinel configuration at all: just the address of a Sentinel, which is the whole point of
+        // auto-detection and matches how falkordb-py, falkordb-go and falkordb-ts behave.
+        try (Driver driver = FalkorDB.driver(sentinelHost, sentinelPort)) {
+            assertWritesReachTheMaster(driver, "sentinel-it-auto");
+        }
+    }
+
+    @Test
+    public void anExplicitlyConfiguredSentinelFindsTheMaster() throws Exception {
+        assumeMasterIsReachableFromHere();
+
+        try (Driver driver = FalkorDB.builder()
+                .sentinel(MASTER_NAME, sentinelHost + ":" + sentinelPort)
+                .build()) {
+            assertWritesReachTheMaster(driver, "sentinel-it-explicit");
+        }
+    }
+
+    @Test
+    public void theSentinelEnvironmentVariablesConfigureADriver() throws Exception {
+        assumeMasterIsReachableFromHere();
+
+        Map<String, String> environment = new HashMap<>();
+        environment.put(DriverEnvironment.SENTINEL_MASTER_VAR, MASTER_NAME);
+        environment.put(DriverEnvironment.SENTINELS_VAR, sentinelHost + ":" + sentinelPort);
+
+        try (Driver driver = DriverEnvironment.resolve(environment::get)) {
+            assertWritesReachTheMaster(driver, "sentinel-it-env");
+        }
+    }
+
+    @Test
+    public void autoDetectionCanBeTurnedOff() throws Exception {
+        // The opt-out has to be observable, otherwise it is decoration. With detection disabled the
+        // driver talks to the Sentinel directly, and a Sentinel does not implement GRAPH.QUERY — so the
+        // query must fail. This is also the behaviour every release before Sentinel support had.
+        try (Driver driver = FalkorDB.builder()
+                .host(sentinelHost)
+                .port(sentinelPort)
+                .autoDetectSentinel(false)
+                .build()) {
+            try (Graph graph = driver.graph("sentinel-it-optout")) {
+                assertThrows(RuntimeException.class, () -> graph.query("CREATE (:N {v:1})"));
+            }
+        }
+    }
+
+    /**
+     * Writes through {@code driver} and confirms on the master container itself that the graph landed
+     * there. Checking the key on the master, rather than reading it back through the same driver, is
+     * what actually pins the routing: a read would be satisfied by whichever server the driver happened
+     * to pick.
+     */
+    private static void assertWritesReachTheMaster(Driver driver, String graphName) {
+        try (Graph graph = driver.graph(graphName)) {
+            ResultSet created =
+                    graph.query("CREATE (:Sentinel {name:$name})", Collections.singletonMap("name", graphName));
+            assertEquals(1, created.getStatistics().nodesCreated());
+
+            ResultSet read = graph.readOnlyQuery("MATCH (n:Sentinel) RETURN n.name");
+            assertEquals(1, read.size());
+            assertEquals(graphName, read.iterator().next().getValue(0));
+        }
+
+        try {
+            assertEquals(
+                    "1",
+                    redisCli(masterContainer, 6379, "EXISTS", graphName).trim(),
+                    "the graph was not written to the master");
+        } catch (Exception e) {
+            throw new IllegalStateException("could not check the master for " + graphName, e);
+        }
+    }
+
+    /**
+     * Sentinel reports the master by its address on the Docker network. That address is routable from
+     * the host on Linux (where CI runs this for real) but not through the VM that backs Docker Desktop
+     * on macOS or Windows, where no amount of port mapping helps because the address comes from the
+     * Sentinel rather than from Testcontainers. Rather than silently passing a test that never
+     * connected, skip when the address cannot be reached.
+     */
+    private static void assumeMasterIsReachableFromHere() {
+        String address;
+        try {
+            address = redisCli(sentinelContainer, SENTINEL_PORT, "SENTINEL", "get-master-addr-by-name", MASTER_NAME);
+        } catch (Exception e) {
+            throw new IllegalStateException("could not ask the Sentinel for the master address", e);
+        }
+        String[] lines = address.trim().split("\\s+");
+        assertTrue(lines.length >= 2, "unexpected Sentinel reply: " + address);
+
+        try (Socket socket = new Socket()) {
+            socket.connect(
+                    new InetSocketAddress(lines[0], Integer.parseInt(lines[1])), (int) REACHABILITY_TIMEOUT.toMillis());
+        } catch (IOException | RuntimeException unreachable) {
+            Assumptions.abort("the Sentinel-reported master address " + lines[0] + ":" + lines[1]
+                    + " is not routable from this host (expected on Docker Desktop; CI runs this on Linux)");
+        }
+    }
+
+    private static void awaitMonitoredMaster() throws Exception {
+        long deadline = System.nanoTime() + SENTINEL_TIMEOUT.toNanos();
+        String lastSeen = "";
+        while (System.nanoTime() < deadline) {
+            lastSeen = redisCli(sentinelContainer, SENTINEL_PORT, "SENTINEL", "master", MASTER_NAME);
+            // `flags` degrades to s_down/o_down while Sentinel is still making up its mind about a
+            // master it has just been pointed at; only `master` on its own means it is usable.
+            if (lastSeen.contains("master") && !lastSeen.contains("_down")) {
+                return;
+            }
+            Thread.sleep(250);
+        }
+        throw new IllegalStateException("the Sentinel never reported a healthy master. Last reply:\n" + lastSeen);
+    }
+
+    private static String redisCli(GenericContainer<?> container, int port, String... arguments) throws Exception {
+        String[] command = new String[arguments.length + 3];
+        command[0] = "redis-cli";
+        command[1] = "-p";
+        command[2] = Integer.toString(port);
+        System.arraycopy(arguments, 0, command, 3, arguments.length);
+        Container.ExecResult result = container.execInContainer(command);
+        if (result.getExitCode() != 0) {
+            throw new IllegalStateException("redis-cli failed: " + result.getStderr());
+        }
+        return result.getStdout();
+    }
+
+    private static void stopQuietly(GenericContainer<?> container) {
+        if (container != null) {
+            container.stop();
+        }
+    }
+}

--- a/src/test/java/com/falkordb/impl/ConnectionUrisTest.java
+++ b/src/test/java/com/falkordb/impl/ConnectionUrisTest.java
@@ -53,6 +53,36 @@ class ConnectionUrisTest {
     }
 
     @Test
+    void redactsAPasswordContainingAnUnescapedAtSign() {
+        // The leak this guards: matching only to the *first* '@' ends the redaction inside the
+        // password and republishes everything after it. A password with a literal '@' is also exactly
+        // the value a URI parser rejects, so it is the one most likely to reach an error message.
+        assertEquals("redis://<redacted>@localhost:6379", ConnectionUris.redact("redis://someone:p@ss@localhost:6379"));
+        assertEquals(
+                "redis://<redacted>@localhost:6379", ConnectionUris.redact("redis://someone:s3c@ret@localhost:6379"));
+    }
+
+    @Test
+    void redactsEveryAtSignInTheAuthorityNotJustTheFirstTwo() {
+        assertEquals(
+                "rediss://<redacted>@localhost:6379/2", ConnectionUris.redact("rediss://u:p@w@d@localhost:6379/2"));
+    }
+
+    @Test
+    void redactsAnAtSignRiddledPasswordWithNoScheme() {
+        assertEquals("<redacted>@localhost:6379", ConnectionUris.redact("someone:p@ss@localhost:6379"));
+    }
+
+    @Test
+    void stopsAtTheAuthorityEvenWhenThePasswordAlsoContainsAnAtSign() {
+        // The greedy match must still not cross into the path: /?# bound it, so the last '@' it can
+        // reach is the one ending the authority.
+        assertEquals(
+                "redis://<redacted>@localhost:6379/graph@2",
+                ConnectionUris.redact("redis://someone:p@ss@localhost:6379/graph@2"));
+    }
+
+    @Test
     void redactsAUriObject() {
         assertEquals(
                 "redis://<redacted>@localhost:6379",

--- a/src/test/java/com/falkordb/impl/ConnectionUrisTest.java
+++ b/src/test/java/com/falkordb/impl/ConnectionUrisTest.java
@@ -1,0 +1,68 @@
+package com.falkordb.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ConnectionUris}. This redaction is the only thing standing between a
+ * mistyped connection string and a password in a bug report, so the boundaries are worth pinning
+ * directly rather than only through the callers that happen to use it today.
+ */
+class ConnectionUrisTest {
+
+    @Test
+    void redactsCredentialsAfterTheScheme() {
+        assertEquals(
+                "redis://<redacted>@localhost:6379", ConnectionUris.redact("redis://someone:hunter2@localhost:6379"));
+    }
+
+    @Test
+    void redactsCredentialsWithNoScheme() {
+        // A value that never made it as far as a scheme is still a value someone typed a password
+        // into, so the anchor has to cover the start of the string as well as "://".
+        assertEquals("<redacted>@localhost:6379", ConnectionUris.redact("someone:hunter2@localhost:6379"));
+    }
+
+    @Test
+    void leavesAUriWithoutCredentialsAlone() {
+        assertEquals("redis://localhost:6379/0", ConnectionUris.redact("redis://localhost:6379/0"));
+    }
+
+    @Test
+    void doesNotSwallowTheUriBecauseOfAnAtSignAfterTheAuthority() {
+        // Excluding /?# from the match keeps a later '@' from anchoring a redaction that would eat the
+        // host too, turning a helpful message into an unreadable one.
+        assertEquals("redis://localhost:6379/graph@2", ConnectionUris.redact("redis://localhost:6379/graph@2"));
+        assertEquals("redis://localhost:6379?tag=a@b", ConnectionUris.redact("redis://localhost:6379?tag=a@b"));
+    }
+
+    @Test
+    void redactsTheAuthorityEvenWhenAPathAlsoContainsAnAtSign() {
+        assertEquals(
+                "redis://<redacted>@localhost:6379/graph@2",
+                ConnectionUris.redact("redis://someone:hunter2@localhost:6379/graph@2"));
+    }
+
+    @Test
+    void redactsAMalformedValueThatNoUriParserWouldAccept() {
+        // The malformed ones matter most: they are the values that get rejected, and rejection is what
+        // produces the message that would carry the password.
+        assertEquals("redis://<redacted>@:::not a uri", ConnectionUris.redact("redis://someone:hunter2@:::not a uri"));
+    }
+
+    @Test
+    void redactsAUriObject() {
+        assertEquals(
+                "redis://<redacted>@localhost:6379",
+                ConnectionUris.redact(URI.create("redis://someone:hunter2@localhost:6379")));
+    }
+
+    @Test
+    void describesANullUriWithoutThrowing() {
+        // Redaction runs on failure paths; throwing a NullPointerException while building an error
+        // message would replace a useful diagnostic with a useless one.
+        assertEquals("null", ConnectionUris.redact((URI) null));
+    }
+}

--- a/src/test/java/com/falkordb/impl/ConnectionUrisTest.java
+++ b/src/test/java/com/falkordb/impl/ConnectionUrisTest.java
@@ -65,4 +65,11 @@ class ConnectionUrisTest {
         // message would replace a useful diagnostic with a useless one.
         assertEquals("null", ConnectionUris.redact((URI) null));
     }
+
+    @Test
+    void describesANullStringWithoutThrowing() {
+        // Same reasoning, and the two overloads have to agree: an overload that throws where its twin
+        // returns is a trap for the next caller, who will not check which one they picked.
+        assertEquals("null", ConnectionUris.redact((String) null));
+    }
 }

--- a/src/test/java/com/falkordb/impl/api/DriverConfigTest.java
+++ b/src/test/java/com/falkordb/impl/api/DriverConfigTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.time.Duration;
@@ -165,5 +166,18 @@ class DriverConfigTest {
         // Preserves the exception Jedis' own URI-based pool constructor raised before we assembled
         // the client config ourselves.
         assertThrows(InvalidURIException.class, () -> new DriverImpl(URI.create("http://localhost:6379")));
+    }
+
+    @Test
+    void rejectingAnInvalidUriDoesNotLeakItsCredentials() {
+        // The URIs most likely to be rejected are hand-written ones, and a hand-written connection URI
+        // is exactly where a password sits. Jedis' message quotes the whole URI, so reporting it
+        // verbatim would put the password into every log and crash report carrying this exception.
+        InvalidURIException e = assertThrows(
+                InvalidURIException.class, () -> new DriverImpl(URI.create("http://someone:hunter2@localhost:6379/0")));
+        assertFalse(e.getMessage().contains("hunter2"), "the password must not survive into the message");
+        assertFalse(e.getMessage().contains("someone"), "the username must not survive into the message");
+        assertTrue(e.getMessage().contains("<redacted>"), "the credentials should be visibly elided");
+        assertTrue(e.getMessage().contains("localhost:6379"), "the part worth debugging should survive");
     }
 }

--- a/src/test/java/com/falkordb/impl/api/SentinelClientConfigTest.java
+++ b/src/test/java/com/falkordb/impl/api/SentinelClientConfigTest.java
@@ -1,0 +1,141 @@
+package com.falkordb.impl.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.DefaultJedisClientConfig;
+
+/**
+ * Unit tests for the two derived client configs Sentinel support needs: the long-lived connection to
+ * the Sentinels (which carries the failover subscription) and the one-shot detection probe. No server
+ * is required.
+ */
+class SentinelClientConfigTest {
+
+    private static DefaultJedisClientConfig dataConfig(boolean ssl, int connectMillis, int socketMillis) {
+        return DriverImpl.buildClientConfig("alice", "s3cret", ssl, connectMillis, socketMillis);
+    }
+
+    @Test
+    void sentinelConfigReusesTheDataCredentialsWhenNoSentinelCredentialsAreSet() {
+        DefaultJedisClientConfig data = dataConfig(false, 2000, 0);
+        DefaultJedisClientConfig sentinel = DriverImpl.sentinelClientConfig(data, SentinelOptions.autoDetect());
+
+        // With no Sentinel ACL of its own, the single-ACL deployment needs no extra configuration at
+        // all (this is what falkordb-go does).
+        assertEquals("alice", sentinel.getUser());
+        assertEquals("s3cret", sentinel.getPassword());
+        assertEquals(2000, sentinel.getConnectionTimeoutMillis());
+    }
+
+    @Test
+    void sentinelConfigNeverCarriesADatabaseIndex() {
+        // driver(URI) takes a database index from the URI's path, and Jedis sends SELECT for any
+        // non-zero index on every connection it opens -- including the ones to the Sentinels, which
+        // implement no SELECT. JedisSentinelPool reports the resulting error as the Sentinel being
+        // down, so a healthy deployment would look dead. Reusing the data config verbatim here, which
+        // is the obvious implementation, is exactly what causes that.
+        DefaultJedisClientConfig data = DefaultJedisClientConfig.builder()
+                .user("alice")
+                .password("s3cret")
+                .database(7)
+                .build();
+
+        assertEquals(
+                0,
+                DriverImpl.sentinelClientConfig(data, SentinelOptions.autoDetect())
+                        .getDatabase());
+        assertEquals(
+                0,
+                DriverImpl.probeClientConfig(data, SentinelOptions.autoDetect()).getDatabase(),
+                "the probe talks to the same Sentinel");
+    }
+
+    @Test
+    void sentinelConfigSubstitutesSentinelCredentialsButKeepsTheTransport() {
+        DefaultJedisClientConfig data = dataConfig(true, 1500, 4000);
+        SentinelOptions options = SentinelOptions.explicit("mymaster", Collections.singletonList("a:26379"))
+                .withCredentials("sentinel-user", "sentinel-password");
+
+        DefaultJedisClientConfig sentinel = DriverImpl.sentinelClientConfig(data, options);
+
+        assertEquals("sentinel-user", sentinel.getUser());
+        assertEquals("sentinel-password", sentinel.getPassword());
+        assertEquals(1500, sentinel.getConnectionTimeoutMillis());
+        assertEquals(4000, sentinel.getSocketTimeoutMillis());
+        assertNotNull(sentinel.getSslOptions(), "TLS must carry over to the Sentinel connection");
+    }
+
+    @Test
+    void sentinelConfigKeepsAnUnboundedReadDeadline() {
+        // JedisSentinelPool's master listener holds a SUBSCRIBE open on each Sentinel to hear about
+        // failovers. A read deadline here would tear that subscription down on a timer, so the
+        // driver's default of "no deadline" must survive the credential substitution.
+        DefaultJedisClientConfig data = dataConfig(false, 2000, DriverImpl.DEFAULT_SOCKET_TIMEOUT_MILLIS);
+        SentinelOptions options = SentinelOptions.autoDetect().withCredentials("u", "p");
+
+        assertEquals(0, DriverImpl.sentinelClientConfig(data, options).getSocketTimeoutMillis());
+    }
+
+    @Test
+    void probeConfigBoundsAnOtherwiseUnlimitedRead() {
+        // The probe is a single round-trip, so it must not inherit "no read deadline": an endpoint
+        // that completes the handshake and then goes silent would otherwise hang the first query.
+        DefaultJedisClientConfig data = dataConfig(false, 2000, DriverImpl.DEFAULT_SOCKET_TIMEOUT_MILLIS);
+
+        DefaultJedisClientConfig probe = DriverImpl.probeClientConfig(data, SentinelOptions.autoDetect());
+
+        assertEquals(DriverImpl.DEFAULT_SENTINEL_PROBE_TIMEOUT_MILLIS, probe.getSocketTimeoutMillis());
+        assertEquals(2000, probe.getConnectionTimeoutMillis(), "the connect timeout is untouched");
+    }
+
+    @Test
+    void probeConfigRespectsAnExplicitReadDeadline() {
+        DefaultJedisClientConfig data = dataConfig(false, 2000, 7000);
+
+        assertEquals(
+                7000,
+                DriverImpl.probeClientConfig(data, SentinelOptions.autoDetect()).getSocketTimeoutMillis(),
+                "a caller who set a socket timeout has already chosen the bound");
+    }
+
+    @Test
+    void probeConfigCarriesSentinelCredentialsAndTls() {
+        DefaultJedisClientConfig data = dataConfig(true, 2000, 0);
+        SentinelOptions options = SentinelOptions.autoDetect().withCredentials("sentinel-user", "sentinel-password");
+
+        DefaultJedisClientConfig probe = DriverImpl.probeClientConfig(data, options);
+
+        assertEquals("sentinel-user", probe.getUser());
+        assertEquals("sentinel-password", probe.getPassword());
+        assertNotNull(probe.getSslOptions());
+    }
+
+    @Test
+    void probeConfigUsesTheDataCredentialsByDefault() {
+        DefaultJedisClientConfig data = dataConfig(false, 2000, 0);
+
+        DefaultJedisClientConfig probe = DriverImpl.probeClientConfig(data, SentinelOptions.autoDetect());
+
+        assertEquals("alice", probe.getUser());
+        assertEquals("s3cret", probe.getPassword());
+        assertNull(probe.getSslOptions());
+    }
+
+    @Test
+    void derivedConfigsStillPinRESP2() {
+        // Same reasoning as DriverConfigTest#everyClientConfigPinsRESP2: the legacy Jedis class this
+        // driver pools cannot speak RESP3, and these two configs are new ways to reach it.
+        DefaultJedisClientConfig data = dataConfig(false, 2000, 0);
+        SentinelOptions options = SentinelOptions.autoDetect().withCredentials("u", "p");
+
+        assertFalse(DriverImpl.sentinelClientConfig(data, options).isAutoNegotiateProtocol());
+        assertFalse(DriverImpl.probeClientConfig(data, options).isAutoNegotiateProtocol());
+        assertFalse(
+                DriverImpl.probeClientConfig(data, SentinelOptions.autoDetect()).isAutoNegotiateProtocol());
+    }
+}

--- a/src/test/java/com/falkordb/impl/api/SentinelClientConfigTest.java
+++ b/src/test/java/com/falkordb/impl/api/SentinelClientConfigTest.java
@@ -66,7 +66,10 @@ class SentinelClientConfigTest {
         assertEquals("sentinel-user", sentinel.getUser());
         assertEquals("sentinel-password", sentinel.getPassword());
         assertEquals(1500, sentinel.getConnectionTimeoutMillis());
-        assertEquals(4000, sentinel.getSocketTimeoutMillis());
+        assertEquals(
+                0,
+                sentinel.getSocketTimeoutMillis(),
+                "the read deadline is the one transport setting that must not carry over");
         assertNotNull(sentinel.getSslOptions(), "TLS must carry over to the Sentinel connection");
     }
 
@@ -79,6 +82,22 @@ class SentinelClientConfigTest {
         SentinelOptions options = SentinelOptions.autoDetect().withCredentials("u", "p");
 
         assertEquals(0, DriverImpl.sentinelClientConfig(data, options).getSocketTimeoutMillis());
+    }
+
+    @Test
+    void sentinelConfigDropsADataReadDeadlineInsteadOfInheritingIt() {
+        // The case the default above cannot catch: a caller who sets a socket timeout for their
+        // graph queries must not have it applied to the Sentinel connection. Once discovery is done
+        // that connection only holds the +switch-master subscription, so a timeout of T bounds no
+        // request -- it expires the subscription every T, and MasterListener answers by logging a
+        // warning and sleeping 5s before resubscribing (JedisSentinelPool.MasterListener#run). The
+        // result is a permanent cycle of log noise and windows with nobody listening for failovers.
+        DefaultJedisClientConfig data = dataConfig(false, 2000, 4000);
+
+        assertEquals(
+                DriverImpl.SENTINEL_SOCKET_TIMEOUT_MILLIS,
+                DriverImpl.sentinelClientConfig(data, SentinelOptions.autoDetect())
+                        .getSocketTimeoutMillis());
     }
 
     @Test
@@ -95,6 +114,9 @@ class SentinelClientConfigTest {
 
     @Test
     void probeConfigRespectsAnExplicitReadDeadline() {
+        // Guards the coupling between the two derived configs: the probe used to take this bound from
+        // the Sentinel config, which now forces the deadline off, so reading it from there would
+        // quietly downgrade every explicit timeout to the probe default.
         DefaultJedisClientConfig data = dataConfig(false, 2000, 7000);
 
         assertEquals(

--- a/src/test/java/com/falkordb/impl/api/SentinelOptionsTest.java
+++ b/src/test/java/com/falkordb/impl/api/SentinelOptionsTest.java
@@ -1,0 +1,122 @@
+package com.falkordb.impl.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.HostAndPort;
+
+/**
+ * Unit tests for {@link SentinelOptions}: the three states it can express, their validation, and the
+ * immutability {@link SentinelOptions#withCredentials} relies on.
+ */
+class SentinelOptionsTest {
+
+    @Test
+    void autoDetectProbesButIsNotExplicit() {
+        SentinelOptions options = SentinelOptions.autoDetect();
+
+        assertTrue(options.isAutoDetect());
+        assertFalse(options.isExplicit());
+        assertNull(options.masterName());
+        assertTrue(options.addresses().isEmpty());
+        assertFalse(options.hasCredentials());
+    }
+
+    @Test
+    void disabledNeitherProbesNorNamesADeployment() {
+        SentinelOptions options = SentinelOptions.disabled();
+
+        assertFalse(options.isAutoDetect());
+        assertFalse(options.isExplicit());
+    }
+
+    @Test
+    void explicitNamesTheDeploymentAndSuppressesProbing() {
+        SentinelOptions options = SentinelOptions.explicit("mymaster", Arrays.asList("a:26379", "b:26379"));
+
+        assertTrue(options.isExplicit());
+        assertFalse(options.isAutoDetect(), "an explicitly named deployment needs no probe");
+        assertEquals("mymaster", options.masterName());
+        assertEquals(endpoints("a:26379", "b:26379"), options.addresses());
+    }
+
+    @Test
+    void explicitTrimsTheMasterName() {
+        assertEquals(
+                "mymaster",
+                SentinelOptions.explicit("  mymaster  ", Collections.singletonList("a:26379"))
+                        .masterName());
+    }
+
+    @Test
+    void explicitRejectsAMissingMasterName() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SentinelOptions.explicit(null, Collections.singletonList("a:26379")));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SentinelOptions.explicit("   ", Collections.singletonList("a:26379")));
+    }
+
+    @Test
+    void explicitRejectsAMissingAddressList() {
+        assertThrows(IllegalArgumentException.class, () -> SentinelOptions.explicit("mymaster", null));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SentinelOptions.explicit("mymaster", Collections.<String>emptyList()));
+    }
+
+    @Test
+    void explicitRejectsAMalformedAddressUpFront() {
+        // Parsing here rather than at pool-construction time is what lets a typo surface from the call
+        // that contains it, instead of from the first query long after the driver was built.
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SentinelOptions.explicit("mymaster", Arrays.asList("a:26379", "b-without-a-port")));
+    }
+
+    @Test
+    void explicitCopiesTheCallersAddressList() {
+        // The builder hands over a list it still holds; mutating it afterwards must not change us.
+        java.util.List<String> mutable = new java.util.ArrayList<>(Collections.singletonList("a:26379"));
+        SentinelOptions options = SentinelOptions.explicit("mymaster", mutable);
+        mutable.add("b:26379");
+
+        assertEquals(endpoints("a:26379"), options.addresses());
+    }
+
+    @Test
+    void withCredentialsReturnsACopyPreservingTheRest() {
+        SentinelOptions explicit = SentinelOptions.explicit("mymaster", Collections.singletonList("a:26379"));
+        SentinelOptions authenticated = explicit.withCredentials("sentinel-user", "sentinel-password");
+
+        assertFalse(explicit.hasCredentials(), "the original must be untouched");
+        assertTrue(authenticated.hasCredentials());
+        assertEquals("sentinel-user", authenticated.user());
+        assertEquals("sentinel-password", authenticated.password());
+        assertEquals("mymaster", authenticated.masterName());
+        assertEquals(endpoints("a:26379"), authenticated.addresses());
+    }
+
+    @Test
+    void passwordOnlySentinelCredentialsCount() {
+        assertTrue(SentinelOptions.autoDetect().withCredentials(null, "p").hasCredentials());
+        assertFalse(SentinelOptions.autoDetect().withCredentials(null, null).hasCredentials());
+    }
+
+    private static Set<HostAndPort> endpoints(String... addresses) {
+        Set<HostAndPort> expected = new LinkedHashSet<>();
+        for (String address : addresses) {
+            expected.add(HostAndPort.from(address));
+        }
+        return expected;
+    }
+}

--- a/src/test/java/com/falkordb/impl/api/SentinelsTest.java
+++ b/src/test/java/com/falkordb/impl/api/SentinelsTest.java
@@ -1,0 +1,166 @@
+package com.falkordb.impl.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.HostAndPort;
+
+/**
+ * Unit tests for {@link Sentinels} — the pure half of Sentinel support: recognising a Sentinel from
+ * its {@code INFO server} reply, picking the master out of a {@code SENTINEL MASTERS} reply, and
+ * parsing {@code host:port} addresses. No server is required; the probe itself is covered end-to-end
+ * by {@code SentinelIT}.
+ */
+class SentinelsTest {
+
+    /** A realistic (abridged) `INFO server` reply, which Redis terminates with CRLF. */
+    private static String infoWithMode(String mode) {
+        return "# Server\r\nredis_version:7.4.0\r\nredis_mode:" + mode + "\r\nos:Linux\r\narch_bits:64\r\n";
+    }
+
+    @Test
+    void recognisesSentinelMode() {
+        assertTrue(Sentinels.isSentinelInfo(infoWithMode("sentinel")));
+    }
+
+    @Test
+    void rejectsStandaloneAndClusterModes() {
+        assertFalse(Sentinels.isSentinelInfo(infoWithMode("standalone")));
+        assertFalse(Sentinels.isSentinelInfo(infoWithMode("cluster")));
+    }
+
+    @Test
+    void rejectsNullOrEmptyInfo() {
+        assertFalse(Sentinels.isSentinelInfo(null));
+        assertFalse(Sentinels.isSentinelInfo(""));
+        assertFalse(Sentinels.isSentinelInfo("# Server\r\nredis_version:7.4.0\r\n"));
+    }
+
+    @Test
+    void readsTheModeFieldRatherThanSearchingTheWholeReply() {
+        // The reason this is parsed line-wise: a substring search for "redis_mode:sentinel" would be
+        // fooled by any other field whose *value* happens to contain it, and config_file is a real
+        // field carrying an operator-chosen path.
+        String info = "# Server\r\nconfig_file:/etc/redis_mode:sentinel.conf\r\nredis_mode:standalone\r\n";
+        assertFalse(Sentinels.isSentinelInfo(info), "a path that merely contains the marker is not the mode");
+    }
+
+    @Test
+    void toleratesLfLineEndingsAndPadding() {
+        assertTrue(Sentinels.isSentinelInfo("# Server\nredis_mode:sentinel\n"));
+        assertTrue(Sentinels.isSentinelInfo("# Server\r\n  redis_mode:sentinel  \r\n"));
+        assertTrue(Sentinels.isSentinelInfo("redis_mode:SENTINEL"));
+    }
+
+    @Test
+    void takesTheNameOfTheSoleMonitoredMaster() {
+        assertEquals("mymaster", Sentinels.soleMasterName(masters("mymaster")));
+    }
+
+    @Test
+    void trimsTheMasterName() {
+        assertEquals("mymaster", Sentinels.soleMasterName(masters("  mymaster  ")));
+    }
+
+    @Test
+    void rejectsAnAmbiguousSentinel() {
+        // Matches falkordb-py/go/ts, which all refuse to guess. The message must point at the way out.
+        IllegalStateException thrown =
+                assertThrows(IllegalStateException.class, () -> Sentinels.soleMasterName(masters("first", "second")));
+        assertTrue(thrown.getMessage().contains("first"), thrown.getMessage());
+        assertTrue(thrown.getMessage().contains("second"), thrown.getMessage());
+        assertTrue(thrown.getMessage().contains("sentinel(masterName"), thrown.getMessage());
+    }
+
+    @Test
+    void rejectsASentinelMonitoringNothing() {
+        assertThrows(IllegalStateException.class, () -> Sentinels.soleMasterName(Collections.emptyList()));
+        assertThrows(IllegalStateException.class, () -> Sentinels.soleMasterName(null));
+    }
+
+    @Test
+    void rejectsAMasterWithoutAUsableName() {
+        assertThrows(
+                IllegalStateException.class,
+                () -> Sentinels.soleMasterName(Collections.singletonList(new HashMap<String, String>())));
+        assertThrows(IllegalStateException.class, () -> Sentinels.soleMasterName(masters("   ")));
+    }
+
+    @Test
+    void parsesHostPortAddresses() {
+        HostAndPort parsed = Sentinels.parseAddress("sentinel.example.com:26379");
+        assertEquals("sentinel.example.com", parsed.getHost());
+        assertEquals(26379, parsed.getPort());
+    }
+
+    @Test
+    void parsesBracketedIpv6Addresses() {
+        assertEquals(26379, Sentinels.parseAddress("[::1]:26379").getPort());
+    }
+
+    @Test
+    void trimsAddressPadding() {
+        assertEquals("host", Sentinels.parseAddress("  host:26379  ").getHost());
+    }
+
+    @Test
+    void rejectsMalformedAddresses() {
+        // Each of these fails somewhere different inside Jedis' parser (or passes it and fails our own
+        // range check), so all of them are pinned rather than just a representative one.
+        for (String malformed : Arrays.asList("localhost", "localhost:abc", ":26379", "", "   ")) {
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> Sentinels.parseAddress(malformed),
+                    "expected \"" + malformed + "\" to be rejected");
+        }
+        assertThrows(IllegalArgumentException.class, () -> Sentinels.parseAddress(null));
+    }
+
+    @Test
+    void rejectsOutOfRangePorts() {
+        assertThrows(IllegalArgumentException.class, () -> Sentinels.parseAddress("localhost:0"));
+        assertThrows(IllegalArgumentException.class, () -> Sentinels.parseAddress("localhost:99999"));
+    }
+
+    @Test
+    void parsesAddressListsInOrder() {
+        Set<HostAndPort> parsed = Sentinels.parseAddresses(Arrays.asList("a:26379", "b:26380", "c:26381"));
+
+        List<String> hosts = new ArrayList<>();
+        for (HostAndPort address : parsed) {
+            hosts.add(address.getHost());
+        }
+        assertLinesMatch(Arrays.asList("a", "b", "c"), hosts, "the caller's order must be preserved");
+    }
+
+    @Test
+    void rejectsAnEmptyAddressList() {
+        assertThrows(IllegalArgumentException.class, () -> Sentinels.parseAddresses(Collections.emptyList()));
+        assertThrows(IllegalArgumentException.class, () -> Sentinels.parseAddresses(null));
+    }
+
+    /** Builds a {@code SENTINEL MASTERS}-shaped reply naming each given master. */
+    private static List<Map<String, String>> masters(String... names) {
+        List<Map<String, String>> masters = new ArrayList<>();
+        for (String name : names) {
+            Map<String, String> master = new LinkedHashMap<>();
+            master.put("name", name);
+            master.put("ip", "10.0.0.1");
+            master.put("port", "6379");
+            masters.add(master);
+        }
+        return masters;
+    }
+}


### PR DESCRIPTION
Closes #46.

Point the driver at a Sentinel and it discovers the master and follows failovers for the lifetime of the driver — queries issued after a promotion reach the new master without recreating anything.

## Behaviour

**Auto-detection, no configuration.** Every factory method probes the endpoint it is given with `INFO server`; if it reports `redis_mode:sentinel`, the master comes from `SENTINEL MASTERS`. This is what falkordb-py, falkordb-go and falkordb-ts already do, so a deployment behaves the same whichever client talks to it.

```java
// sentinel-a is a Sentinel, not a FalkorDB server — the driver works this out for itself
Driver driver = FalkorDB.driver("sentinel-a", 26379);
```

**Nothing that works today can start failing.** Detection failures are non-fatal by design: an endpoint that cannot be probed, or that refuses `INFO` by ACL, falls back to the direct pool every previous release would have built. Only a *positive* Sentinel identification makes problems fatal — at that point a direct connection would fail on every graph command anyway, so a clear error beats a baffling one. `autoDetectSentinel(false)` skips the probe entirely.

**Explicit configuration**, required when a Sentinel monitors more than one master (auto-detection cannot guess, and says so), and useful for listing several Sentinels:

```java
FalkorDB.builder().sentinel("mymaster", "a:26379", "b:26379", "c:26379").build()
```

Sentinels frequently have their own ACL, so `sentinelCredentials(...)` configures them separately; omitted, they reuse the master's credentials (as falkordb-go does). `FALKORDB_SENTINEL_MASTER` + `FALKORDB_SENTINELS` configure the same thing from the environment, taking precedence over `FALKORDB_URL` and `FALKORDB_HOST`/`FALKORDB_PORT`.

## Three things worth knowing when reading the diff

**`DriverImpl` resolves its pool on first use, not in the constructor.** Driver construction has never performed I/O and the suite depends on that (`ConfigBuilderTest` and `DriverEnvironmentTest` build drivers against hosts that do not exist), so the probe had to be deferred. The memoisation is a lock-free CAS rather than a `synchronized` block, because holding a monitor across network I/O would pin a virtual thread's carrier — which the `pin-check` gate forbids. One consequence: a "multiple masters" error now surfaces at first query rather than at construction.

**Connections to the Sentinels get their own client config** rather than reusing the data one. It must not carry the database index a URI can supply (`redis://host:26379/2`), because Jedis would then send `SELECT` to a Sentinel, which has no such command — and `JedisSentinelPool` reports that error as the Sentinel being *down*, so a healthy deployment looks dead. It must also keep an unbounded read deadline, because the pool holds a `SUBSCRIBE` open on each Sentinel to hear `+switch-master`; a read timeout would tear that subscription down on a timer.

**A third, separate config is used for the one-shot probe**, with a bounded read deadline, so an endpoint that accepts the connection but never answers cannot hang the first query.

## Verification

Unit tests (36 new) cover the parsing and decision logic against synthetic replies. `SentinelIT` runs a master/replica/Sentinel topology under Testcontainers; its assertions *write*, since the topology contains a read-only replica and only a write proves the driver landed on the master. Where the Sentinel-reported master address is not routable from the host (Docker Desktop on macOS/Windows) those tests skip rather than pass vacuously — CI runs them on Linux, where it is routable.

Beyond the suite, the feature was exercised end-to-end from inside the Docker network against a real deployment: auto-detection, explicit configuration, the environment variables, the opt-out, no regression for direct connections, an actual `SENTINEL FAILOVER` (the driver followed the promotion from `172.18.0.2` to `.3` without being recreated), and the multi-master error message.

Local gates: `fmt-check`, `lint`, `javadoc`, `verify` (316 unit + 129 integration), `api-diff`, `examples`, `spellcheck` all pass. `pin-check` fails identically on a clean `master` — pre-existing and unrelated.

## API impact

Purely additive: new methods on `FalkorDB.Builder`, and new classes in the internal `com.falkordb.impl` package (excluded from `api-diff` and `javadoc`). No change to the `Driver` interface, so implementors are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Redis Sentinel support for high-availability and failover-aware connections.
  * Sentinel deployments can be configured through the builder or environment variables.
  * Added automatic Sentinel detection, with an option to disable it.
  * Added support for separate Sentinel credentials.
  * Driver creation remains lazy and does not connect to Redis immediately.
* **Bug Fixes**
  * Connection errors now redact credentials embedded in connection URIs.
* **Documentation**
  * Documented Sentinel configuration, environment-variable precedence, credentials, detection behavior, and connection setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->